### PR TITLE
feat: replay retrieval benchmarks use real retriever pipeline

### DIFF
--- a/benchmarks/replay/anonymized-real-sessions.json
+++ b/benchmarks/replay/anonymized-real-sessions.json
@@ -1,25 +1,39 @@
 {
   "name": "anonymized-real-session-replay-v1",
-  "description": "Anonymized real-session-style retrieval replay fixture for Precision@k / Recall@k / nDCG@k checks.",
+  "description": "Anonymized real-session-style retrieval replay fixture for Precision@k / Recall@k / nDCG@k / no-match checks.",
   "ks": [1, 3, 5],
   "queries": [
     {
       "queryId": "q-cli-fast",
       "query": "fast search should avoid embedding startup",
+      "expectation": "match",
       "expectedIds": ["m-cli-fast", "m-runtime-light"],
-      "expectedRelevance": { "m-cli-fast": 3, "m-runtime-light": 2 }
+      "expectedRelevance": { "m-cli-fast": 3, "m-runtime-light": 2 },
+      "knownAnswer": "CLI search --strategy fast uses keyword retrieval and should not start embedding model initialization."
     },
     {
       "queryId": "q-hook-policy",
       "query": "hook should not inject weak keyword rescue",
+      "expectation": "match",
       "expectedIds": ["m-hook-policy", "m-hook-threshold"],
-      "expectedRelevance": { "m-hook-policy": 3, "m-hook-threshold": 2 }
+      "expectedRelevance": { "m-hook-policy": 3, "m-hook-threshold": 2 },
+      "knownAnswer": "Claude hook prompt injection has a separate conservative policy for high-confidence memories."
     },
     {
       "queryId": "q-replay-bench",
       "query": "precision recall replay benchmark output",
+      "expectation": "match",
       "expectedIds": ["m-benchmark", "m-metrics"],
-      "expectedRelevance": { "m-benchmark": 3, "m-metrics": 2 }
+      "expectedRelevance": { "m-benchmark": 3, "m-metrics": 2 },
+      "knownAnswer": "Replay benchmark reports Precision@k and Recall@k over anonymized session queries."
+    },
+    {
+      "queryId": "q-no-match-command-artifact",
+      "query": "local-command-stdout command-name opus",
+      "expectation": "no_match",
+      "expectedIds": [],
+      "expectedRelevance": {},
+      "forbiddenIds": ["m-cli-fast", "m-hook-policy", "m-benchmark"]
     }
   ],
   "memories": [

--- a/benchmarks/replay/anonymized-real-sessions.json
+++ b/benchmarks/replay/anonymized-real-sessions.json
@@ -1,11 +1,26 @@
 {
   "name": "anonymized-real-session-replay-v1",
-  "description": "Anonymized real-session-style retrieval replay fixture for Precision@k / Recall@k checks.",
+  "description": "Anonymized real-session-style retrieval replay fixture for Precision@k / Recall@k / nDCG@k checks.",
   "ks": [1, 3, 5],
   "queries": [
-    { "queryId": "q-cli-fast", "query": "fast search should avoid embedding startup", "expectedIds": ["m-cli-fast", "m-runtime-light"] },
-    { "queryId": "q-hook-policy", "query": "hook should not inject weak keyword rescue", "expectedIds": ["m-hook-policy", "m-hook-threshold"] },
-    { "queryId": "q-replay-bench", "query": "precision recall replay benchmark output", "expectedIds": ["m-benchmark", "m-metrics"] }
+    {
+      "queryId": "q-cli-fast",
+      "query": "fast search should avoid embedding startup",
+      "expectedIds": ["m-cli-fast", "m-runtime-light"],
+      "expectedRelevance": { "m-cli-fast": 3, "m-runtime-light": 2 }
+    },
+    {
+      "queryId": "q-hook-policy",
+      "query": "hook should not inject weak keyword rescue",
+      "expectedIds": ["m-hook-policy", "m-hook-threshold"],
+      "expectedRelevance": { "m-hook-policy": 3, "m-hook-threshold": 2 }
+    },
+    {
+      "queryId": "q-replay-bench",
+      "query": "precision recall replay benchmark output",
+      "expectedIds": ["m-benchmark", "m-metrics"],
+      "expectedRelevance": { "m-benchmark": 3, "m-metrics": 2 }
+    }
   ],
   "memories": [
     { "id": "m-cli-fast", "content": "CLI search --strategy fast uses keyword retrieval and should not start embedding model initialization." },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "ops:heartbeat": "bash scripts/heartbeat-memory-orchestrator.sh",
     "ops:health": "npm run ops:sync-gap:report && npm run ops:sync-gap:heal && npm run ops:review:resolve",
     "ops:projects:clean-unknown": "node scripts/delete-unknown-projects.js",
-    "benchmark:replay": "tsx scripts/replay-retrieval-benchmark.ts"
+    "benchmark:replay": "tsx scripts/replay-retrieval-benchmark.ts",
+    "benchmark:qrels": "tsx scripts/generate-session-qrels.ts"
   },
   "keywords": [
     "claude-code",

--- a/scripts/generate-session-qrels.ts
+++ b/scripts/generate-session-qrels.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env tsx
+import { readFile, writeFile } from 'node:fs/promises';
+import { buildSessionQrelsFixtureFromJsonl } from '../src/core/session-qrels.js';
+
+const args = process.argv.slice(2);
+const sessions: string[] = [];
+let outPath = '';
+let name = 'session-qrels-fixture';
+let ks = [1, 3, 5];
+let maxQueries: number | undefined;
+let redactContent = false;
+
+for (let i = 0; i < args.length; i += 1) {
+  const arg = args[i];
+  if (arg === '--session') {
+    const value = args[++i];
+    if (value) sessions.push(value);
+  } else if (arg === '--out') {
+    outPath = args[++i] ?? '';
+  } else if (arg === '--name') {
+    name = args[++i] ?? name;
+  } else if (arg === '--ks') {
+    ks = (args[++i] ?? '').split(',').map((value) => Number(value.trim())).filter(Number.isFinite);
+  } else if (arg === '--max-queries') {
+    const parsed = Number(args[++i]);
+    maxQueries = Number.isFinite(parsed) ? parsed : undefined;
+  } else if (arg === '--redact-content') {
+    redactContent = true;
+  } else if (!arg.startsWith('--')) {
+    sessions.push(arg);
+  }
+}
+
+if (sessions.length === 0) {
+  console.error('Usage: tsx scripts/generate-session-qrels.ts --session <claude.jsonl> [--session <more.jsonl>] [--out fixture.json] [--ks 1,3,5] [--redact-content]');
+  process.exit(2);
+}
+
+if (!redactContent) {
+  console.error('WARNING: generated qrels include raw user prompts and assistant responses. Review before committing or sharing, or pass --redact-content for shareable metadata.');
+}
+
+const jsonl = (await Promise.all(sessions.map((session) => readFile(session, 'utf8')))).join('\n');
+const fixture = buildSessionQrelsFixtureFromJsonl(jsonl, { name, ks, maxQueries, redactContent });
+const output = `${JSON.stringify(fixture, null, 2)}\n`;
+
+if (outPath) {
+  await writeFile(outPath, output, 'utf8');
+} else {
+  process.stdout.write(output);
+}

--- a/scripts/generate-session-qrels.ts
+++ b/scripts/generate-session-qrels.ts
@@ -1,51 +1,115 @@
 #!/usr/bin/env tsx
-import { readFile, writeFile } from 'node:fs/promises';
-import { buildSessionQrelsFixtureFromJsonl } from '../src/core/session-qrels.js';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import * as path from 'node:path';
+import {
+  buildSessionQrelsFixtureFromJsonl,
+  collectClaudeSessionJsonlFiles,
+  summarizeSessionQrelsFixture
+} from '../src/core/session-qrels.js';
 
 const args = process.argv.slice(2);
-const sessions: string[] = [];
-let outPath = '';
-let name = 'session-qrels-fixture';
-let ks = [1, 3, 5];
-let maxQueries: number | undefined;
-let redactContent = false;
 
-for (let i = 0; i < args.length; i += 1) {
-  const arg = args[i];
-  if (arg === '--session') {
-    const value = args[++i];
-    if (value) sessions.push(value);
-  } else if (arg === '--out') {
-    outPath = args[++i] ?? '';
-  } else if (arg === '--name') {
-    name = args[++i] ?? name;
-  } else if (arg === '--ks') {
-    ks = (args[++i] ?? '').split(',').map((value) => Number(value.trim())).filter(Number.isFinite);
-  } else if (arg === '--max-queries') {
-    const parsed = Number(args[++i]);
-    maxQueries = Number.isFinite(parsed) ? parsed : undefined;
-  } else if (arg === '--redact-content') {
-    redactContent = true;
-  } else if (!arg.startsWith('--')) {
-    sessions.push(arg);
+void main(args);
+
+async function main(argv: string[]): Promise<void> {
+  const sessions: string[] = [];
+  const sessionDirs: string[] = [];
+  let outPath = '';
+  let summaryOutPath = '';
+  let name = 'session-qrels-fixture';
+  let ks = [1, 3, 5];
+  let maxQueries: number | undefined;
+  let maxFiles: number | undefined;
+  let minBytes = 0;
+  let redactContent = false;
+  let includeSubagents = false;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--session') {
+      const value = argv[++i];
+      if (value) sessions.push(value);
+    } else if (arg === '--sessions-dir' || arg === '--session-dir') {
+      const value = argv[++i];
+      if (value) sessionDirs.push(value);
+    } else if (arg === '--out') {
+      outPath = argv[++i] ?? '';
+    } else if (arg === '--summary-out') {
+      summaryOutPath = argv[++i] ?? '';
+    } else if (arg === '--name') {
+      name = argv[++i] ?? name;
+    } else if (arg === '--ks') {
+      ks = (argv[++i] ?? '').split(',').map((value) => Number(value.trim())).filter(Number.isFinite);
+    } else if (arg === '--max-queries') {
+      const parsed = Number(argv[++i]);
+      maxQueries = Number.isFinite(parsed) ? parsed : undefined;
+    } else if (arg === '--max-files') {
+      const parsed = Number(argv[++i]);
+      maxFiles = Number.isFinite(parsed) ? parsed : undefined;
+    } else if (arg === '--min-bytes') {
+      const parsed = Number(argv[++i]);
+      minBytes = Number.isFinite(parsed) ? parsed : minBytes;
+    } else if (arg === '--redact-content') {
+      redactContent = true;
+    } else if (arg === '--include-subagents') {
+      includeSubagents = true;
+    } else if (!arg.startsWith('--')) {
+      sessions.push(arg);
+    }
   }
+
+  for (const sessionDir of sessionDirs) {
+    const discovered = await collectClaudeSessionJsonlFiles(expandUserPath(sessionDir), {
+      includeSubagents,
+      maxFiles,
+      minBytes
+    });
+    sessions.push(...discovered);
+  }
+
+  const uniqueSessions = Array.from(new Set(sessions.map(expandUserPath)));
+
+  if (uniqueSessions.length === 0) {
+    console.error('Usage: tsx scripts/generate-session-qrels.ts --session <claude.jsonl> [--session <more.jsonl>] [--sessions-dir ~/.claude/projects] [--max-files 50] [--out fixture.json] [--summary-out summary.json] [--ks 1,3,5] [--redact-content]');
+    process.exit(2);
+  }
+
+  if (!redactContent) {
+    console.error('WARNING: generated qrels include raw user prompts and assistant responses. Review before committing or sharing, or pass --redact-content for shareable metadata.');
+  }
+
+  const generatedAt = new Date().toISOString();
+  const jsonl = (await Promise.all(uniqueSessions.map((session) => readFile(session, 'utf8')))).join('\n');
+  const fixture = buildSessionQrelsFixtureFromJsonl(jsonl, {
+    name,
+    ks,
+    maxQueries,
+    redactContent,
+    sourceFileCount: uniqueSessions.length,
+    rawContentIncluded: !redactContent,
+    generatedAt
+  });
+  const output = `${JSON.stringify(fixture, null, 2)}\n`;
+  const summary = summarizeSessionQrelsFixture(fixture);
+
+  if (outPath) {
+    await mkdir(path.dirname(expandUserPath(outPath)), { recursive: true });
+    await writeFile(expandUserPath(outPath), output, 'utf8');
+  } else {
+    process.stdout.write(output);
+  }
+
+  if (summaryOutPath) {
+    await mkdir(path.dirname(expandUserPath(summaryOutPath)), { recursive: true });
+    await writeFile(expandUserPath(summaryOutPath), `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
+  }
+
+  console.error(`Generated ${summary.queryCount} qrels from ${uniqueSessions.length} Claude JSONL file(s).`);
 }
 
-if (sessions.length === 0) {
-  console.error('Usage: tsx scripts/generate-session-qrels.ts --session <claude.jsonl> [--session <more.jsonl>] [--out fixture.json] [--ks 1,3,5] [--redact-content]');
-  process.exit(2);
-}
-
-if (!redactContent) {
-  console.error('WARNING: generated qrels include raw user prompts and assistant responses. Review before committing or sharing, or pass --redact-content for shareable metadata.');
-}
-
-const jsonl = (await Promise.all(sessions.map((session) => readFile(session, 'utf8')))).join('\n');
-const fixture = buildSessionQrelsFixtureFromJsonl(jsonl, { name, ks, maxQueries, redactContent });
-const output = `${JSON.stringify(fixture, null, 2)}\n`;
-
-if (outPath) {
-  await writeFile(outPath, output, 'utf8');
-} else {
-  process.stdout.write(output);
+function expandUserPath(value: string): string {
+  if (value === '~') return homedir();
+  if (value.startsWith('~/')) return path.join(homedir(), value.slice(2));
+  return value;
 }

--- a/scripts/generate-session-qrels.ts
+++ b/scripts/generate-session-qrels.ts
@@ -5,7 +5,8 @@ import * as path from 'node:path';
 import {
   buildSessionQrelsFixtureFromJsonl,
   collectClaudeSessionJsonlFiles,
-  summarizeSessionQrelsFixture
+  summarizeSessionQrelsFixture,
+  type SessionQrelsNoMatchQueryInput
 } from '../src/core/session-qrels.js';
 
 const args = process.argv.slice(2);
@@ -24,6 +25,7 @@ async function main(argv: string[]): Promise<void> {
   let minBytes = 0;
   let redactContent = false;
   let includeSubagents = false;
+  const noMatchQueries: SessionQrelsNoMatchQueryInput[] = [];
 
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
@@ -54,6 +56,14 @@ async function main(argv: string[]): Promise<void> {
       redactContent = true;
     } else if (arg === '--include-subagents') {
       includeSubagents = true;
+    } else if (arg === '--no-match-query' || arg === '--negative-query') {
+      const query = argv[++i];
+      if (query) noMatchQueries.push({ query });
+    } else if (arg === '--no-match-forbidden-ids' || arg === '--negative-forbidden-ids') {
+      const value = argv[++i] ?? '';
+      const forbiddenIds = value.split(',').map((id) => id.trim()).filter(Boolean);
+      const last = noMatchQueries[noMatchQueries.length - 1];
+      if (last) last.forbiddenIds = forbiddenIds;
     } else if (!arg.startsWith('--')) {
       sessions.push(arg);
     }
@@ -71,7 +81,7 @@ async function main(argv: string[]): Promise<void> {
   const uniqueSessions = Array.from(new Set(sessions.map(expandUserPath)));
 
   if (uniqueSessions.length === 0) {
-    console.error('Usage: tsx scripts/generate-session-qrels.ts --session <claude.jsonl> [--session <more.jsonl>] [--sessions-dir ~/.claude/projects] [--max-files 50] [--out fixture.json] [--summary-out summary.json] [--ks 1,3,5] [--redact-content]');
+    console.error('Usage: tsx scripts/generate-session-qrels.ts --session <claude.jsonl> [--session <more.jsonl>] [--sessions-dir ~/.claude/projects] [--max-files 50] [--out fixture.json] [--summary-out summary.json] [--ks 1,3,5] [--redact-content] [--no-match-query "query" --no-match-forbidden-ids id1,id2]');
     process.exit(2);
   }
 
@@ -88,7 +98,8 @@ async function main(argv: string[]): Promise<void> {
     redactContent,
     sourceFileCount: uniqueSessions.length,
     rawContentIncluded: !redactContent,
-    generatedAt
+    generatedAt,
+    noMatchQueries
   });
   const output = `${JSON.stringify(fixture, null, 2)}\n`;
   const summary = summarizeSessionQrelsFixture(fixture);

--- a/scripts/replay-retrieval-benchmark.ts
+++ b/scripts/replay-retrieval-benchmark.ts
@@ -6,6 +6,7 @@ import {
   formatReplayEvaluationMarkdown,
   type ReplayEvaluationFixture
 } from '../src/core/replay-evaluator.js';
+import type { RetrievalStrategy } from '../src/core/retriever.js';
 
 const args = process.argv.slice(2);
 
@@ -16,6 +17,9 @@ async function main(argv: string[]): Promise<void> {
   let outPath = '';
   let format: 'json' | 'markdown' = 'json';
   let includePerQuery = true;
+  let strategy: RetrievalStrategy | undefined;
+  let topK: number | undefined;
+  let minScore: number | undefined;
   let positionalFixtureConsumed = false;
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -29,6 +33,15 @@ async function main(argv: string[]): Promise<void> {
       if (parsed === 'markdown' || parsed === 'json') format = parsed;
     } else if (arg === '--no-per-query') {
       includePerQuery = false;
+    } else if (arg === '--strategy') {
+      const parsed = argv[++i];
+      if (parsed === 'auto' || parsed === 'fast' || parsed === 'deep') strategy = parsed;
+    } else if (arg === '--top-k' || arg === '--topK') {
+      const parsed = Number(argv[++i]);
+      topK = Number.isFinite(parsed) ? parsed : undefined;
+    } else if (arg === '--min-score') {
+      const parsed = Number(argv[++i]);
+      minScore = Number.isFinite(parsed) ? parsed : undefined;
     } else if (!arg.startsWith('--') && !positionalFixtureConsumed) {
       fixturePath = arg;
       positionalFixtureConsumed = true;
@@ -36,7 +49,14 @@ async function main(argv: string[]): Promise<void> {
   }
 
   const fixture = JSON.parse(await readFile(fixturePath, 'utf8')) as ReplayEvaluationFixture;
-  const report = evaluateReplayFixture(fixture, { includePerQuery });
+  const report = await evaluateReplayFixture(fixture, {
+    includePerQuery,
+    topK,
+    retrievalOptions: {
+      ...(strategy ? { strategy } : {}),
+      ...(minScore !== undefined ? { minScore } : {})
+    }
+  });
   const output = format === 'markdown'
     ? formatReplayEvaluationMarkdown(report, { qrelsPath: fixturePath })
     : `${JSON.stringify(report, null, 2)}\n`;

--- a/scripts/replay-retrieval-benchmark.ts
+++ b/scripts/replay-retrieval-benchmark.ts
@@ -7,7 +7,7 @@ interface Fixture {
   name: string;
   description: string;
   ks: number[];
-  queries: Array<{ queryId: string; query: string; expectedIds: string[] }>;
+  queries: Array<{ queryId: string; query: string; expectedIds: string[]; expectedRelevance?: Record<string, number> }>;
   memories: Array<{ id: string; content: string }>;
 }
 
@@ -16,6 +16,7 @@ const fixture = JSON.parse(await readFile(fixturePath, 'utf8')) as Fixture;
 const inputs = fixture.queries.map((query) => ({
   queryId: query.queryId,
   expectedIds: query.expectedIds,
+  expectedRelevance: query.expectedRelevance,
   retrievedIds: rankByTokenOverlap(query.query, fixture.memories).map((memory) => memory.id)
 }));
 const perQuery = computePrecisionRecallAtK(inputs, fixture.ks);

--- a/scripts/replay-retrieval-benchmark.ts
+++ b/scripts/replay-retrieval-benchmark.ts
@@ -1,43 +1,49 @@
 #!/usr/bin/env tsx
-import { readFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
-import { computePrecisionRecallAtK, summarizeReplayMetrics } from '../src/core/retrieval-benchmark.js';
+import {
+  evaluateReplayFixture,
+  formatReplayEvaluationMarkdown,
+  type ReplayEvaluationFixture
+} from '../src/core/replay-evaluator.js';
 
-interface Fixture {
-  name: string;
-  description: string;
-  ks: number[];
-  queries: Array<{ queryId: string; query: string; expectedIds: string[]; expectedRelevance?: Record<string, number> }>;
-  memories: Array<{ id: string; content: string }>;
-}
+const args = process.argv.slice(2);
 
-const fixturePath = process.argv[2] || path.join('benchmarks', 'replay', 'anonymized-real-sessions.json');
-const fixture = JSON.parse(await readFile(fixturePath, 'utf8')) as Fixture;
-const inputs = fixture.queries.map((query) => ({
-  queryId: query.queryId,
-  expectedIds: query.expectedIds,
-  expectedRelevance: query.expectedRelevance,
-  retrievedIds: rankByTokenOverlap(query.query, fixture.memories).map((memory) => memory.id)
-}));
-const perQuery = computePrecisionRecallAtK(inputs, fixture.ks);
-const summary = summarizeReplayMetrics(perQuery, fixture.ks);
+void main(args);
 
-console.log(JSON.stringify({ name: fixture.name, description: fixture.description, summary, perQuery }, null, 2));
+async function main(argv: string[]): Promise<void> {
+  let fixturePath = path.join('benchmarks', 'replay', 'anonymized-real-sessions.json');
+  let outPath = '';
+  let format: 'json' | 'markdown' = 'json';
+  let includePerQuery = true;
+  let positionalFixtureConsumed = false;
 
-function rankByTokenOverlap(query: string, memories: Fixture['memories']): Fixture['memories'] {
-  const queryTokens = tokenize(query);
-  return [...memories]
-    .map((memory) => ({ memory, score: overlap(queryTokens, tokenize(memory.content)) }))
-    .sort((a, b) => b.score - a.score || a.memory.id.localeCompare(b.memory.id))
-    .map((row) => row.memory);
-}
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--fixture') {
+      fixturePath = argv[++i] ?? fixturePath;
+    } else if (arg === '--out' || arg === '--report-out') {
+      outPath = argv[++i] ?? '';
+    } else if (arg === '--format') {
+      const parsed = argv[++i];
+      if (parsed === 'markdown' || parsed === 'json') format = parsed;
+    } else if (arg === '--no-per-query') {
+      includePerQuery = false;
+    } else if (!arg.startsWith('--') && !positionalFixtureConsumed) {
+      fixturePath = arg;
+      positionalFixtureConsumed = true;
+    }
+  }
 
-function tokenize(text: string): Set<string> {
-  return new Set(text.toLowerCase().replace(/[^a-z0-9가-힣\s]/g, ' ').split(/\s+/).filter((token) => token.length >= 2));
-}
+  const fixture = JSON.parse(await readFile(fixturePath, 'utf8')) as ReplayEvaluationFixture;
+  const report = evaluateReplayFixture(fixture, { includePerQuery });
+  const output = format === 'markdown'
+    ? formatReplayEvaluationMarkdown(report, { qrelsPath: fixturePath })
+    : `${JSON.stringify(report, null, 2)}\n`;
 
-function overlap(a: Set<string>, b: Set<string>): number {
-  let hits = 0;
-  for (const token of a) if (b.has(token)) hits += 1;
-  return hits;
+  if (outPath) {
+    await writeFile(outPath, output, 'utf8');
+  } else {
+    process.stdout.write(output);
+  }
 }

--- a/src/core/replay-evaluator.ts
+++ b/src/core/replay-evaluator.ts
@@ -4,17 +4,33 @@ import {
   type ReplayMetricsSummary,
   type ReplayQueryMetrics
 } from './retrieval-benchmark.js';
+import { createRetrievalServices, type RetrieveMemoriesOptions } from './engine/retrieval-services.js';
+import { Matcher } from './matcher.js';
+import type { Embedder } from './embedder.js';
+import type { MatchConfidence, MemoryEvent } from './types.js';
+import type { SearchResult, VectorStore } from './vector-store.js';
+
+export type ReplayExpectation = 'match' | 'no_match';
 
 export interface ReplayEvaluationQuery {
   queryId: string;
   query: string;
   expectedIds: string[];
   expectedRelevance?: Record<string, number>;
+  expectation?: ReplayExpectation;
+  forbiddenIds?: string[];
+  knownAnswer?: string;
 }
 
 export interface ReplayEvaluationMemory {
   id: string;
   content: string;
+  sourceSessionId?: string;
+  sourceTurnIndex?: number;
+  timestamp?: string;
+  eventType?: MemoryEvent['eventType'];
+  canonicalKey?: string;
+  metadata?: Record<string, unknown>;
 }
 
 export interface ReplayEvaluationFixtureMetadata {
@@ -32,10 +48,32 @@ export interface ReplayEvaluationFixture {
   metadata?: ReplayEvaluationFixtureMetadata;
 }
 
+export interface ReplayRetrievalRunInput {
+  fixture: ReplayEvaluationFixture;
+  query: ReplayEvaluationQuery;
+  topK: number;
+  retrievalOptions: Partial<RetrieveMemoriesOptions>;
+}
+
+export interface ReplayRetrievalRunResult {
+  retrievedIds: string[];
+  candidateIds?: string[];
+  confidence?: MatchConfidence;
+  fallbackTrace?: string[];
+}
+
+export type ReplayRetrievalRunner = (
+  query: string,
+  input: ReplayRetrievalRunInput
+) => Promise<ReplayRetrievalRunResult>;
+
 export interface ReplayEvaluationOptions {
   generatedAt?: string;
   includePerQuery?: boolean;
   evaluator?: string;
+  topK?: number;
+  retrievalOptions?: Partial<RetrieveMemoriesOptions>;
+  retrievalRunner?: ReplayRetrievalRunner;
 }
 
 export interface ReplayFixtureStats {
@@ -46,33 +84,115 @@ export interface ReplayFixtureStats {
   rawContentIncluded?: boolean;
 }
 
+export interface ReplayFailedQuery {
+  queryId: string;
+  expectedIds: string[];
+  retrievedIds: string[];
+  expectation?: ReplayExpectation;
+  reason?: 'missing_expected' | 'unexpected_match';
+}
+
+export interface ReplayEvaluationSummary extends ReplayMetricsSummary {
+  positiveQueryCount: number;
+  noMatchQueryCount: number;
+  noMatchCorrect: number;
+  noMatchAccuracy: number;
+  forbiddenHitCount: number;
+  hitAtK: Record<number, number>;
+  mrr: number;
+  failedQueryCount: number;
+  failedQueries: ReplayFailedQuery[];
+}
+
+export interface ReplayEvaluationQueryMetrics extends ReplayQueryMetrics {
+  retrievedIds: string[];
+  candidateIds: string[];
+  confidence: MatchConfidence;
+  fallbackTrace: string[];
+  reciprocalRank: number;
+  expectation?: ReplayExpectation;
+  forbiddenHitIds?: string[];
+  noMatchSatisfied?: boolean;
+}
+
 export interface ReplayEvaluationReport {
   name: string;
   description?: string;
   evaluator: string;
   generatedAt: string;
   fixtureStats: ReplayFixtureStats;
-  summary: ReplayMetricsSummary;
-  perQuery: ReplayQueryMetrics[];
+  summary: ReplayEvaluationSummary;
+  perQuery: ReplayEvaluationQueryMetrics[];
 }
 
 export interface ReplayEvaluationMarkdownOptions {
   qrelsPath?: string;
 }
 
-export function evaluateReplayFixture(
+export async function evaluateReplayFixture(
   fixture: ReplayEvaluationFixture,
   options: ReplayEvaluationOptions = {}
-): ReplayEvaluationReport {
-  const perQuery = computePrecisionRecallAtK(
-    fixture.queries.map((query) => ({
-      queryId: query.queryId,
-      expectedIds: query.expectedIds,
-      expectedRelevance: query.expectedRelevance,
-      retrievedIds: rankByTokenOverlap(query.query, fixture.memories).map((memory) => memory.id)
+): Promise<ReplayEvaluationReport> {
+  const topK = determineTopK(fixture, options.topK);
+  const retrievalOptions: Partial<RetrieveMemoriesOptions> = {
+    strategy: 'auto',
+    minScore: 0.1,
+    includeShared: false,
+    adaptiveRerank: false,
+    ...options.retrievalOptions,
+    topK
+  };
+  const runner = options.retrievalRunner ?? createReplayRetrievalRunner(fixture);
+
+  const runs = await Promise.all(
+    fixture.queries.map(async (query) => {
+      const run = await runner(query.query, {
+        fixture,
+        query,
+        topK,
+        retrievalOptions
+      });
+      return {
+        query,
+        retrievedIds: uniqueIds(run.retrievedIds).slice(0, topK),
+        candidateIds: uniqueIds(run.candidateIds ?? run.retrievedIds),
+        confidence: run.confidence ?? 'none',
+        fallbackTrace: run.fallbackTrace ?? []
+      };
+    })
+  );
+
+  const baseMetrics = computePrecisionRecallAtK(
+    runs.map((run) => ({
+      queryId: run.query.queryId,
+      expectedIds: run.query.expectedIds,
+      expectedRelevance: run.query.expectedRelevance,
+      retrievedIds: run.retrievedIds
     })),
     fixture.ks
   );
+
+  const perQuery: ReplayEvaluationQueryMetrics[] = baseMetrics.map((metric, index) => {
+    const run = runs[index];
+    const expectation = getReplayExpectation(run.query);
+    const base: ReplayEvaluationQueryMetrics = {
+      ...metric,
+      retrievedIds: run.retrievedIds,
+      candidateIds: run.candidateIds,
+      confidence: run.confidence,
+      fallbackTrace: run.fallbackTrace,
+      reciprocalRank: expectation === 'match' ? reciprocalRank(run.retrievedIds, run.query.expectedIds) : 0
+    };
+
+    if (expectation === 'no_match') {
+      const forbiddenHitIds = findForbiddenHitIds(run.retrievedIds, run.query.forbiddenIds ?? []);
+      base.expectation = 'no_match';
+      base.forbiddenHitIds = forbiddenHitIds;
+      base.noMatchSatisfied = forbiddenHitIds.length === 0 && run.confidence === 'none';
+    }
+
+    return base;
+  });
 
   const fixtureStats: ReplayFixtureStats = {
     queryCount: fixture.queries.length,
@@ -88,10 +208,10 @@ export function evaluateReplayFixture(
 
   const report: ReplayEvaluationReport = {
     name: fixture.name,
-    evaluator: options.evaluator ?? 'token-overlap-v1',
+    evaluator: options.evaluator ?? 'retriever-pipeline-v1',
     generatedAt: options.generatedAt ?? new Date().toISOString(),
     fixtureStats,
-    summary: summarizeReplayMetrics(perQuery, fixture.ks),
+    summary: summarizeEvaluationMetrics(perQuery, fixture.queries, fixture.ks),
     perQuery: options.includePerQuery === false ? [] : perQuery
   };
 
@@ -100,6 +220,39 @@ export function evaluateReplayFixture(
   }
 
   return report;
+}
+
+export function createReplayRetrievalRunner(
+  fixture: ReplayEvaluationFixture
+): ReplayRetrievalRunner {
+  const eventStore = new ReplayEventStore(fixture.memories);
+  const vectorStore = new ReplayVectorStore(eventStore.events);
+  const embedder = new ReplayEmbedder();
+  const services = createRetrievalServices({
+    initialize: async () => undefined,
+    eventStore: eventStore as unknown as Parameters<typeof createRetrievalServices>[0]['eventStore'],
+    vectorStore: vectorStore as unknown as VectorStore,
+    embedder: embedder as unknown as Embedder,
+    matcher: new Matcher(),
+    getProjectHash: () => null,
+    hasSharedStore: () => false
+  });
+
+  return async (query, input) => {
+    const result = await services.retrievalOrchestrator.retrieveMemories(query, {
+      ...input.retrievalOptions,
+      topK: input.topK,
+      includeShared: false
+    });
+
+    return {
+      retrievedIds: result.memories.map((memory) => memory.event.id),
+      candidateIds: (result.candidateDebug ?? result.selectedDebug ?? [])
+        .map((detail) => detail.eventId),
+      confidence: result.matchResult.confidence,
+      fallbackTrace: result.fallbackTrace ?? []
+    };
+  };
 }
 
 export function formatReplayEvaluationMarkdown(
@@ -125,12 +278,12 @@ export function formatReplayEvaluationMarkdown(
   lines.push('');
   lines.push('## Summary');
   lines.push('');
-  lines.push('| k | Precision@k | Recall@k | nDCG@k |');
-  lines.push('|---:|---:|---:|---:|');
+  lines.push('| k | Precision@k | Recall@k | nDCG@k | Hit@k |');
+  lines.push('|---:|---:|---:|---:|---:|');
 
   for (const k of sortedKValues(report.summary)) {
     lines.push(
-      `| ${k} | ${formatMetric(report.summary.precisionAtK[k] ?? 0)} | ${formatMetric(report.summary.recallAtK[k] ?? 0)} | ${formatMetric(report.summary.ndcgAtK[k] ?? 0)} |`
+      `| ${k} | ${formatMetric(report.summary.precisionAtK[k] ?? 0)} | ${formatMetric(report.summary.recallAtK[k] ?? 0)} | ${formatMetric(report.summary.ndcgAtK[k] ?? 0)} | ${formatMetric(report.summary.hitAtK[k] ?? 0)} |`
     );
   }
 
@@ -139,18 +292,38 @@ export function formatReplayEvaluationMarkdown(
   lines.push('');
   lines.push('| Metric | Value |');
   lines.push('|---|---:|');
+  lines.push(`| Positive queries | ${report.summary.positiveQueryCount} |`);
+  lines.push(`| No-match queries | ${report.summary.noMatchQueryCount} |`);
+  lines.push(`| No-match accuracy | ${formatMetric(report.summary.noMatchAccuracy)} |`);
+  lines.push(`| Forbidden hits | ${report.summary.forbiddenHitCount} |`);
+  lines.push(`| MRR | ${formatMetric(report.summary.mrr)} |`);
+  lines.push(`| Failed queries | ${report.summary.failedQueryCount} |`);
   for (const k of sortedKValues(report.summary)) {
     lines.push(`| Precision@${k} | ${formatMetric(report.summary.precisionAtK[k] ?? 0)} |`);
     lines.push(`| Recall@${k} | ${formatMetric(report.summary.recallAtK[k] ?? 0)} |`);
     lines.push(`| nDCG@${k} | ${formatMetric(report.summary.ndcgAtK[k] ?? 0)} |`);
+    lines.push(`| Hit@${k} | ${formatMetric(report.summary.hitAtK[k] ?? 0)} |`);
+  }
+
+  if (report.summary.failedQueries.length > 0) {
+    lines.push('');
+    lines.push('## Failed queries');
+    lines.push('');
+    lines.push('| queryId | expectedIds | retrievedIds |');
+    lines.push('|---|---|---|');
+    for (const failed of report.summary.failedQueries) {
+      lines.push(
+        `| ${escapeMarkdownCell(failed.queryId)} | ${escapeMarkdownCell(failed.expectedIds.join(', '))} | ${escapeMarkdownCell(failed.retrievedIds.join(', '))} |`
+      );
+    }
   }
 
   if (report.perQuery.length > 0) {
     lines.push('');
     lines.push('## Per-query metrics');
     lines.push('');
-    lines.push('| queryId | k | hits | Precision@k | Recall@k | nDCG@k |');
-    lines.push('|---|---:|---:|---:|---:|---:|');
+    lines.push('| queryId | k | hits | Precision@k | Recall@k | nDCG@k | RR | confidence |');
+    lines.push('|---|---:|---:|---:|---:|---:|---:|---|');
 
     for (const query of report.perQuery) {
       const ks = Object.keys(query.at).map(Number).sort((a, b) => a - b);
@@ -158,7 +331,7 @@ export function formatReplayEvaluationMarkdown(
         const metric = query.at[k];
         if (!metric) continue;
         lines.push(
-          `| ${escapeMarkdownCell(query.queryId)} | ${k} | ${metric.hits} | ${formatMetric(metric.precision)} | ${formatMetric(metric.recall)} | ${formatMetric(metric.ndcg)} |`
+          `| ${escapeMarkdownCell(query.queryId)} | ${k} | ${metric.hits} | ${formatMetric(metric.precision)} | ${formatMetric(metric.recall)} | ${formatMetric(metric.ndcg)} | ${formatMetric(query.reciprocalRank)} | ${query.confidence} |`
         );
       }
     }
@@ -170,35 +343,154 @@ export function formatReplayEvaluationMarkdown(
   return lines.join('\n');
 }
 
-export function rankByTokenOverlap(
-  query: string,
-  memories: ReplayEvaluationMemory[]
-): ReplayEvaluationMemory[] {
-  const queryTokens = tokenize(query);
-  return [...memories]
-    .map((memory) => ({ memory, score: overlap(queryTokens, tokenize(memory.content)) }))
-    .sort((a, b) => b.score - a.score || a.memory.id.localeCompare(b.memory.id))
-    .map((row) => row.memory);
+function summarizeEvaluationMetrics(
+  perQuery: ReplayEvaluationQueryMetrics[],
+  queries: ReplayEvaluationQuery[],
+  ks: number[]
+): ReplayEvaluationSummary {
+  const pairs = perQuery.map((metric, index) => ({
+    metric,
+    query: queries[index],
+    expectation: getReplayExpectation(queries[index])
+  }));
+  const positivePairs = pairs.filter((pair) => pair.expectation === 'match');
+  const noMatchPairs = pairs.filter((pair) => pair.expectation === 'no_match');
+  const positiveMetrics = positivePairs.map((pair) => pair.metric);
+  const base = summarizeReplayMetrics(positiveMetrics, ks);
+  const normalizedKs = normalizeKs(ks);
+  const hitAtK: Record<number, number> = {};
+  for (const k of normalizedKs) {
+    hitAtK[k] = average(positiveMetrics.map((metric) => (metric.at[k]?.hits ?? 0) > 0 ? 1 : 0));
+  }
+
+  const positiveFailures: ReplayFailedQuery[] = positivePairs
+    .filter(({ metric, query }) => query.expectedIds.length > 0 && metric.reciprocalRank === 0)
+    .map(({ metric, query }) => ({
+      queryId: query.queryId,
+      expectedIds: [...query.expectedIds],
+      retrievedIds: [...metric.retrievedIds],
+      expectation: 'match',
+      reason: 'missing_expected'
+    }));
+
+  const noMatchFailures: ReplayFailedQuery[] = noMatchPairs
+    .filter(({ metric }) => metric.noMatchSatisfied !== true)
+    .map(({ metric, query }) => ({
+      queryId: query.queryId,
+      expectedIds: [],
+      retrievedIds: [...metric.retrievedIds],
+      expectation: 'no_match',
+      reason: 'unexpected_match'
+    }));
+
+  const noMatchCorrect = noMatchPairs.filter(({ metric }) => metric.noMatchSatisfied === true).length;
+  const forbiddenHitCount = noMatchPairs.reduce(
+    (sum, { metric }) => sum + (metric.forbiddenHitIds?.length ?? 0),
+    0
+  );
+  const failedQueries = [...positiveFailures, ...noMatchFailures];
+
+  return {
+    ...base,
+    queryCount: perQuery.length,
+    positiveQueryCount: positivePairs.length,
+    noMatchQueryCount: noMatchPairs.length,
+    noMatchCorrect,
+    noMatchAccuracy: noMatchPairs.length === 0 ? 0 : noMatchCorrect / noMatchPairs.length,
+    forbiddenHitCount,
+    hitAtK,
+    mrr: average(positiveMetrics.map((metric) => metric.reciprocalRank)),
+    failedQueryCount: failedQueries.length,
+    failedQueries
+  };
+}
+
+function determineTopK(fixture: ReplayEvaluationFixture, optionTopK?: number): number {
+  return Math.max(1, optionTopK ?? 0, ...fixture.ks.map((k) => Math.floor(k)).filter((k) => k > 0));
 }
 
 function sortedKValues(summary: ReplayMetricsSummary): number[] {
   return Object.keys(summary.precisionAtK).map(Number).sort((a, b) => a - b);
 }
 
-function tokenize(text: string): Set<string> {
-  return new Set(
-    text
-      .toLowerCase()
-      .replace(/[^a-z0-9가-힣\s]/g, ' ')
-      .split(/\s+/)
-      .filter((token) => token.length >= 2)
-  );
+function normalizeKs(ks: number[]): number[] {
+  const seen = new Set<number>();
+  const normalized: number[] = [];
+  for (const rawK of ks) {
+    const k = Math.max(0, Math.floor(rawK));
+    if (seen.has(k)) continue;
+    seen.add(k);
+    normalized.push(k);
+  }
+  return normalized.sort((a, b) => a - b);
 }
 
-function overlap(a: Set<string>, b: Set<string>): number {
-  let hits = 0;
-  for (const token of Array.from(a)) if (b.has(token)) hits += 1;
-  return hits;
+function uniqueIds(ids: string[]): string[] {
+  const seen = new Set<string>();
+  const unique: string[] = [];
+  for (const id of ids) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    unique.push(id);
+  }
+  return unique;
+}
+
+function reciprocalRank(retrievedIds: string[], expectedIds: string[]): number {
+  const expected = new Set(expectedIds);
+  if (expected.size === 0) return 0;
+  const index = retrievedIds.findIndex((id) => expected.has(id));
+  return index === -1 ? 0 : 1 / (index + 1);
+}
+
+function getReplayExpectation(query: ReplayEvaluationQuery | undefined): ReplayExpectation {
+  if (!query) return 'match';
+  return query.expectation ?? (query.expectedIds.length === 0 ? 'no_match' : 'match');
+}
+
+function findForbiddenHitIds(retrievedIds: string[], forbiddenIds: string[]): string[] {
+  if (forbiddenIds.length === 0) return [];
+  const forbidden = new Set(forbiddenIds);
+  return uniqueIds(retrievedIds.filter((id) => forbidden.has(id)));
+}
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s_.:-]/gu, ' ')
+    .split(/\s+/)
+    .flatMap((token) => token.split(/(?=[._:-])|(?<=[._:-])/g))
+    .map((token) => token.replace(/^[._:-]+|[._:-]+$/g, ''))
+    .filter((token) => token.length >= 2)
+    .slice(0, 128);
+}
+
+function keywordScore(queryTokens: string[], content: string): number {
+  if (queryTokens.length === 0) return 0;
+  const contentTokens = new Set(tokenize(content));
+  const hits = queryTokens.filter((token) => contentTokens.has(token)).length;
+  return hits / queryTokens.length;
+}
+
+function vectorize(text: string, dimensions = 64): number[] {
+  const vector = new Array<number>(dimensions).fill(0);
+  for (const token of tokenize(text)) {
+    let hash = 2166136261;
+    for (let i = 0; i < token.length; i += 1) {
+      hash ^= token.charCodeAt(i);
+      hash = Math.imul(hash, 16777619);
+    }
+    vector[Math.abs(hash) % dimensions] += 1;
+  }
+  const norm = Math.sqrt(vector.reduce((sum, value) => sum + value * value, 0)) || 1;
+  return vector.map((value) => value / norm);
+}
+
+function cosine(a: number[], b: number[]): number {
+  const length = Math.min(a.length, b.length);
+  let dot = 0;
+  for (let i = 0; i < length; i += 1) dot += a[i] * b[i];
+  return Math.max(0, Math.min(1, dot));
 }
 
 function formatMetric(value: number): string {
@@ -207,4 +499,127 @@ function formatMetric(value: number): string {
 
 function escapeMarkdownCell(value: string): string {
   return value.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+function average(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+class ReplayEventStore {
+  readonly events: MemoryEvent[];
+  private readonly byId: Map<string, MemoryEvent>;
+
+  constructor(memories: ReplayEvaluationMemory[]) {
+    this.events = memories.map((memory, index) => replayMemoryToEvent(memory, index));
+    this.byId = new Map(this.events.map((event) => [event.id, event]));
+  }
+
+  async keywordSearch(query: string, limit = 10): Promise<Array<{ event: MemoryEvent; rank: number }>> {
+    const queryTokens = tokenize(query);
+    return this.events
+      .map((event) => ({ event, score: keywordScore(queryTokens, event.content) }))
+      .filter((row) => row.score > 0)
+      .sort((a, b) => b.score - a.score || a.event.id.localeCompare(b.event.id))
+      .slice(0, limit)
+      .map((row, index) => ({ event: row.event, rank: -row.score - index / 1000 }));
+  }
+
+  async getRecentEvents(limit = 100): Promise<MemoryEvent[]> {
+    return [...this.events]
+      .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime() || a.id.localeCompare(b.id))
+      .slice(0, limit);
+  }
+
+  async getEvent(id: string): Promise<MemoryEvent | null> {
+    return this.byId.get(id) ?? null;
+  }
+
+  async getSessionEvents(sessionId: string): Promise<MemoryEvent[]> {
+    return this.events
+      .filter((event) => event.sessionId === sessionId)
+      .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime() || a.id.localeCompare(b.id));
+  }
+
+  async getHelpfulnessStats(): Promise<{ avgScore: number; totalEvaluated: number; totalRetrievals: number; helpful: number; neutral: number; unhelpful: number }> {
+    return { avgScore: 0, totalEvaluated: 0, totalRetrievals: 0, helpful: 0, neutral: 0, unhelpful: 0 };
+  }
+
+  async recordRetrievalTrace(): Promise<void> {
+    return undefined;
+  }
+
+  async incrementAccessCount(): Promise<void> {
+    return undefined;
+  }
+
+  async recordRetrieval(): Promise<void> {
+    return undefined;
+  }
+}
+
+class ReplayVectorStore {
+  private readonly rows: Array<SearchResult & { vector: number[] }>;
+
+  constructor(events: MemoryEvent[]) {
+    this.rows = events.map((event) => ({
+      id: `replay-vector-${event.id}`,
+      eventId: event.id,
+      content: event.content,
+      score: 0,
+      sessionId: event.sessionId,
+      eventType: event.eventType,
+      timestamp: event.timestamp.toISOString(),
+      vector: vectorize(event.content)
+    }));
+  }
+
+  async search(queryVector: number[], options: { limit?: number; minScore?: number; sessionId?: string } = {}): Promise<SearchResult[]> {
+    const limit = options.limit ?? 5;
+    const minScore = options.minScore ?? 0;
+    return this.rows
+      .filter((row) => !options.sessionId || row.sessionId === options.sessionId)
+      .map((row) => ({ ...row, score: cosine(queryVector, row.vector) }))
+      .filter((row) => row.score >= minScore)
+      .sort((a, b) => b.score - a.score || a.eventId.localeCompare(b.eventId))
+      .slice(0, limit)
+      .map((row) => ({
+        id: row.id,
+        eventId: row.eventId,
+        content: row.content,
+        score: row.score,
+        sessionId: row.sessionId,
+        eventType: row.eventType,
+        timestamp: row.timestamp
+      }));
+  }
+
+  async count(): Promise<number> {
+    return this.rows.length;
+  }
+}
+
+class ReplayEmbedder {
+  async embed(text: string): Promise<{ vector: number[]; model: string; dimensions: number }> {
+    const vector = vectorize(text);
+    return { vector, model: 'deterministic-replay-hash', dimensions: vector.length };
+  }
+}
+
+function replayMemoryToEvent(memory: ReplayEvaluationMemory, index: number): MemoryEvent {
+  const sessionId = memory.sourceSessionId ?? 'replay-fixture';
+  const timestamp = memory.timestamp
+    ? new Date(memory.timestamp)
+    : new Date(Date.UTC(2026, 0, 1, 0, 0, index));
+
+  return {
+    id: memory.id,
+    sessionId,
+    eventType: memory.eventType ?? 'agent_response',
+    content: memory.content,
+    canonicalKey: memory.canonicalKey ?? `replay/${memory.id}`,
+    dedupeKey: `replay:${sessionId}:${memory.id}`,
+    timestamp,
+    metadata: memory.metadata ?? {}
+  };
 }

--- a/src/core/replay-evaluator.ts
+++ b/src/core/replay-evaluator.ts
@@ -1,0 +1,210 @@
+import {
+  computePrecisionRecallAtK,
+  summarizeReplayMetrics,
+  type ReplayMetricsSummary,
+  type ReplayQueryMetrics
+} from './retrieval-benchmark.js';
+
+export interface ReplayEvaluationQuery {
+  queryId: string;
+  query: string;
+  expectedIds: string[];
+  expectedRelevance?: Record<string, number>;
+}
+
+export interface ReplayEvaluationMemory {
+  id: string;
+  content: string;
+}
+
+export interface ReplayEvaluationFixtureMetadata {
+  sourceFileCount?: number;
+  rawContentIncluded?: boolean;
+  generatedAt?: string;
+}
+
+export interface ReplayEvaluationFixture {
+  name: string;
+  description?: string;
+  ks: number[];
+  queries: ReplayEvaluationQuery[];
+  memories: ReplayEvaluationMemory[];
+  metadata?: ReplayEvaluationFixtureMetadata;
+}
+
+export interface ReplayEvaluationOptions {
+  generatedAt?: string;
+  includePerQuery?: boolean;
+  evaluator?: string;
+}
+
+export interface ReplayFixtureStats {
+  queryCount: number;
+  memoryCount: number;
+  ks: number[];
+  sourceFileCount?: number;
+  rawContentIncluded?: boolean;
+}
+
+export interface ReplayEvaluationReport {
+  name: string;
+  description?: string;
+  evaluator: string;
+  generatedAt: string;
+  fixtureStats: ReplayFixtureStats;
+  summary: ReplayMetricsSummary;
+  perQuery: ReplayQueryMetrics[];
+}
+
+export interface ReplayEvaluationMarkdownOptions {
+  qrelsPath?: string;
+}
+
+export function evaluateReplayFixture(
+  fixture: ReplayEvaluationFixture,
+  options: ReplayEvaluationOptions = {}
+): ReplayEvaluationReport {
+  const perQuery = computePrecisionRecallAtK(
+    fixture.queries.map((query) => ({
+      queryId: query.queryId,
+      expectedIds: query.expectedIds,
+      expectedRelevance: query.expectedRelevance,
+      retrievedIds: rankByTokenOverlap(query.query, fixture.memories).map((memory) => memory.id)
+    })),
+    fixture.ks
+  );
+
+  const fixtureStats: ReplayFixtureStats = {
+    queryCount: fixture.queries.length,
+    memoryCount: fixture.memories.length,
+    ks: fixture.ks
+  };
+  if (fixture.metadata?.sourceFileCount !== undefined) {
+    fixtureStats.sourceFileCount = fixture.metadata.sourceFileCount;
+  }
+  if (fixture.metadata?.rawContentIncluded !== undefined) {
+    fixtureStats.rawContentIncluded = fixture.metadata.rawContentIncluded;
+  }
+
+  const report: ReplayEvaluationReport = {
+    name: fixture.name,
+    evaluator: options.evaluator ?? 'token-overlap-v1',
+    generatedAt: options.generatedAt ?? new Date().toISOString(),
+    fixtureStats,
+    summary: summarizeReplayMetrics(perQuery, fixture.ks),
+    perQuery: options.includePerQuery === false ? [] : perQuery
+  };
+
+  if (fixture.description !== undefined) {
+    report.description = fixture.description;
+  }
+
+  return report;
+}
+
+export function formatReplayEvaluationMarkdown(
+  report: ReplayEvaluationReport,
+  options: ReplayEvaluationMarkdownOptions = {}
+): string {
+  const lines: string[] = [];
+  lines.push('# Retrieval Replay Benchmark Report');
+  lines.push('');
+  lines.push(`- Fixture: ${escapeMarkdownCell(report.name)}`);
+  if (report.description) lines.push(`- Description: ${escapeMarkdownCell(report.description)}`);
+  if (options.qrelsPath) lines.push(`- Qrels: \`${options.qrelsPath}\``);
+  lines.push(`- Evaluator: \`${report.evaluator}\``);
+  lines.push(`- Generated at: ${report.generatedAt}`);
+  lines.push(`- Queries: ${report.fixtureStats.queryCount}`);
+  lines.push(`- Memories: ${report.fixtureStats.memoryCount}`);
+  if (report.fixtureStats.sourceFileCount !== undefined) {
+    lines.push(`- Source files: ${report.fixtureStats.sourceFileCount}`);
+  }
+  if (report.fixtureStats.rawContentIncluded !== undefined) {
+    lines.push(`- Raw content in evaluated fixture: ${report.fixtureStats.rawContentIncluded ? 'yes' : 'no'}`);
+  }
+  lines.push('');
+  lines.push('## Summary');
+  lines.push('');
+  lines.push('| k | Precision@k | Recall@k | nDCG@k |');
+  lines.push('|---:|---:|---:|---:|');
+
+  for (const k of sortedKValues(report.summary)) {
+    lines.push(
+      `| ${k} | ${formatMetric(report.summary.precisionAtK[k] ?? 0)} | ${formatMetric(report.summary.recallAtK[k] ?? 0)} | ${formatMetric(report.summary.ndcgAtK[k] ?? 0)} |`
+    );
+  }
+
+  lines.push('');
+  lines.push('## Key metrics');
+  lines.push('');
+  lines.push('| Metric | Value |');
+  lines.push('|---|---:|');
+  for (const k of sortedKValues(report.summary)) {
+    lines.push(`| Precision@${k} | ${formatMetric(report.summary.precisionAtK[k] ?? 0)} |`);
+    lines.push(`| Recall@${k} | ${formatMetric(report.summary.recallAtK[k] ?? 0)} |`);
+    lines.push(`| nDCG@${k} | ${formatMetric(report.summary.ndcgAtK[k] ?? 0)} |`);
+  }
+
+  if (report.perQuery.length > 0) {
+    lines.push('');
+    lines.push('## Per-query metrics');
+    lines.push('');
+    lines.push('| queryId | k | hits | Precision@k | Recall@k | nDCG@k |');
+    lines.push('|---|---:|---:|---:|---:|---:|');
+
+    for (const query of report.perQuery) {
+      const ks = Object.keys(query.at).map(Number).sort((a, b) => a - b);
+      for (const k of ks) {
+        const metric = query.at[k];
+        if (!metric) continue;
+        lines.push(
+          `| ${escapeMarkdownCell(query.queryId)} | ${k} | ${metric.hits} | ${formatMetric(metric.precision)} | ${formatMetric(metric.recall)} | ${formatMetric(metric.ndcg)} |`
+        );
+      }
+    }
+  }
+
+  lines.push('');
+  lines.push('> Report intentionally omits raw query and memory text.');
+  lines.push('');
+  return lines.join('\n');
+}
+
+export function rankByTokenOverlap(
+  query: string,
+  memories: ReplayEvaluationMemory[]
+): ReplayEvaluationMemory[] {
+  const queryTokens = tokenize(query);
+  return [...memories]
+    .map((memory) => ({ memory, score: overlap(queryTokens, tokenize(memory.content)) }))
+    .sort((a, b) => b.score - a.score || a.memory.id.localeCompare(b.memory.id))
+    .map((row) => row.memory);
+}
+
+function sortedKValues(summary: ReplayMetricsSummary): number[] {
+  return Object.keys(summary.precisionAtK).map(Number).sort((a, b) => a - b);
+}
+
+function tokenize(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .replace(/[^a-z0-9가-힣\s]/g, ' ')
+      .split(/\s+/)
+      .filter((token) => token.length >= 2)
+  );
+}
+
+function overlap(a: Set<string>, b: Set<string>): number {
+  let hits = 0;
+  for (const token of Array.from(a)) if (b.has(token)) hits += 1;
+  return hits;
+}
+
+function formatMetric(value: number): string {
+  return value.toFixed(4).replace(/\.0+$/, '').replace(/(\.\d*?)0+$/, '$1');
+}
+
+function escapeMarkdownCell(value: string): string {
+  return value.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}

--- a/src/core/retrieval-benchmark.ts
+++ b/src/core/retrieval-benchmark.ts
@@ -2,12 +2,15 @@ export interface ReplayMetricInput {
   queryId: string;
   expectedIds: string[];
   retrievedIds: string[];
+  /** Optional graded qrels labels. Missing expected ids default to relevance 1. */
+  expectedRelevance?: Record<string, number>;
 }
 
 export interface PrecisionRecallAtK {
   precision: number;
   recall: number;
   hits: number;
+  ndcg: number;
 }
 
 export interface ReplayQueryMetrics {
@@ -19,6 +22,7 @@ export interface ReplayMetricsSummary {
   queryCount: number;
   precisionAtK: Record<number, number>;
   recallAtK: Record<number, number>;
+  ndcgAtK: Record<number, number>;
 }
 
 export function computePrecisionRecallAtK(
@@ -28,6 +32,7 @@ export function computePrecisionRecallAtK(
   const normalizedKs = normalizeKs(ks);
   return inputs.map((input) => {
     const expected = new Set(input.expectedIds);
+    const relevance = normalizeRelevance(input.expectedIds, input.expectedRelevance);
     const at: Record<number, PrecisionRecallAtK> = {};
 
     for (const k of normalizedKs) {
@@ -36,7 +41,8 @@ export function computePrecisionRecallAtK(
       at[k] = {
         precision: k === 0 ? 0 : hits / k,
         recall: expected.size === 0 ? 0 : hits / expected.size,
-        hits
+        hits,
+        ndcg: computeNdcgAtK(retrieved, relevance, k)
       };
     }
 
@@ -51,13 +57,15 @@ export function summarizeReplayMetrics(
   const normalizedKs = normalizeKs(ks);
   const precisionAtK: Record<number, number> = {};
   const recallAtK: Record<number, number> = {};
+  const ndcgAtK: Record<number, number> = {};
 
   for (const k of normalizedKs) {
     precisionAtK[k] = average(metrics.map((metric) => metric.at[k]?.precision ?? 0));
     recallAtK[k] = average(metrics.map((metric) => metric.at[k]?.recall ?? 0));
+    ndcgAtK[k] = average(metrics.map((metric) => metric.at[k]?.ndcg ?? 0));
   }
 
-  return { queryCount: metrics.length, precisionAtK, recallAtK };
+  return { queryCount: metrics.length, precisionAtK, recallAtK, ndcgAtK };
 }
 
 function normalizeKs(ks: number[]): number[] {
@@ -72,6 +80,35 @@ function normalizeKs(ks: number[]): number[] {
   }
 
   return normalized.sort((a, b) => a - b);
+}
+
+function normalizeRelevance(expectedIds: string[], expectedRelevance?: Record<string, number>): Record<string, number> {
+  const relevance: Record<string, number> = {};
+  for (const id of expectedIds) {
+    const raw = expectedRelevance?.[id] ?? 1;
+    relevance[id] = Number.isFinite(raw) ? Math.max(0, raw) : 0;
+  }
+  return relevance;
+}
+
+function computeNdcgAtK(retrieved: string[], relevance: Record<string, number>, k: number): number {
+  if (k <= 0) return 0;
+
+  const seen = new Set<string>();
+  const dcg = retrieved.reduce((sum, id, index) => {
+    if (seen.has(id)) return sum;
+    seen.add(id);
+    return sum + discountedGain(relevance[id] ?? 0, index);
+  }, 0);
+
+  const idealRelevance = Object.values(relevance).sort((a, b) => b - a).slice(0, k);
+  const idealDcg = idealRelevance.reduce((sum, rel, index) => sum + discountedGain(rel, index), 0);
+  return idealDcg === 0 ? 0 : dcg / idealDcg;
+}
+
+function discountedGain(relevance: number, zeroBasedRank: number): number {
+  if (relevance <= 0) return 0;
+  return (2 ** relevance - 1) / Math.log2(zeroBasedRank + 2);
 }
 
 function average(values: number[]): number {

--- a/src/core/session-qrels.ts
+++ b/src/core/session-qrels.ts
@@ -1,3 +1,6 @@
+import { readdir, stat } from 'node:fs/promises';
+import * as path from 'node:path';
+
 export interface SessionQrelsMemory {
   id: string;
   content: string;
@@ -15,12 +18,19 @@ export interface SessionQrelsQuery {
   sourceTurnIndex: number;
 }
 
+export interface SessionQrelsFixtureMetadata {
+  sourceFileCount?: number;
+  rawContentIncluded: boolean;
+  generatedAt?: string;
+}
+
 export interface SessionQrelsFixture {
   name: string;
   description: string;
   ks: number[];
   queries: SessionQrelsQuery[];
   memories: SessionQrelsMemory[];
+  metadata?: SessionQrelsFixtureMetadata;
 }
 
 export interface SessionQrelsOptions {
@@ -29,6 +39,35 @@ export interface SessionQrelsOptions {
   ks?: number[];
   maxQueries?: number;
   redactContent?: boolean;
+  sourceFileCount?: number;
+  rawContentIncluded?: boolean;
+  generatedAt?: string;
+}
+
+export interface SessionQrelsFileCollectionOptions {
+  includeSubagents?: boolean;
+  maxFiles?: number;
+  minBytes?: number;
+}
+
+export interface SessionQrelsPerSessionSummary {
+  sourceSessionId: string;
+  queryCount: number;
+  memoryCount: number;
+  firstTurnIndex: number;
+  lastTurnIndex: number;
+}
+
+export interface SessionQrelsSummary {
+  name: string;
+  description: string;
+  ks: number[];
+  queryCount: number;
+  memoryCount: number;
+  sourceSessionCount: number;
+  sourceFileCount?: number;
+  rawContentIncluded: boolean;
+  perSession: SessionQrelsPerSessionSummary[];
 }
 
 interface ClaudeContentBlock {
@@ -112,12 +151,109 @@ export function buildSessionQrelsFixtureFromJsonl(
     }
   }
 
+  const redactContent = options.redactContent === true;
+  const rawContentIncluded = options.rawContentIncluded ?? !redactContent;
+
   return {
     name: options.name ?? 'session-qrels-fixture',
     description: options.description ?? 'Session-derived qrels fixture generated from Claude JSONL user/assistant turns.',
     ks: options.ks ?? [1, 3, 5],
     queries,
-    memories
+    memories,
+    metadata: {
+      sourceFileCount: options.sourceFileCount,
+      rawContentIncluded,
+      generatedAt: options.generatedAt
+    }
+  };
+}
+
+export async function collectClaudeSessionJsonlFiles(
+  rootDir: string,
+  options: SessionQrelsFileCollectionOptions = {}
+): Promise<string[]> {
+  const maxFiles = options.maxFiles ?? Number.POSITIVE_INFINITY;
+  const minBytes = options.minBytes ?? 0;
+  const files: string[] = [];
+
+  async function walk(dir: string): Promise<void> {
+    if (files.length >= maxFiles) return;
+
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+
+    for (const entry of entries) {
+      if (files.length >= maxFiles) return;
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (!options.includeSubagents && entry.name.toLowerCase() === 'subagents') continue;
+        await walk(fullPath);
+        continue;
+      }
+
+      if (!entry.isFile() || !entry.name.endsWith('.jsonl')) continue;
+      if (minBytes > 0) {
+        try {
+          const info = await stat(fullPath);
+          if (info.size < minBytes) continue;
+        } catch {
+          continue;
+        }
+      }
+      files.push(fullPath);
+    }
+  }
+
+  await walk(rootDir);
+  return files;
+}
+
+export function summarizeSessionQrelsFixture(fixture: SessionQrelsFixture): SessionQrelsSummary {
+  const bySession = new Map<string, SessionQrelsPerSessionSummary>();
+
+  function ensureSession(sourceSessionId: string, turnIndex: number): SessionQrelsPerSessionSummary {
+    const existing = bySession.get(sourceSessionId);
+    if (existing) {
+      existing.firstTurnIndex = Math.min(existing.firstTurnIndex, turnIndex);
+      existing.lastTurnIndex = Math.max(existing.lastTurnIndex, turnIndex);
+      return existing;
+    }
+    const created: SessionQrelsPerSessionSummary = {
+      sourceSessionId,
+      queryCount: 0,
+      memoryCount: 0,
+      firstTurnIndex: turnIndex,
+      lastTurnIndex: turnIndex
+    };
+    bySession.set(sourceSessionId, created);
+    return created;
+  }
+
+  for (const query of fixture.queries) {
+    ensureSession(query.sourceSessionId, query.sourceTurnIndex).queryCount += 1;
+  }
+  for (const memory of fixture.memories) {
+    ensureSession(memory.sourceSessionId, memory.sourceTurnIndex).memoryCount += 1;
+  }
+
+  const perSession = Array.from(bySession.values()).sort((a, b) => a.sourceSessionId.localeCompare(b.sourceSessionId));
+
+  return {
+    name: fixture.name,
+    description: fixture.description,
+    ks: fixture.ks,
+    queryCount: fixture.queries.length,
+    memoryCount: fixture.memories.length,
+    sourceSessionCount: perSession.length,
+    sourceFileCount: fixture.metadata?.sourceFileCount,
+    rawContentIncluded: fixture.metadata?.rawContentIncluded ?? true,
+    perSession
   };
 }
 

--- a/src/core/session-qrels.ts
+++ b/src/core/session-qrels.ts
@@ -9,6 +9,8 @@ export interface SessionQrelsMemory {
   timestamp?: string;
 }
 
+export type SessionQrelsExpectation = 'match' | 'no_match';
+
 export interface SessionQrelsQuery {
   queryId: string;
   query: string;
@@ -16,6 +18,9 @@ export interface SessionQrelsQuery {
   expectedRelevance: Record<string, number>;
   sourceSessionId: string;
   sourceTurnIndex: number;
+  expectation?: SessionQrelsExpectation;
+  forbiddenIds?: string[];
+  knownAnswer?: string;
 }
 
 export interface SessionQrelsFixtureMetadata {
@@ -33,6 +38,14 @@ export interface SessionQrelsFixture {
   metadata?: SessionQrelsFixtureMetadata;
 }
 
+export interface SessionQrelsNoMatchQueryInput {
+  queryId?: string;
+  query: string;
+  forbiddenIds?: string[];
+  sourceSessionId?: string;
+  sourceTurnIndex?: number;
+}
+
 export interface SessionQrelsOptions {
   name?: string;
   description?: string;
@@ -42,6 +55,7 @@ export interface SessionQrelsOptions {
   sourceFileCount?: number;
   rawContentIncluded?: boolean;
   generatedAt?: string;
+  noMatchQueries?: SessionQrelsNoMatchQueryInput[];
 }
 
 export interface SessionQrelsFileCollectionOptions {
@@ -63,6 +77,9 @@ export interface SessionQrelsSummary {
   description: string;
   ks: number[];
   queryCount: number;
+  positiveQueryCount: number;
+  noMatchQueryCount: number;
+  knownAnswerCount: number;
   memoryCount: number;
   sourceSessionCount: number;
   sourceFileCount?: number;
@@ -132,9 +149,10 @@ export function buildSessionQrelsFixtureFromJsonl(
       const idSuffix = `${pending.sessionId}-${pending.turnIndex}`;
       const memoryId = `m-${idSuffix}`;
       const queryId = `q-${idSuffix}`;
+      const memoryContent = options.redactContent ? `[redacted memory ${memoryId}]` : answer;
       memories.push({
         id: memoryId,
-        content: options.redactContent ? `[redacted memory ${memoryId}]` : answer,
+        content: memoryContent,
         sourceSessionId: pending.sessionId,
         sourceTurnIndex: pending.turnIndex,
         timestamp: entry.timestamp ?? pending.timestamp
@@ -145,11 +163,15 @@ export function buildSessionQrelsFixtureFromJsonl(
         expectedIds: [memoryId],
         expectedRelevance: { [memoryId]: 2 },
         sourceSessionId: pending.sessionId,
-        sourceTurnIndex: pending.turnIndex
+        sourceTurnIndex: pending.turnIndex,
+        expectation: 'match',
+        knownAnswer: memoryContent
       });
       pendingBySession.delete(sessionId);
     }
   }
+
+  appendExplicitNoMatchQueries(queries, options);
 
   const redactContent = options.redactContent === true;
   const rawContentIncluded = options.rawContentIncluded ?? !redactContent;
@@ -244,17 +266,55 @@ export function summarizeSessionQrelsFixture(fixture: SessionQrelsFixture): Sess
 
   const perSession = Array.from(bySession.values()).sort((a, b) => a.sourceSessionId.localeCompare(b.sourceSessionId));
 
+  const positiveQueryCount = fixture.queries.filter((query) => getQueryExpectation(query) === 'match').length;
+  const noMatchQueryCount = fixture.queries.filter((query) => getQueryExpectation(query) === 'no_match').length;
+  const knownAnswerCount = fixture.queries.filter((query) => typeof query.knownAnswer === 'string' && query.knownAnswer.length > 0).length;
+
   return {
     name: fixture.name,
     description: fixture.description,
     ks: fixture.ks,
     queryCount: fixture.queries.length,
+    positiveQueryCount,
+    noMatchQueryCount,
+    knownAnswerCount,
     memoryCount: fixture.memories.length,
     sourceSessionCount: perSession.length,
     sourceFileCount: fixture.metadata?.sourceFileCount,
     rawContentIncluded: fixture.metadata?.rawContentIncluded ?? true,
     perSession
   };
+}
+
+function appendExplicitNoMatchQueries(
+  queries: SessionQrelsQuery[],
+  options: SessionQrelsOptions
+): void {
+  const inputs = options.noMatchQueries ?? [];
+  if (inputs.length === 0) return;
+
+  const remaining = options.maxQueries === undefined
+    ? Number.POSITIVE_INFINITY
+    : Math.max(0, options.maxQueries - queries.length);
+
+  const startIndex = queries.length;
+  inputs.slice(0, remaining).forEach((input, index) => {
+    const queryId = input.queryId ?? `q-no-match-${startIndex + index + 1}`;
+    queries.push({
+      queryId,
+      query: options.redactContent ? `[redacted query ${queryId}]` : input.query,
+      expectedIds: [],
+      expectedRelevance: {},
+      sourceSessionId: input.sourceSessionId ?? 'no-match',
+      sourceTurnIndex: input.sourceTurnIndex ?? 0,
+      expectation: 'no_match',
+      forbiddenIds: [...(input.forbiddenIds ?? [])]
+    });
+  });
+}
+
+function getQueryExpectation(query: SessionQrelsQuery): SessionQrelsExpectation {
+  return query.expectation ?? (query.expectedIds.length === 0 ? 'no_match' : 'match');
 }
 
 function parseEntry(line: string): ClaudeJsonlEntry | null {

--- a/src/core/session-qrels.ts
+++ b/src/core/session-qrels.ts
@@ -1,0 +1,164 @@
+export interface SessionQrelsMemory {
+  id: string;
+  content: string;
+  sourceSessionId: string;
+  sourceTurnIndex: number;
+  timestamp?: string;
+}
+
+export interface SessionQrelsQuery {
+  queryId: string;
+  query: string;
+  expectedIds: string[];
+  expectedRelevance: Record<string, number>;
+  sourceSessionId: string;
+  sourceTurnIndex: number;
+}
+
+export interface SessionQrelsFixture {
+  name: string;
+  description: string;
+  ks: number[];
+  queries: SessionQrelsQuery[];
+  memories: SessionQrelsMemory[];
+}
+
+export interface SessionQrelsOptions {
+  name?: string;
+  description?: string;
+  ks?: number[];
+  maxQueries?: number;
+  redactContent?: boolean;
+}
+
+interface ClaudeContentBlock {
+  type: string;
+  text?: string;
+}
+
+type ClaudeMessageContent = string | ClaudeContentBlock[];
+
+interface ClaudeJsonlEntry {
+  type?: string;
+  sessionId?: string;
+  timestamp?: string;
+  message?: {
+    role?: string;
+    content?: ClaudeMessageContent;
+  };
+}
+
+interface PendingPrompt {
+  sessionId: string;
+  text: string;
+  turnIndex: number;
+  timestamp?: string;
+}
+
+export function buildSessionQrelsFixtureFromJsonl(
+  jsonl: string | string[],
+  options: SessionQrelsOptions = {}
+): SessionQrelsFixture {
+  const lines = Array.isArray(jsonl) ? jsonl : jsonl.split(/\r?\n/);
+  const queries: SessionQrelsQuery[] = [];
+  const memories: SessionQrelsMemory[] = [];
+  const sessionCounters = new Map<string, number>();
+  const pendingBySession = new Map<string, PendingPrompt>();
+
+  for (const line of lines) {
+    if (options.maxQueries !== undefined && queries.length >= options.maxQueries) break;
+    const entry = parseEntry(line);
+    if (!entry) continue;
+
+    const sessionId = entry.sessionId || 'unknown-session';
+    const content = extractTextContent(entry.message?.content);
+    if (!content) continue;
+
+    if (entry.type === 'user') {
+      if (isWorthBenchmarkingPrompt(content)) {
+        const turnIndex = nextSessionCounter(sessionCounters, sessionId);
+        pendingBySession.set(sessionId, { sessionId, text: content, turnIndex, timestamp: entry.timestamp });
+      } else {
+        pendingBySession.delete(sessionId);
+      }
+      continue;
+    }
+
+    if (entry.type === 'assistant') {
+      const pending = pendingBySession.get(sessionId);
+      if (!pending) continue;
+
+      const answer = content.trim();
+      if (answer.length === 0) continue;
+      const idSuffix = `${pending.sessionId}-${pending.turnIndex}`;
+      const memoryId = `m-${idSuffix}`;
+      const queryId = `q-${idSuffix}`;
+      memories.push({
+        id: memoryId,
+        content: options.redactContent ? `[redacted memory ${memoryId}]` : answer,
+        sourceSessionId: pending.sessionId,
+        sourceTurnIndex: pending.turnIndex,
+        timestamp: entry.timestamp ?? pending.timestamp
+      });
+      queries.push({
+        queryId,
+        query: options.redactContent ? `[redacted query ${queryId}]` : pending.text,
+        expectedIds: [memoryId],
+        expectedRelevance: { [memoryId]: 2 },
+        sourceSessionId: pending.sessionId,
+        sourceTurnIndex: pending.turnIndex
+      });
+      pendingBySession.delete(sessionId);
+    }
+  }
+
+  return {
+    name: options.name ?? 'session-qrels-fixture',
+    description: options.description ?? 'Session-derived qrels fixture generated from Claude JSONL user/assistant turns.',
+    ks: options.ks ?? [1, 3, 5],
+    queries,
+    memories
+  };
+}
+
+function parseEntry(line: string): ClaudeJsonlEntry | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  try {
+    return JSON.parse(trimmed) as ClaudeJsonlEntry;
+  } catch {
+    return null;
+  }
+}
+
+function extractTextContent(content: ClaudeMessageContent | undefined): string | null {
+  if (!content) return null;
+  if (typeof content === 'string') return content.trim();
+  const texts = content
+    .filter((block) => block.type === 'text' && block.text)
+    .map((block) => block.text?.trim() ?? '')
+    .filter(Boolean);
+  return texts.length > 0 ? texts.join('\n') : null;
+}
+
+function isWorthBenchmarkingPrompt(content: string): boolean {
+  const trimmed = content.trim();
+  if (isClaudeLocalCommandArtifact(trimmed)) return false;
+  if (trimmed.startsWith('/')) return false;
+  if (trimmed.length < 15) return false;
+  return /[a-zA-Z가-힣]{2,}/.test(trimmed);
+}
+
+function isClaudeLocalCommandArtifact(content: string): boolean {
+  return (
+    /^<local-command-(stdout|stderr)>/.test(content) ||
+    /^<command-(name|message)>/.test(content) ||
+    (content.includes('<command-name>') && content.includes('<local-command-stdout>'))
+  );
+}
+
+function nextSessionCounter(counters: Map<string, number>, sessionId: string): number {
+  const next = (counters.get(sessionId) ?? 0) + 1;
+  counters.set(sessionId, next);
+  return next;
+}

--- a/tests/core/replay-evaluator.test.ts
+++ b/tests/core/replay-evaluator.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  evaluateReplayFixture,
+  formatReplayEvaluationMarkdown
+} from '../../src/core/replay-evaluator.js';
+
+const fixture = {
+  name: 'private-real-session-qrels',
+  description: 'contains raw real session text that reports must not leak',
+  ks: [1, 3],
+  queries: [
+    {
+      queryId: 'q-secret-1',
+      query: 'SECRET vector search recall regression',
+      expectedIds: ['m-secret-1'],
+      expectedRelevance: { 'm-secret-1': 2 }
+    }
+  ],
+  memories: [
+    {
+      id: 'm-secret-1',
+      content: 'SECRET vector search recall regression fix uses token overlap baseline'
+    },
+    {
+      id: 'm-noise',
+      content: 'unrelated dashboard layout memory'
+    }
+  ]
+};
+
+describe('replay fixture evaluator', () => {
+  it('evaluates token-overlap retrieval and returns a sanitized report', () => {
+    const report = evaluateReplayFixture(fixture, {
+      generatedAt: '2026-05-05T00:00:00.000Z'
+    });
+    const serialized = JSON.stringify(report);
+
+    expect(report).toMatchObject({
+      name: 'private-real-session-qrels',
+      evaluator: 'token-overlap-v1',
+      generatedAt: '2026-05-05T00:00:00.000Z',
+      fixtureStats: {
+        queryCount: 1,
+        memoryCount: 2,
+        ks: [1, 3]
+      },
+      summary: {
+        queryCount: 1,
+        precisionAtK: { 1: 1, 3: 1 / 3 },
+        recallAtK: { 1: 1, 3: 1 },
+        ndcgAtK: { 1: 1, 3: 1 }
+      }
+    });
+    expect(report.perQuery).toEqual([
+      {
+        queryId: 'q-secret-1',
+        at: {
+          1: { precision: 1, recall: 1, hits: 1, ndcg: 1 },
+          3: { precision: 1 / 3, recall: 1, hits: 1, ndcg: 1 }
+        }
+      }
+    ]);
+    expect(serialized).not.toContain('SECRET');
+    expect(serialized).not.toContain('vector search recall regression');
+  });
+
+  it('formats markdown reports without raw query or memory content', () => {
+    const report = evaluateReplayFixture(fixture, {
+      generatedAt: '2026-05-05T00:00:00.000Z',
+      includePerQuery: false
+    });
+
+    const markdown = formatReplayEvaluationMarkdown(report, {
+      qrelsPath: '.claude-memory/benchmarks/real-session-qrels.json'
+    });
+
+    expect(markdown).toContain('# Retrieval Replay Benchmark Report');
+    expect(markdown).toContain('private-real-session-qrels');
+    expect(markdown).toContain('nDCG@1');
+    expect(markdown).toContain('.claude-memory/benchmarks/real-session-qrels.json');
+    expect(markdown).not.toContain('SECRET');
+    expect(markdown).not.toContain('vector search recall regression');
+  });
+});

--- a/tests/core/replay-evaluator.test.ts
+++ b/tests/core/replay-evaluator.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import {
   evaluateReplayFixture,
-  formatReplayEvaluationMarkdown
+  formatReplayEvaluationMarkdown,
+  type ReplayRetrievalRunner
 } from '../../src/core/replay-evaluator.js';
 
 const fixture = {
@@ -20,7 +21,7 @@ const fixture = {
   memories: [
     {
       id: 'm-secret-1',
-      content: 'SECRET vector search recall regression fix uses token overlap baseline'
+      content: 'SECRET vector search recall regression fix uses retriever pipeline replay'
     },
     {
       id: 'm-noise',
@@ -30,15 +31,30 @@ const fixture = {
 };
 
 describe('replay fixture evaluator', () => {
-  it('evaluates token-overlap retrieval and returns a sanitized report', () => {
-    const report = evaluateReplayFixture(fixture, {
-      generatedAt: '2026-05-05T00:00:00.000Z'
+  it('evaluates through the retriever pipeline runner and returns a sanitized report', async () => {
+    const calls: Array<{ query: string; queryId: string; topK: number }> = [];
+    const retrievalRunner: ReplayRetrievalRunner = async (query, input) => {
+      calls.push({ query, queryId: input.query.queryId, topK: input.topK });
+      return {
+        retrievedIds: ['m-secret-1', 'm-noise'],
+        candidateIds: ['m-secret-1', 'm-noise'],
+        confidence: 'high',
+        fallbackTrace: ['stage:primary:fast']
+      };
+    };
+
+    const report = await evaluateReplayFixture(fixture, {
+      generatedAt: '2026-05-05T00:00:00.000Z',
+      retrievalRunner
     });
     const serialized = JSON.stringify(report);
 
+    expect(calls).toEqual([
+      { query: 'SECRET vector search recall regression', queryId: 'q-secret-1', topK: 3 }
+    ]);
     expect(report).toMatchObject({
       name: 'private-real-session-qrels',
-      evaluator: 'token-overlap-v1',
+      evaluator: 'retriever-pipeline-v1',
       generatedAt: '2026-05-05T00:00:00.000Z',
       fixtureStats: {
         queryCount: 1,
@@ -49,12 +65,20 @@ describe('replay fixture evaluator', () => {
         queryCount: 1,
         precisionAtK: { 1: 1, 3: 1 / 3 },
         recallAtK: { 1: 1, 3: 1 },
-        ndcgAtK: { 1: 1, 3: 1 }
+        ndcgAtK: { 1: 1, 3: 1 },
+        hitAtK: { 1: 1, 3: 1 },
+        mrr: 1,
+        failedQueryCount: 0
       }
     });
     expect(report.perQuery).toEqual([
       {
         queryId: 'q-secret-1',
+        retrievedIds: ['m-secret-1', 'm-noise'],
+        candidateIds: ['m-secret-1', 'm-noise'],
+        confidence: 'high',
+        fallbackTrace: ['stage:primary:fast'],
+        reciprocalRank: 1,
         at: {
           1: { precision: 1, recall: 1, hits: 1, ndcg: 1 },
           3: { precision: 1 / 3, recall: 1, hits: 1, ndcg: 1 }
@@ -65,8 +89,78 @@ describe('replay fixture evaluator', () => {
     expect(serialized).not.toContain('vector search recall regression');
   });
 
-  it('formats markdown reports without raw query or memory content', () => {
-    const report = evaluateReplayFixture(fixture, {
+  it('uses the real in-memory Retriever/RetrievalOrchestrator pipeline by default', async () => {
+    const report = await evaluateReplayFixture(fixture, {
+      generatedAt: '2026-05-05T00:00:00.000Z',
+      retrievalOptions: { strategy: 'fast' }
+    });
+
+    expect(report.evaluator).toBe('retriever-pipeline-v1');
+    expect(report.perQuery[0]).toMatchObject({
+      queryId: 'q-secret-1',
+      retrievedIds: expect.arrayContaining(['m-secret-1']),
+      candidateIds: expect.arrayContaining(['m-secret-1']),
+      fallbackTrace: expect.arrayContaining(['stage:primary:fast'])
+    });
+    expect(report.summary.hitAtK[1]).toBe(1);
+  });
+
+  it('counts no-match qrels separately from positive retrieval misses', async () => {
+    const report = await evaluateReplayFixture({
+      name: 'negative-qrels-fixture',
+      ks: [1, 3],
+      queries: [
+        {
+          queryId: 'q-positive',
+          query: 'retriever pipeline replay answer',
+          expectation: 'match',
+          expectedIds: ['m-positive'],
+          expectedRelevance: { 'm-positive': 2 },
+          knownAnswer: 'Retriever pipeline replay answer should be found.'
+        },
+        {
+          queryId: 'q-command-artifact-no-match',
+          query: 'local-command-stdout command-name opus',
+          expectation: 'no_match',
+          expectedIds: [],
+          expectedRelevance: {},
+          forbiddenIds: ['m-positive']
+        }
+      ],
+      memories: [
+        {
+          id: 'm-positive',
+          content: 'Retriever pipeline replay answer should be found.'
+        }
+      ]
+    }, {
+      generatedAt: '2026-05-05T00:00:00.000Z',
+      retrievalOptions: { strategy: 'auto' }
+    });
+
+    expect(report.summary).toMatchObject({
+      queryCount: 2,
+      positiveQueryCount: 1,
+      noMatchQueryCount: 1,
+      noMatchCorrect: 1,
+      noMatchAccuracy: 1,
+      failedQueryCount: 0,
+      precisionAtK: { 1: 1, 3: 1 / 3 },
+      recallAtK: { 1: 1, 3: 1 },
+      hitAtK: { 1: 1, 3: 1 }
+    });
+    expect(report.perQuery[1]).toMatchObject({
+      queryId: 'q-command-artifact-no-match',
+      expectation: 'no_match',
+      retrievedIds: [],
+      forbiddenHitIds: [],
+      noMatchSatisfied: true,
+      confidence: 'none'
+    });
+  });
+
+  it('formats markdown reports without raw query or memory content', async () => {
+    const report = await evaluateReplayFixture(fixture, {
       generatedAt: '2026-05-05T00:00:00.000Z',
       includePerQuery: false
     });
@@ -78,6 +172,8 @@ describe('replay fixture evaluator', () => {
     expect(markdown).toContain('# Retrieval Replay Benchmark Report');
     expect(markdown).toContain('private-real-session-qrels');
     expect(markdown).toContain('nDCG@1');
+    expect(markdown).toContain('Hit@1');
+    expect(markdown).toContain('MRR');
     expect(markdown).toContain('.claude-memory/benchmarks/real-session-qrels.json');
     expect(markdown).not.toContain('SECRET');
     expect(markdown).not.toContain('vector search recall regression');

--- a/tests/core/retrieval-benchmark.test.ts
+++ b/tests/core/retrieval-benchmark.test.ts
@@ -12,28 +12,38 @@ describe('retrieval replay benchmark metrics', () => {
       [1, 3]
     );
 
-    expect(queryMetrics).toEqual([
-      {
-        queryId: 'q1',
-        at: {
-          1: { precision: 1, recall: 0.5, hits: 1 },
-          3: { precision: 2 / 3, recall: 1, hits: 2 }
-        }
-      },
-      {
-        queryId: 'q2',
-        at: {
-          1: { precision: 0, recall: 0, hits: 0 },
-          3: { precision: 0, recall: 0, hits: 0 }
-        }
-      }
-    ]);
+    expect(queryMetrics[0].at[1]).toMatchObject({ precision: 1, recall: 0.5, hits: 1 });
+    expect(queryMetrics[0].at[3]).toMatchObject({ precision: 2 / 3, recall: 1, hits: 2 });
+    expect(queryMetrics[0].at[1].ndcg).toBe(1);
+    expect(queryMetrics[0].at[3].ndcg).toBeCloseTo(0.91972, 4);
+    expect(queryMetrics[1].at[1]).toMatchObject({ precision: 0, recall: 0, hits: 0 });
+    expect(queryMetrics[1].at[3]).toMatchObject({ precision: 0, recall: 0, hits: 0 });
 
-    expect(summarizeReplayMetrics(queryMetrics, [1, 3])).toEqual({
+    const summary = summarizeReplayMetrics(queryMetrics, [1, 3]);
+    expect(summary).toMatchObject({
       queryCount: 2,
       precisionAtK: { 1: 0.5, 3: 1 / 3 },
       recallAtK: { 1: 0.25, 3: 0.5 }
     });
+    expect(summary.ndcgAtK[1]).toBe(0.5);
+    expect(summary.ndcgAtK[3]).toBeCloseTo(0.45986, 4);
+  });
+
+  it('computes graded nDCG@k from qrels relevance labels', () => {
+    const [queryMetrics] = computePrecisionRecallAtK(
+      [
+        {
+          queryId: 'q-graded',
+          expectedIds: ['a', 'b'],
+          expectedRelevance: { a: 3, b: 1 },
+          retrievedIds: ['b', 'a', 'noise']
+        }
+      ],
+      [2]
+    );
+
+    expect(queryMetrics.at[2]).toMatchObject({ precision: 1, recall: 1, hits: 2 });
+    expect(queryMetrics.at[2].ndcg).toBeCloseTo(0.70981, 4);
   });
 
   it('deduplicates retrieved ids so replay metrics cannot over-count repeated hits', () => {
@@ -48,11 +58,12 @@ describe('retrieval replay benchmark metrics', () => {
       {
         queryId: 'q-duplicate',
         at: {
-          1: { precision: 1, recall: 1, hits: 1 },
-          3: { precision: 1 / 3, recall: 1, hits: 1 }
+          1: { precision: 1, recall: 1, hits: 1, ndcg: 1 },
+          3: { precision: 1 / 3, recall: 1, hits: 1, ndcg: 1 }
         }
       }
     ]);
+    expect(queryMetrics[0].at[3].ndcg).toBe(1);
   });
 
   it('normalizes k values without losing zero-result replay rows', () => {
@@ -65,9 +76,9 @@ describe('retrieval replay benchmark metrics', () => {
       {
         queryId: 'q-empty',
         at: {
-          0: { precision: 0, recall: 0, hits: 0 },
-          1: { precision: 0, recall: 0, hits: 0 },
-          3: { precision: 0, recall: 0, hits: 0 }
+          0: { precision: 0, recall: 0, hits: 0, ndcg: 0 },
+          1: { precision: 0, recall: 0, hits: 0, ndcg: 0 },
+          3: { precision: 0, recall: 0, hits: 0, ndcg: 0 }
         }
       }
     ]);
@@ -75,7 +86,8 @@ describe('retrieval replay benchmark metrics', () => {
     expect(summarizeReplayMetrics(queryMetrics, [3.9, 1, 1, -2])).toEqual({
       queryCount: 1,
       precisionAtK: { 0: 0, 1: 0, 3: 0 },
-      recallAtK: { 0: 0, 1: 0, 3: 0 }
+      recallAtK: { 0: 0, 1: 0, 3: 0 },
+      ndcgAtK: { 0: 0, 1: 0, 3: 0 }
     });
   });
 });

--- a/tests/core/session-qrels.test.ts
+++ b/tests/core/session-qrels.test.ts
@@ -1,6 +1,14 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import * as path from 'node:path';
+import { tmpdir } from 'node:os';
+
 import { describe, expect, it } from 'vitest';
 
-import { buildSessionQrelsFixtureFromJsonl } from '../../src/core/session-qrels.js';
+import {
+  buildSessionQrelsFixtureFromJsonl,
+  collectClaudeSessionJsonlFiles,
+  summarizeSessionQrelsFixture
+} from '../../src/core/session-qrels.js';
 
 describe('session qrels fixture generation', () => {
   it('turns Claude-style user/assistant session turns into replay qrels', () => {
@@ -125,5 +133,67 @@ describe('session qrels fixture generation', () => {
       id: 'm-sensitive-1',
       content: '[redacted memory m-sensitive-1]'
     });
+  });
+
+  it('summarizes generated qrels without leaking raw prompt or memory content', () => {
+    const jsonl = [
+      JSON.stringify({
+        type: 'user',
+        sessionId: 'sensitive',
+        message: { role: 'user', content: 'SECRET customer retrieval question with enough words' }
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        sessionId: 'sensitive',
+        message: { role: 'assistant', content: 'SECRET assistant answer that should stay out of reports' }
+      })
+    ].join('\n');
+    const fixture = buildSessionQrelsFixtureFromJsonl(jsonl, {
+      name: 'private-real-session-qrels',
+      ks: [1, 3, 10],
+      sourceFileCount: 2,
+      rawContentIncluded: true
+    });
+
+    const summary = summarizeSessionQrelsFixture(fixture);
+    const serialized = JSON.stringify(summary);
+
+    expect(summary).toMatchObject({
+      name: 'private-real-session-qrels',
+      queryCount: 1,
+      memoryCount: 1,
+      sourceSessionCount: 1,
+      sourceFileCount: 2,
+      rawContentIncluded: true,
+      ks: [1, 3, 10]
+    });
+    expect(summary.perSession).toEqual([
+      {
+        sourceSessionId: 'sensitive',
+        queryCount: 1,
+        memoryCount: 1,
+        firstTurnIndex: 1,
+        lastTurnIndex: 1
+      }
+    ]);
+    expect(serialized).not.toContain('SECRET');
+  });
+
+  it('collects Claude JSONL sessions recursively while excluding subagents by default', async () => {
+    const root = path.join(tmpdir(), `session-qrels-${process.pid}-${Date.now()}`);
+    const projectDir = path.join(root, 'project-a');
+    const subagentDir = path.join(projectDir, 'subagents');
+    await mkdir(subagentDir, { recursive: true });
+    await writeFile(path.join(projectDir, 'top.jsonl'), '{}\n', 'utf8');
+    await writeFile(path.join(subagentDir, 'agent.jsonl'), '{}\n', 'utf8');
+    await writeFile(path.join(projectDir, 'notes.txt'), 'ignore', 'utf8');
+
+    await expect(collectClaudeSessionJsonlFiles(root)).resolves.toEqual([
+      path.join(projectDir, 'top.jsonl')
+    ]);
+    await expect(collectClaudeSessionJsonlFiles(root, { includeSubagents: true })).resolves.toEqual([
+      path.join(subagentDir, 'agent.jsonl'),
+      path.join(projectDir, 'top.jsonl')
+    ]);
   });
 });

--- a/tests/core/session-qrels.test.ts
+++ b/tests/core/session-qrels.test.ts
@@ -106,6 +106,57 @@ describe('session qrels fixture generation', () => {
     ]);
   });
 
+  it('adds known-answer labels and explicit no-match qrels', () => {
+    const jsonl = [
+      JSON.stringify({
+        type: 'user',
+        sessionId: 's-known',
+        message: { role: 'user', content: 'how should replay qrels record known answer fixtures' }
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        sessionId: 's-known',
+        message: { role: 'assistant', content: 'Known-answer qrels should keep the expected assistant answer tied to the expected memory id.' }
+      })
+    ].join('\n');
+
+    const fixture = buildSessionQrelsFixtureFromJsonl(jsonl, {
+      noMatchQueries: [
+        {
+          queryId: 'q-negative-empty-result',
+          query: 'unanswered moon cheese deployment question',
+          forbiddenIds: ['m-s-known-1'],
+          sourceSessionId: 's-known'
+        }
+      ]
+    });
+
+    expect(fixture.queries).toHaveLength(2);
+    expect(fixture.queries[0]).toMatchObject({
+      queryId: 'q-s-known-1',
+      expectation: 'match',
+      expectedIds: ['m-s-known-1'],
+      knownAnswer: 'Known-answer qrels should keep the expected assistant answer tied to the expected memory id.'
+    });
+    expect(fixture.queries[1]).toMatchObject({
+      queryId: 'q-negative-empty-result',
+      query: 'unanswered moon cheese deployment question',
+      expectation: 'no_match',
+      expectedIds: [],
+      expectedRelevance: {},
+      forbiddenIds: ['m-s-known-1'],
+      sourceSessionId: 's-known'
+    });
+
+    const summary = summarizeSessionQrelsFixture(fixture);
+    expect(summary).toMatchObject({
+      queryCount: 2,
+      positiveQueryCount: 1,
+      noMatchQueryCount: 1,
+      knownAnswerCount: 1
+    });
+  });
+
   it('can redact raw session text when generating shareable qrels metadata', () => {
     const jsonl = [
       JSON.stringify({

--- a/tests/core/session-qrels.test.ts
+++ b/tests/core/session-qrels.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildSessionQrelsFixtureFromJsonl } from '../../src/core/session-qrels.js';
+
+describe('session qrels fixture generation', () => {
+  it('turns Claude-style user/assistant session turns into replay qrels', () => {
+    const jsonl = [
+      JSON.stringify({
+        type: 'user',
+        sessionId: 's1',
+        message: { role: 'user', content: 'retrieval benchmark should report nDCG and precision together' },
+        timestamp: '2026-05-05T00:00:00.000Z'
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        sessionId: 's1',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'Use graded relevance qrels and report nDCG@k beside Precision@k and Recall@k.' }] },
+        timestamp: '2026-05-05T00:01:00.000Z'
+      }),
+      JSON.stringify({
+        type: 'user',
+        sessionId: 's1',
+        message: { role: 'user', content: '<command-name>/model</command-name>\n<local-command-stdout>opus</local-command-stdout>' }
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        sessionId: 's1',
+        message: { role: 'assistant', content: 'This local command result must not become a benchmark qrel.' }
+      }),
+      JSON.stringify({
+        type: 'user',
+        sessionId: 's1',
+        message: { role: 'user', content: [{ type: 'text', text: 'fast search CLI should avoid embedding startup for qrels smoke tests' }] }
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        sessionId: 's1',
+        message: { role: 'assistant', content: 'Fast search benchmark fixtures should stay lightweight and deterministic.' }
+      })
+    ].join('\n');
+
+    const fixture = buildSessionQrelsFixtureFromJsonl(jsonl, {
+      name: 'session-qrels-test',
+      ks: [1, 3]
+    });
+
+    expect(fixture.name).toBe('session-qrels-test');
+    expect(fixture.ks).toEqual([1, 3]);
+    expect(fixture.queries).toHaveLength(2);
+    expect(fixture.memories).toHaveLength(2);
+    expect(fixture.queries[0]).toMatchObject({
+      queryId: 'q-s1-1',
+      query: 'retrieval benchmark should report nDCG and precision together',
+      expectedIds: ['m-s1-1'],
+      expectedRelevance: { 'm-s1-1': 2 }
+    });
+    expect(fixture.memories[0]).toMatchObject({
+      id: 'm-s1-1',
+      content: 'Use graded relevance qrels and report nDCG@k beside Precision@k and Recall@k.',
+      sourceSessionId: 's1'
+    });
+    expect(fixture.queries.map((query) => query.query)).not.toContain('opus');
+  });
+
+  it('pairs pending prompts independently per session id', () => {
+    const jsonl = [
+      JSON.stringify({
+        type: 'user',
+        sessionId: 's1',
+        message: { role: 'user', content: 'session one asks about retrieval replay metrics' }
+      }),
+      JSON.stringify({
+        type: 'user',
+        sessionId: 's2',
+        message: { role: 'user', content: 'session two asks about qrels generation safety' }
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        sessionId: 's1',
+        message: { role: 'assistant', content: 'Session one answer explains nDCG replay metrics.' }
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        sessionId: 's2',
+        message: { role: 'assistant', content: 'Session two answer explains qrels generation safety.' }
+      })
+    ].join('\n');
+
+    const fixture = buildSessionQrelsFixtureFromJsonl(jsonl);
+
+    expect(fixture.queries.map((query) => [query.queryId, query.query])).toEqual([
+      ['q-s1-1', 'session one asks about retrieval replay metrics'],
+      ['q-s2-1', 'session two asks about qrels generation safety']
+    ]);
+    expect(fixture.memories.map((memory) => [memory.id, memory.content])).toEqual([
+      ['m-s1-1', 'Session one answer explains nDCG replay metrics.'],
+      ['m-s2-1', 'Session two answer explains qrels generation safety.']
+    ]);
+  });
+
+  it('can redact raw session text when generating shareable qrels metadata', () => {
+    const jsonl = [
+      JSON.stringify({
+        type: 'user',
+        sessionId: 'sensitive',
+        message: { role: 'user', content: 'SECRET customer project prompt should not leak' }
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        sessionId: 'sensitive',
+        message: { role: 'assistant', content: 'SECRET implementation answer should not leak' }
+      })
+    ].join('\n');
+
+    const fixture = buildSessionQrelsFixtureFromJsonl(jsonl, { redactContent: true });
+    const serialized = JSON.stringify(fixture);
+
+    expect(serialized).not.toContain('SECRET');
+    expect(fixture.queries[0]).toMatchObject({
+      queryId: 'q-sensitive-1',
+      query: '[redacted query q-sensitive-1]',
+      expectedIds: ['m-sensitive-1']
+    });
+    expect(fixture.memories[0]).toMatchObject({
+      id: 'm-sensitive-1',
+      content: '[redacted memory m-sensitive-1]'
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Switch replay retrieval benchmark from token-overlap scoring to the real Retriever + RetrievalOrchestrator pipeline.
- Add deterministic in-memory replay runner/report fields for Hit@k, MRR, failed queries, candidate/retrieved IDs, confidence, and fallback trace.
- Extend qrels with known-answer and negative/no-match expectations, including forbidden IDs and separate no-match accuracy.
- Add CLI support for generating no-match qrels and expand the anonymized replay fixture.

## Verification
- [x] `npm run typecheck`
- [x] `npm test -- --run` — 54 files / 223 tests passed
- [x] `npm run build`
- [x] `npm run benchmark:replay -- --fixture benchmarks/replay/anonymized-real-sessions.json --format json --no-per-query`
  - `queryCount=4`, `positiveQueryCount=3`, `noMatchQueryCount=1`, `noMatchAccuracy=1`, `failedQueryCount=0`
- [x] `npm run benchmark:qrels -- ... --redact-content --no-match-query ...`
- [x] `graphify update .`
- [x] `git diff --check`

## Notes
- `npm run lint` currently fails because this repository does not have an `eslint` binary/dependency available: `sh: eslint: command not found`.
