### PR TITLE
feat: add Codex and Hermes memory integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 dist/
 .claude-memory/
+memory/
 .history/
 test_access.js
 .omc/

--- a/README.md
+++ b/README.md
@@ -416,7 +416,17 @@ claude-memory-layer mcp install --config-path /path/to/claude_desktop_config.jso
 claude-memory-layer mcp install --server-name claude-memory-layer --command claude-memory-layer-mcp
 ```
 
-설정 후 Claude Desktop을 재시작하면 MCP 서버가 로드됩니다. 로컬 checkout에서 서버만 바로 테스트하려면 `npm run build` 후 다음처럼 직접 실행할 수도 있습니다:
+설정 후 Claude Desktop을 재시작하면 MCP 서버가 로드됩니다. Codex/Hermes처럼 MCP client가 있는 다른 agent에는 로컬 checkout의 built server를 직접 등록할 수 있습니다:
+
+```bash
+# Codex
+codex mcp add claude-memory-layer -- node /path/to/claude-memory-layer/dist/mcp/index.js
+
+# Hermes
+hermes mcp add claude-memory-layer --command node --args /path/to/claude-memory-layer/dist/mcp/index.js
+```
+
+로컬 checkout에서 서버만 바로 테스트하려면 `npm run build` 후 다음처럼 직접 실행할 수도 있습니다:
 
 ```bash
 node dist/mcp/index.js
@@ -426,10 +436,10 @@ node dist/mcp/index.js
 
 | 도구 | 설명 |
 |------|------|
-| `mem-search` | 메모리 검색 |
-| `mem-timeline` | 타임라인 조회 |
-| `mem-details` | 상세 정보 조회 |
-| `mem-stats` | 통계 조회 |
+| `mem-search` | 메모리 검색 (`projectPath`를 주면 프로젝트별 저장소 검색) |
+| `mem-timeline` | 타임라인 조회 (`projectPath` 지원) |
+| `mem-details` | 상세 정보 조회 (`projectPath` 지원) |
+| `mem-stats` | 통계 조회 (`projectPath` 지원) |
 
 ## Web Viewer
 
@@ -484,6 +494,27 @@ Imported responses: 186
 Skipped duplicates: 0
 Embeddings processed: 342
 ```
+
+### Codex 세션 임포트
+
+Codex CLI 기록(`~/.codex/sessions`)은 기본적으로 read-only validate/replay로 먼저 확인하고, 명시적 import 명령으로만 메모리에 저장합니다:
+
+```bash
+# 읽기 전용 검증/리포트
+npx claude-memory-layer codex validate --project /path/to/project --format markdown
+
+# 현재 프로젝트 Codex 세션을 프로젝트별 메모리로 import
+cd /path/to/project
+npx claude-memory-layer codex import
+
+# 특정 세션만 import
+npx claude-memory-layer codex import --project /path/to/project --session /path/to/session.jsonl
+
+# 모든 Codex 세션 import (전역 저장소 사용; 필요할 때만)
+npx claude-memory-layer codex import --all --verbose
+```
+
+옵션: `--sessions-dir`, `--limit`, `--force`, `--no-process-embeddings`.
 
 ### 중복 처리
 

--- a/README.md
+++ b/README.md
@@ -516,6 +516,29 @@ npx claude-memory-layer codex import --all --verbose
 
 옵션: `--sessions-dir`, `--limit`, `--force`, `--no-process-embeddings`.
 
+### Hermes 세션 임포트
+
+Hermes Agent 기록(`~/.hermes/state.db`)도 원본 DB를 read-only validate/replay로 먼저 확인하고, 명시적 import 명령으로만 프로젝트별 메모리에 저장합니다. 기본 전략은 live sync가 아니라 **SessionDB → CML explicit derived import**입니다:
+
+```bash
+# 읽기 전용 검증/리포트
+npx claude-memory-layer hermes validate --project /path/to/project --format markdown
+
+# 현재 프로젝트 Hermes 세션을 프로젝트별 메모리로 import
+cd /path/to/project
+npx claude-memory-layer hermes import
+
+# 특정 Hermes session id만 import
+npx claude-memory-layer hermes import --project /path/to/project --session 20260505_010203_abcd1234
+
+# 모든 Hermes 세션 import (전역 저장소 사용; 필요할 때만)
+npx claude-memory-layer hermes import --all --verbose
+```
+
+옵션: `--state-db`, `--limit`, `--force`, `--no-process-embeddings`.
+
+Hermes import는 user/assistant turn만 저장하고 tool/system 메시지는 건너뜁니다. 검증 리포트에는 aggregate count만 포함되며 transcript 본문은 포함하지 않습니다.
+
 ### 중복 처리
 
 임포트는 콘텐츠 해시 기반으로 중복을 자동 감지합니다. 여러 번 실행해도 같은 내용이 중복 저장되지 않습니다.

--- a/docs/HERMES_MEMORY_INGESTION_ANALYSIS.md
+++ b/docs/HERMES_MEMORY_INGESTION_ANALYSIS.md
@@ -1,0 +1,437 @@
+# Hermes Agent memory/session 구조 분석 및 claude-memory-layer 연동 제안
+
+작성 시각: 2026-05-05 23:05 KST
+대상 저장소: `/Users/namsangboy/workspace/claude-memory-layer`
+참조 Hermes Agent checkout: `/Users/namsangboy/.hermes/hermes-agent` (`7530ce04e`, upstream HEAD와 동일)
+
+## 결론 요약
+
+**Hermes용 ingestion은 만들 가치가 있지만, 지금 바로 `live ingestion`부터 넣는 것은 비추천이다.**
+
+권장 순서는 다음과 같다.
+
+1. **Hermes SessionDB explicit import/validate adapter**를 먼저 만든다. *(1차 구현 완료: `claude-memory-layer hermes validate|replay|import`)*
+   - Hermes의 원본 transcript source-of-truth는 `~/.hermes/state.db`로 둔다.
+   - claude-memory-layer는 선택된 Hermes 세션을 project-scoped memory store로 복제/파생한다.
+   - 현재 CLI는 `--project`, `--session`, `--all`, `--state-db`, `--limit`, `--force`를 제공한다.
+2. 그 다음 **“최근 맥락/주제 지도 + wiki-link식 상세 ref 읽기” MCP read-only tool**을 만든다.
+   - 이 기능은 Hermes의 `session_search`와 겹치지만 완전 중복은 아니다.
+   - 특히 Claude Code/Codex/Hermes가 같은 프로젝트 memory backend를 공유하려면 의미가 있다.
+3. 마지막으로 필요성이 검증되면 **Hermes external memory provider plugin 방식의 opt-in live sync**를 추가한다.
+   - 기본은 user/assistant turn만 저장한다.
+   - tool output/file content/Bash output 저장은 privacy filter 통과 + explicit opt-in일 때만 허용한다.
+
+즉, **“import + context tool 먼저, live ingestion은 나중”**이 가장 안전하고 실익이 크다.
+
+---
+
+## 1. Hermes Agent에 이미 있는 기능
+
+### 1.1 Built-in curated memory
+
+Hermes 문서와 코드 기준으로, 기본 persistent memory는 두 파일 중심이다.
+
+- `MEMORY.md`: agent personal notes, 환경/프로젝트/교훈 등
+- `USER.md`: 사용자 프로필/선호
+
+특징:
+
+- `~/.hermes/memories/` 아래 저장
+- 세션 시작 시 system prompt에 frozen snapshot으로 주입
+- char limit이 작다: memory 약 2,200 chars, user 약 1,375 chars
+- 세션 중 `memory` tool로 add/replace/remove 가능하지만, system prompt 반영은 다음 세션부터
+
+따라서 이 레이어는 “항상 기억해야 하는 소수의 durable fact” 용도이지, 긴 대화/프로젝트별 세부 맥락 저장소가 아니다.
+
+### 1.2 SessionDB + session_search
+
+Hermes는 모든 CLI/gateway 대화를 SQLite에 저장한다.
+
+확인한 local DB:
+
+```text
+~/.hermes/state.db
+sessions: 656
+messages: 14108
+source counts:
+  discord: 653
+  cli: 3
+```
+
+스키마 핵심:
+
+- `sessions`: `id`, `source`, `user_id`, `model`, `system_prompt`, `parent_session_id`, `started_at`, `ended_at`, `message_count`, `title` 등
+- `messages`: `id`, `session_id`, `role`, `content`, `tool_calls`, `tool_name`, `timestamp`, reasoning/codex fields 등
+- `messages_fts`, `messages_fts_trigram`: FTS5 검색용
+
+관련 코드:
+
+- `hermes_state.py`
+  - `append_message()`로 메시지 저장
+  - `search_messages()`로 FTS5/trigram 검색
+  - `list_sessions_rich()`로 recent sessions/preview/last_active 제공
+  - `get_messages_as_conversation()`으로 세션 복원
+- `tools/session_search_tool.py`
+  - query 없으면 최근 세션 metadata 반환
+  - query 있으면 FTS5 검색 → 세션별 transcript 로드 → auxiliary LLM으로 요약
+  - 현재 세션 lineage는 제외
+- `website/docs/developer-guide/session-storage.md`
+  - Hermes session store 구조 문서
+
+즉, 사용자가 말한 “특정 대화 세션에서 어떤 주제에 대해 말했는지, 최근 맥락 중심으로 알려주기”의 일부는 이미 Hermes의 `session_search`에 있다.
+
+다만 Hermes 기본 `session_search`는 다음 한계가 있다.
+
+- Hermes 내부 transcript만 대상으로 한다.
+- Claude Code/Codex transcript와 같은 project memory backend로 합쳐지지 않는다.
+- 반환값은 검색 결과 세션 요약 중심이며, 안정적인 `memory://...` ref를 따라 더 깊게 탐색하는 wiki-link UX는 없다.
+- project path scope가 Hermes SessionDB schema에 명시적으로 없다. 현재 `sessions` 테이블에 cwd/project_path 컬럼이 없다.
+- derived topic map/decision/task/code-context layer는 없다. FTS match + LLM summary에 가깝다.
+
+### 1.3 External memory provider plugin 구조
+
+Hermes는 built-in memory 외에 외부 memory provider를 하나 활성화할 수 있다.
+
+`hermes memory status` 결과:
+
+```text
+Built-in: always active
+Provider: (none — built-in only)
+Installed plugins: byterover, hindsight, holographic, honcho, mem0, openviking, retaindb, supermemory
+```
+
+관련 구조:
+
+- `agent/memory_provider.py`: provider interface
+- `agent/memory_manager.py`: provider lifecycle/orchestration
+- `plugins/memory/*`: Honcho, Hindsight, OpenViking 등 provider 구현
+- `run_agent.py`
+  - turn 시작: `memory_manager.on_turn_start()`
+  - LLM 호출 전: `memory_manager.prefetch_all(query)` 결과를 current user message에 ephemeral context로 주입
+  - turn 종료: `memory_manager.sync_all(original_user_message, final_response, session_id=...)`
+  - session 종료: `memory_manager.on_session_end(messages)`
+
+중요한 점:
+
+- Hermes는 이미 “외부 memory backend로 매 턴 sync/prefetch”할 수 있는 확장 포인트를 제공한다.
+- 그러므로 live ingestion을 하려면 Hermes core hook을 새로 뚫기보다 **memory provider plugin**으로 붙이는 것이 맞다.
+- 하지만 현재 사용자 환경은 external provider가 꺼져 있고 built-in only다.
+
+---
+
+## 2. claude-memory-layer 현재 구조와 source-of-truth
+
+현재 claude-memory-layer는 다음 구조다.
+
+### 2.1 Source-of-truth
+
+`src/core/event-store.ts` 기준:
+
+- L0 `events` table이 append-only source-of-truth
+- 주요 event type:
+  - `user_prompt`
+  - `agent_response`
+  - `session_summary`
+  - `tool_observation`
+- `sessions` table은 session metadata
+- `event_dedup`은 idempotency
+- `embedding_outbox`, `vector_outbox`, `memory_levels`, `entries/entities/edges` 등은 derived/projection layer
+
+즉 CML의 원본은 “project-scoped memory events”이고, vector/summary/fact/entity/edge는 재생성 가능한 파생물이다.
+
+### 2.2 Project scoping
+
+`src/services/memory-service-registry.ts` 기준:
+
+- default store: `~/.claude-code/memory`
+- project store: `getProjectStoragePath(projectPath)`
+- `getMemoryServiceForProject(projectPath)`는 project hash별 service를 cache한다.
+- 최근 커밋에서 MCP tools가 `projectPath`를 받아 project-specific service를 resolve하도록 변경됐다.
+
+현재 등록된 MCP tools:
+
+- `mem-search`
+- `mem-timeline`
+- `mem-details`
+- `mem-stats`
+
+`projectPath`가 있으면 project store를 조회하고, 없으면 default store를 조회한다.
+
+### 2.3 Claude/Codex ingestion
+
+현재 상태:
+
+- Claude Code는 `.claude-plugin/hooks.json` 기반 hook ingestion을 유지한다.
+- Codex는 explicit CLI import가 추가됐다.
+- Codex/Hermes는 CML MCP server를 read-only query tool로 사용할 수 있다.
+
+검증된 커밋:
+
+```text
+4bf0915fb1aa09e60bcca482b5ae7650b10ea1eb feat: add project-aware MCP and Codex import CLI
+```
+
+검증 결과:
+
+```text
+npm run typecheck: passed
+npm run build: passed
+npm test -- --run: 56 files, 229 tests passed
+hermes mcp test claude-memory-layer: connected, tools discovered 4
+```
+
+현재 generated local store:
+
+```text
+/Users/namsangboy/workspace/claude-memory-layer/memory/  # untracked
+```
+
+---
+
+## 3. Hermes built-in 기능과 CML 추가 기능의 gap
+
+| 요구/기능 | Hermes built-in | CML 현재 | CML에 추가할 가치 |
+|---|---:|---:|---:|
+| 모든 Hermes 대화 원본 저장 | 있음: `~/.hermes/state.db` | 없음 | 낮음. 원본은 Hermes DB가 이미 담당 |
+| 최근 세션 목록/preview | 있음: `session_search()` query 없음 | 부분적 | 낮음~중간 |
+| 키워드로 과거 Hermes 대화 검색 | 있음: FTS5 + 요약 | MCP `mem-search`, 단 Hermes ingest 필요 | 중간 |
+| Claude/Codex/Hermes 공통 project memory | 없음 | 있음: projectPath 기반 | 높음 |
+| project-specific long-term context | Hermes schema에 project_path 없음 | 있음 | 높음 |
+| 세션별 topic map/최근 맥락 | 일부: search summary | 아직 약함 | 높음 |
+| wiki-link식 상세 ref follow-up | 없음 | `mem-details`, `mem-timeline` 기반으로 확장 가능 | 높음 |
+| 자동 turn prefetch/context injection | external provider로 가능 | Hermes MCP 수동 호출만 가능 | 중간~높음, opt-in |
+| live turn sync | external provider로 가능 | Hermes adapter 없음 | 중간. 하지만 privacy risk 큼 |
+
+핵심은 이렇다.
+
+- **Hermes-only memory**라면 이미 built-in `session_search`와 external providers가 꽤 강하다.
+- **Claude Code/Codex/Hermes를 같은 프로젝트 기억층으로 묶는 것**은 Hermes built-in만으로는 해결되지 않는다.
+- 따라서 CML이 집중해야 할 차별점은 “Hermes transcript 원본 저장”이 아니라 **cross-agent project memory + topic/ref navigation**이다.
+
+---
+
+## 4. Live ingestion을 바로 만들 때의 리스크
+
+### 4.1 중복 source-of-truth
+
+Hermes는 이미 `~/.hermes/state.db`에 raw transcript를 저장한다.
+CML live ingestion이 매 turn 같은 내용을 저장하면:
+
+- Hermes DB와 CML DB가 둘 다 원본처럼 보인다.
+- 실패/중단/수정/압축 세션에서 불일치가 생긴다.
+- 재import/replay/dedupe 기준이 복잡해진다.
+
+권장 원칙:
+
+- Hermes raw transcript source-of-truth = `~/.hermes/state.db`
+- CML source-of-truth = project-scoped derived memory events
+- Hermes → CML은 explicit import 또는 opt-in mirror로 취급
+
+### 4.2 Privacy
+
+Hermes 세션에는 tool output, file content, command output, reasoning/codex fields, platform context가 포함될 수 있다.
+CML의 기존 privacy 설정은 `password`, `secret`, `api_key`, `token`, `bearer` 등의 exclude pattern이 있지만, live ingestion에는 부족할 수 있다.
+
+특히 위험한 항목:
+
+- Bash/terminal output
+- file read/search 결과
+- config/log 파일 내용
+- OAuth/API token이 포함된 stdout/stderr
+- Discord/Telegram group context
+- reasoning/codex internal fields
+
+따라서 live ingestion은 다음이 선행되어야 한다.
+
+- credential/secret redaction 강화
+- tool output allowlist/denylist
+- max chars/lines 제한
+- platform/source filter
+- group chat privacy policy
+- import dry-run report
+
+### 4.3 Project scoping 문제
+
+Hermes `sessions` schema에는 project path/cwd 컬럼이 없다.
+따라서 “이 Hermes 세션이 어떤 프로젝트에 속하는가”를 자동 판별하기 어렵다.
+
+가능한 해법:
+
+1. import 시 사용자가 `--project /path --session-id <id>`로 명시한다.
+2. Hermes session title/thread/source message에 포함된 경로를 heuristic으로 추출한다.
+3. Hermes upstream에 session metadata로 `workdir/project_path` 저장을 제안한다.
+4. CML Hermes provider에서 turn sync 시 현재 `workdir`를 metadata로 넘긴다.
+
+현 단계에서는 1번이 가장 안전하다.
+
+---
+
+## 5. 권장 구현 로드맵
+
+### Phase 1 — Hermes explicit import/validate adapter
+
+목표: live ingestion 없이 안전하게 Hermes 과거 세션을 CML project memory로 가져오기.
+
+신규 CLI:
+
+```bash
+claude-memory-layer hermes validate --project /path/to/project --format markdown
+claude-memory-layer hermes import --project /path/to/project --session <hermes-session-id> --no-process-embeddings
+claude-memory-layer hermes import --all --verbose
+```
+
+현재 1차 구현 범위:
+
+- read-only validation/replay report (`validate`, `replay`)
+- explicit mutation path (`import`)
+- project/current-cwd scoped import by default
+- `--all` without `--project` only when intentionally using global memory
+- user/assistant turns only; tool/system messages skipped
+- built-in sensitive pattern redaction before memory storage
+
+추후 확장 후보: `--source`, `--since`, stronger project metadata matching.
+
+구현 포인트:
+
+- source: `~/.hermes/state.db` 직접 read-only open 또는 `hermes sessions export` JSONL 사용
+- dedupe key: `hermes:<session_id>:<message_id>:<role>`
+- event mapping:
+  - user → `user_prompt`
+  - assistant → `agent_response`
+  - tool → `tool_observation` only if allowlisted/redacted
+  - session end or compression summary → `session_summary` if available/derived
+- metadata:
+  - `sourceAgent: 'hermes'`
+  - `hermes.sessionId`
+  - `hermes.messageId`
+  - `hermes.source` (`cli`, `discord`, etc.)
+  - `scope.project.path/hash`
+- default: tool output off or aggressively truncated
+- `--dry-run` report 필수
+
+TDD:
+
+- fixture SQLite DB 생성
+- project-scoped import 검증
+- duplicate import idempotency 검증
+- privacy redaction 검증
+- source/project/session filters 검증
+
+### Phase 2 — topic map + recent context + wiki-link MCP tools
+
+목표: CML이 “검색 결과 목록”에서 “현재 작업 맥락을 이어주는 context navigator”로 발전.
+
+신규 MCP tools 후보:
+
+1. `mem-context-pack`
+   - input: `projectPath`, `query?`, `sessionId?`, `recentHours?`, `topK?`
+   - output:
+     - 최근 맥락 요약
+     - 주요 topic/decision/open task/code context
+     - 근거 event/session refs
+     - 더 자세히 볼 수 있는 refs
+
+2. `mem-session-topics`
+   - input: `projectPath`, `sessionId`
+   - output:
+     - chronological topic segments
+     - 각 segment의 핵심 질문/결론/파일/툴
+     - `memory://project/<hash>/session/<id>/segment/<n>` refs
+
+3. `mem-read-ref`
+   - input: `ref`
+   - output:
+     - 해당 event/timeline/segment/session detail
+     - 원문은 필요한 만큼만, secrets redacted
+
+예상 UX:
+
+```text
+최근 claude-memory-layer 맥락:
+1. Codex/Hermes MCP 등록과 projectPath 지원을 구현/검증했다.
+   refs: memory://project/.../session/.../segment/1
+2. Codex import CLI를 TDD로 추가하고 full test 통과했다.
+   refs: memory://project/.../session/.../segment/2
+3. 남은 이슈: eslint missing, generated memory/ untracked, Hermes ingestion 설계.
+   refs: memory://project/.../session/.../segment/3
+
+더 자세히 필요하면 mem-read-ref로 ref를 열어라.
+```
+
+이 기능은 Hermes `session_search`와 다르다.
+
+- Hermes `session_search`: Hermes transcript 대상, query-driven summary
+- CML context-pack: project memory 전체 대상, Claude/Codex/Hermes 통합, topic/ref 기반 drill-down
+
+### Phase 3 — optional Hermes memory provider plugin
+
+목표: Hermes에서 CML context를 자동 prefetch/inject하고, 완료 turn을 CML에 opt-in sync.
+
+권장 형태:
+
+- Hermes external memory provider plugin: `plugins/memory/claude_memory_layer`
+- 설정:
+
+```yaml
+memory:
+  provider: claude_memory_layer
+  claude_memory_layer:
+    mode: tools-only | context | hybrid
+    writeFrequency: session | turn | off
+    projectStrategy: explicit | cwd | global
+    toolOutput: off | allowlist | redacted
+```
+
+Provider responsibilities:
+
+- `prefetch(query)`: CML `mem-context-pack` 호출 후 current user message에 ephemeral context 주입
+- `sync_turn(user, assistant, session_id)`: user/assistant만 기본 저장
+- `on_session_end(messages)`: session summary/derived topic update
+- provider-specific tools: `cml_search`, `cml_context`, `cml_read_ref`, `cml_import_session`
+
+주의:
+
+- 이 provider를 켜면 Hermes가 자동으로 CML을 호출하므로, MCP tool 수동 호출과 중복 context가 생길 수 있다.
+- 따라서 기본값은 `tools-only` 또는 `writeFrequency: off`로 시작하는 것이 안전하다.
+
+---
+
+## 6. 최종 권장안
+
+### 지금 만들 것
+
+1. **Hermes explicit importer/validator**
+   - live가 아닌 batch/dry-run 기반
+   - Hermes DB를 raw source-of-truth로 존중
+   - project/session/source filter 명시
+
+2. **CML context navigator MCP tools**
+   - `mem-context-pack`
+   - `mem-session-topics`
+   - `mem-read-ref`
+
+이 두 가지는 사용자가 말한 “최근 맥락 중심 context + wiki link처럼 더 깊은 memory file/detail 읽기” 니즈에 직접 대응한다.
+
+### 지금 만들지 말 것
+
+- Hermes raw transcript를 매 turn 무조건 CML에 live sync하는 기능
+- tool output/file content를 기본 저장하는 기능
+- Hermes built-in `session_search`를 대체하려는 기능
+
+### 나중에 만들 것
+
+- Hermes external memory provider plugin
+- Hermes upstream session metadata 개선 PR 또는 local patch: `project_path/workdir` 저장
+- CML privacy filter 강화 후 tool observation ingestion 확대
+
+---
+
+## 7. 판단
+
+**Hermes 자체만 보면 이미 memory/session_search가 있으므로, Hermes용 live ingestion은 “굳이 지금 필요 없음”에 가깝다.**
+
+하지만 **Claude Code, Codex, Hermes를 같은 프로젝트별 memory backend로 묶고**, 그 위에 **recent context/topic map/ref drill-down**을 제공하는 기능은 Hermes에 이미 있는 기능이 아니므로 만들 가치가 높다.
+
+따라서 제품 방향은 다음 한 문장으로 정리된다.
+
+> claude-memory-layer는 Hermes의 SessionDB를 대체하지 말고, Hermes/Claude/Codex transcript에서 추출한 project-scoped durable context graph와 navigable context pack을 제공하는 MCP memory layer가 되어야 한다.

--- a/docs/PRODUCT_VALIDATION_MATRIX.md
+++ b/docs/PRODUCT_VALIDATION_MATRIX.md
@@ -12,8 +12,11 @@ This document mirrors the tested matrix in `src/core/product-validation-matrix.t
 | Codex | Codex adapter scan | ready | Recursively scan `~/.codex/sessions`, match by `session_meta.payload.cwd`, and count malformed/unsupported records. |
 | Codex | Codex adapter import | covered | Existing explicit import path remains mutation-only; `codex import` now exposes project/session/all imports while validation/replay stay read-only. |
 | Codex | Codex adapter replay | ready | Normalize real Codex `response_item` message records and aggregate replay counts without transcript content. |
-| CLI/API | CLI / API / reporting | ready | Provide `claude-memory-layer codex validate` / `codex replay` with JSON/Markdown reports. |
-| Safety | Safety / dry-run | ready | Default Codex validation is read-only, avoids Claude settings/memory mutation, and can anonymize project labels. |
+| Hermes | Hermes adapter scan | ready | Read Hermes `~/.hermes/state.db` in read-only mode, match project context, and aggregate unsupported/empty/truncated counts without transcript content. |
+| Hermes | Hermes adapter import | covered | `hermes import` exposes project/session/all imports while preserving SessionDB as raw source-of-truth and storing only redacted user/assistant turns. |
+| Hermes | Hermes adapter replay | ready | Normalize Hermes SessionDB rows into aggregate replay reports without transcript content or secrets. |
+| CLI/API | CLI / API / reporting | ready | Provide `claude-memory-layer codex validate` / `codex replay` and `hermes validate` / `hermes replay` with JSON/Markdown reports. |
+| Safety | Safety / dry-run | ready | Default Codex/Hermes validation is read-only, avoids Claude settings/memory mutation, and can exclude transcript content from reports. |
 
 ## Codex validation requirements
 
@@ -28,6 +31,19 @@ This document mirrors the tested matrix in `src/core/product-validation-matrix.t
 - `--anonymize-projects`: replace raw cwd labels with stable project hashes for shareable reports.
 
 Reports include only aggregate counts: sessions scanned/matched, records read, messages/turns normalized, user/assistant counts, malformed lines, skipped/unsupported records, empty assistant messages, truncated messages, missing cwd, warnings, top projects, and source paths. Transcript text is never included in validation reports.
+
+## Hermes validation requirements
+
+`claude-memory-layer hermes validate` and `claude-memory-layer hermes replay` are intentionally read-only. They support:
+
+- `--project <path>`: match sessions whose Hermes session context/title includes the project path.
+- `--state-db <path>`: override the default `~/.hermes/state.db` source for tests, profiles, or replay fixtures.
+- `--limit <number>`: cap the number of matching sessions scanned.
+- `--format json|markdown`: choose machine-readable or human-readable aggregate output.
+- `--output <path>`: save the aggregate report to disk.
+- `--dry-run`: explicit safety marker; mutation is not supported by validation/replay.
+
+Reports include only aggregate counts: sessions scanned/matched, messages read/normalized, turns normalized, user/assistant counts, skipped/unsupported messages, empty assistant messages, truncated messages, missing project context, warnings, top sources, and source paths. Transcript text is never included in validation reports.
 
 ## Codex import requirements
 

--- a/docs/PRODUCT_VALIDATION_MATRIX.md
+++ b/docs/PRODUCT_VALIDATION_MATRIX.md
@@ -10,7 +10,7 @@ This document mirrors the tested matrix in `src/core/product-validation-matrix.t
 | Claude | Claude adapter search | covered | Search memory by project/session with plain and disclosure output paths. |
 | Claude | Claude adapter disclosure | covered | Exercise search → expand → source/citation disclosure flow. |
 | Codex | Codex adapter scan | ready | Recursively scan `~/.codex/sessions`, match by `session_meta.payload.cwd`, and count malformed/unsupported records. |
-| Codex | Codex adapter import | partial | Existing explicit import path remains mutation-only; validation/replay does not import by default. |
+| Codex | Codex adapter import | covered | Existing explicit import path remains mutation-only; `codex import` now exposes project/session/all imports while validation/replay stay read-only. |
 | Codex | Codex adapter replay | ready | Normalize real Codex `response_item` message records and aggregate replay counts without transcript content. |
 | CLI/API | CLI / API / reporting | ready | Provide `claude-memory-layer codex validate` / `codex replay` with JSON/Markdown reports. |
 | Safety | Safety / dry-run | ready | Default Codex validation is read-only, avoids Claude settings/memory mutation, and can anonymize project labels. |
@@ -29,10 +29,22 @@ This document mirrors the tested matrix in `src/core/product-validation-matrix.t
 
 Reports include only aggregate counts: sessions scanned/matched, records read, messages/turns normalized, user/assistant counts, malformed lines, skipped/unsupported records, empty assistant messages, truncated messages, missing cwd, warnings, top projects, and source paths. Transcript text is never included in validation reports.
 
+## Codex import requirements
+
+`claude-memory-layer codex import` is the explicit mutation path. It supports:
+
+- `--project <path>`: import matching Codex sessions into the project-scoped memory store.
+- `--session <file>`: import one Codex JSONL session into the selected project scope.
+- `--all`: import all Codex sessions; without `--project`, this intentionally uses global memory and prints a warning.
+- `--sessions-dir <path>`: override the default `~/.codex/sessions` root for tests, replays, or alternate Codex profiles.
+- `--limit <number>`, `--force`, `--verbose`, and `--no-process-embeddings` for bounded/repeatable operational runs.
+
 ## Evidence
 
 - `tests/core/product-validation-matrix.test.ts` checks coverage, summary, and Markdown rendering of the matrix.
 - `tests/core/codex-session-history-importer-validation.test.ts` covers Codex dry-run scan/replay, cwd project matching, malformed lines, unsupported/tool-ish records, empty assistant messages, large/truncated content, missing cwd, all-session summary, and transcript exclusion.
 - `tests/apps/codex-validation-output.test.ts` covers JSON and Markdown reporting helpers.
+- `tests/apps/codex-import-runner.test.ts` covers explicit Codex import routing for project, session, and global all-session modes.
 - `src/services/codex-session-history-importer.ts` implements read-only scan/normalize/validate helpers in addition to existing explicit Codex import APIs.
+- `src/apps/cli/codex-import-runner.ts` implements the safe import command runner.
 - `src/apps/cli/index.ts` exposes the user-facing commands.

--- a/src/apps/cli/codex-import-runner.ts
+++ b/src/apps/cli/codex-import-runner.ts
@@ -1,0 +1,119 @@
+import {
+  createCodexSessionHistoryImporter,
+  type CodexSessionHistoryImporter,
+  type CodexSessionHistoryImporterOptions
+} from '../../services/codex-session-history-importer.js';
+import {
+  getDefaultMemoryService,
+  getMemoryServiceForProject,
+  type MemoryService
+} from '../../services/memory-service.js';
+import type { ImportOptions, ImportResult, ProgressEvent } from '../../services/session-history-importer.js';
+
+export interface CodexImportCommandOptions {
+  project?: string;
+  session?: string;
+  all?: boolean;
+  limit?: string;
+  force?: boolean;
+  verbose?: boolean;
+  sessionsDir?: string;
+  processEmbeddings?: boolean;
+}
+
+export interface CodexImportOutcome {
+  mode: 'project' | 'session' | 'all';
+  storageScope: 'project' | 'global';
+  projectPath?: string;
+  result: ImportResult;
+  embedCount: number;
+}
+
+export interface CodexImportRunnerDeps {
+  cwd: () => string;
+  getDefaultMemoryService: () => MemoryService;
+  getMemoryServiceForProject: (projectPath: string) => MemoryService;
+  createImporter: (
+    memoryService: MemoryService,
+    options?: CodexSessionHistoryImporterOptions
+  ) => Pick<CodexSessionHistoryImporter, 'importProject' | 'importAll' | 'importSessionFile'>;
+  onProgress?: (event: ProgressEvent) => void;
+}
+
+const realDeps: CodexImportRunnerDeps = {
+  cwd: () => process.cwd(),
+  getDefaultMemoryService,
+  getMemoryServiceForProject,
+  createImporter: createCodexSessionHistoryImporter
+};
+
+function parsePositiveInteger(value: string | undefined, name: string): number | undefined {
+  if (value === undefined) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Invalid --${name}: expected a positive integer`);
+  }
+  return parsed;
+}
+
+function shouldUseGlobalStorage(options: CodexImportCommandOptions): boolean {
+  return options.all === true && !options.project && !options.session;
+}
+
+export async function runCodexImportOnce(
+  options: CodexImportCommandOptions,
+  deps: CodexImportRunnerDeps = realDeps
+): Promise<CodexImportOutcome> {
+  const targetProjectPath = options.project || deps.cwd();
+  const useGlobalStorage = shouldUseGlobalStorage(options);
+  const memoryService = useGlobalStorage
+    ? deps.getDefaultMemoryService()
+    : deps.getMemoryServiceForProject(targetProjectPath);
+  const importer = deps.createImporter(memoryService, { sessionsDir: options.sessionsDir });
+
+  await memoryService.initialize();
+  await memoryService.ensureEmbeddingModelForImport({ autoMigrate: true });
+
+  const importOptions: ImportOptions = {
+    limit: parsePositiveInteger(options.limit, 'limit'),
+    force: options.force,
+    verbose: options.verbose,
+    onProgress: deps.onProgress
+  };
+
+  let mode: CodexImportOutcome['mode'];
+  let result: ImportResult;
+
+  try {
+    if (options.session) {
+      mode = 'session';
+      result = await importer.importSessionFile(options.session, {
+        ...importOptions,
+        projectPath: targetProjectPath
+      });
+    } else if (options.all) {
+      mode = 'all';
+      result = await importer.importAll(importOptions);
+    } else {
+      mode = 'project';
+      result = await importer.importProject(targetProjectPath, {
+        ...importOptions,
+        projectPath: targetProjectPath
+      });
+    }
+
+    const embedCount = options.processEmbeddings === false
+      ? 0
+      : await memoryService.processPendingEmbeddings();
+
+    return {
+      mode,
+      storageScope: useGlobalStorage ? 'global' : 'project',
+      projectPath: useGlobalStorage ? undefined : targetProjectPath,
+      result,
+      embedCount
+    };
+  } finally {
+    await memoryService.shutdown();
+  }
+}

--- a/src/apps/cli/hermes-import-runner.ts
+++ b/src/apps/cli/hermes-import-runner.ts
@@ -1,0 +1,124 @@
+import {
+  createHermesSessionHistoryImporter,
+  type HermesSessionHistoryImporter,
+  type HermesSessionHistoryImporterOptions
+} from '../../services/hermes-session-history-importer.js';
+import {
+  getDefaultMemoryService,
+  getMemoryServiceForProject,
+  type MemoryService
+} from '../../services/memory-service.js';
+import type { ImportOptions, ImportResult, ProgressEvent } from '../../services/session-history-importer.js';
+
+export interface HermesImportCommandOptions {
+  project?: string;
+  session?: string;
+  all?: boolean;
+  limit?: string;
+  force?: boolean;
+  verbose?: boolean;
+  stateDb?: string;
+  stateDbPath?: string;
+  processEmbeddings?: boolean;
+}
+
+export interface HermesImportOutcome {
+  mode: 'project' | 'session' | 'all';
+  storageScope: 'project' | 'global';
+  projectPath?: string;
+  result: ImportResult;
+  embedCount: number;
+}
+
+export interface HermesImportRunnerDeps {
+  cwd: () => string;
+  getDefaultMemoryService: () => MemoryService;
+  getMemoryServiceForProject: (projectPath: string) => MemoryService;
+  createImporter: (
+    memoryService: MemoryService,
+    options?: HermesSessionHistoryImporterOptions
+  ) => Pick<HermesSessionHistoryImporter, 'importProject' | 'importAll' | 'importSession'>;
+  onProgress?: (event: ProgressEvent) => void;
+}
+
+const realDeps: HermesImportRunnerDeps = {
+  cwd: () => process.cwd(),
+  getDefaultMemoryService,
+  getMemoryServiceForProject,
+  createImporter: createHermesSessionHistoryImporter
+};
+
+function parsePositiveInteger(value: string | undefined, name: string): number | undefined {
+  if (value === undefined) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Invalid --${name}: expected a positive integer`);
+  }
+  return parsed;
+}
+
+function shouldUseGlobalStorage(options: HermesImportCommandOptions): boolean {
+  return options.all === true && !options.project && !options.session;
+}
+
+function getStateDbPathOption(options: HermesImportCommandOptions): string | undefined {
+  return options.stateDbPath ?? options.stateDb;
+}
+
+export async function runHermesImportOnce(
+  options: HermesImportCommandOptions,
+  deps: HermesImportRunnerDeps = realDeps
+): Promise<HermesImportOutcome> {
+  const targetProjectPath = options.project || deps.cwd();
+  const useGlobalStorage = shouldUseGlobalStorage(options);
+  const memoryService = useGlobalStorage
+    ? deps.getDefaultMemoryService()
+    : deps.getMemoryServiceForProject(targetProjectPath);
+  const importer = deps.createImporter(memoryService, { stateDbPath: getStateDbPathOption(options) });
+
+  await memoryService.initialize();
+  await memoryService.ensureEmbeddingModelForImport({ autoMigrate: true });
+
+  const importOptions: ImportOptions = {
+    limit: parsePositiveInteger(options.limit, 'limit'),
+    force: options.force,
+    verbose: options.verbose,
+    onProgress: deps.onProgress
+  };
+
+  let mode: HermesImportOutcome['mode'];
+  let result: ImportResult;
+
+  try {
+    if (options.session) {
+      mode = 'session';
+      result = await importer.importSession(options.session, {
+        ...importOptions,
+        projectPath: targetProjectPath
+      });
+    } else if (options.all) {
+      mode = 'all';
+      result = await importer.importAll(importOptions);
+    } else {
+      mode = 'project';
+      result = await importer.importProject(targetProjectPath, {
+        ...importOptions,
+        projectPath: targetProjectPath
+      });
+    }
+
+    const embedCount = options.processEmbeddings === false
+      ? 0
+      : await memoryService.processPendingEmbeddings();
+
+    return {
+      mode,
+      storageScope: useGlobalStorage ? 'global' : 'project',
+      projectPath: useGlobalStorage ? undefined : targetProjectPath,
+      result,
+      embedCount
+    };
+  } finally {
+    await memoryService.shutdown();
+  }
+}

--- a/src/apps/cli/hermes-validation-output.ts
+++ b/src/apps/cli/hermes-validation-output.ts
@@ -1,0 +1,91 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { HermesSessionValidationReport } from '../../services/hermes-session-history-importer.js';
+
+export type HermesValidationReportFormat = 'json' | 'markdown';
+
+function formatNumber(value: number): string {
+  return Number.isFinite(value) ? value.toLocaleString('en-US') : String(value);
+}
+
+export function formatHermesValidationReport(
+  report: HermesSessionValidationReport,
+  format: HermesValidationReportFormat = 'markdown'
+): string {
+  if (format === 'json') {
+    return `${JSON.stringify(report, null, 2)}\n`;
+  }
+
+  const lines: string[] = [
+    '# Hermes dry-run validation report',
+    '',
+    `Generated: ${report.generatedAt}`,
+    `Dry-run: ${report.dryRun ? 'yes' : 'no'}`,
+    `Will mutate memory: ${report.willMutate ? 'yes' : 'no'}`,
+    `State DB: ${report.source.stateDbPath}`,
+    `Project filter: ${report.source.projectPath ?? '(none)'}`,
+    `Source paths: ${report.source.sourcePaths.join(', ')}`,
+    `Session limit: ${report.limits.sessionLimit ?? '(none)'}`,
+    `Max content chars: ${formatNumber(report.limits.maxContentChars)}`,
+    '',
+    '## Totals',
+    '',
+    `- Sessions scanned: ${formatNumber(report.totals.sessionsScanned)}`,
+    `- Sessions matched: ${formatNumber(report.totals.sessionsMatched)}`,
+    `- Messages read: ${formatNumber(report.totals.messagesRead)}`,
+    `- Messages normalized: ${formatNumber(report.totals.messagesNormalized)}`,
+    `- Turns normalized: ${formatNumber(report.totals.turnsNormalized)}`,
+    `- User messages: ${formatNumber(report.totals.userMessages)}`,
+    `- Assistant messages: ${formatNumber(report.totals.assistantMessages)}`,
+    `- Skipped/unsupported messages: ${formatNumber(report.totals.skippedUnsupportedMessages)}`,
+    `- Empty assistant messages: ${formatNumber(report.totals.emptyAssistantMessages)}`,
+    `- Truncated messages: ${formatNumber(report.totals.truncatedMessages)}`,
+    `- Missing project context: ${formatNumber(report.totals.missingProjectContext)}`,
+    `- Warnings: ${formatNumber(report.totals.warnings)}`,
+    '',
+    '## Top sources',
+    '',
+    '| Source | Sessions | Messages | Turns | User | Assistant | Skipped/unsupported | Truncated | Empty assistant |',
+    '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |'
+  ];
+
+  if (report.topSources.length === 0) {
+    lines.push('| (none) | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |');
+  } else {
+    for (const source of report.topSources) {
+      lines.push([
+        `| ${source.source}`,
+        formatNumber(source.sessions),
+        formatNumber(source.messagesNormalized),
+        formatNumber(source.turnsNormalized),
+        formatNumber(source.userMessages),
+        formatNumber(source.assistantMessages),
+        formatNumber(source.skippedUnsupportedMessages),
+        formatNumber(source.truncatedMessages),
+        `${formatNumber(source.emptyAssistantMessages)} |`
+      ].join(' | '));
+    }
+  }
+
+  lines.push('', '## Warnings', '');
+  if (report.warnings.length === 0) {
+    lines.push('- None');
+  } else {
+    for (const warning of report.warnings) {
+      lines.push(`- ${warning}`);
+    }
+  }
+
+  lines.push('', '_Aggregate counts only; transcript content is not included._', '');
+  return lines.join('\n');
+}
+
+export function writeHermesValidationReport(
+  outputPath: string,
+  report: HermesSessionValidationReport,
+  format: HermesValidationReportFormat = 'markdown'
+): void {
+  const dir = path.dirname(outputPath);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(outputPath, formatHermesValidationReport(report, format), 'utf8');
+}

--- a/src/apps/cli/index.ts
+++ b/src/apps/cli/index.ts
@@ -16,7 +16,10 @@ import {
 } from '../../services/memory-service.js';
 import { getProjectStoragePath } from '../../core/registry/project-path.js';
 import { createSessionHistoryImporter, type ProgressEvent } from '../../services/session-history-importer.js';
-import { validateCodexSessions } from '../../services/codex-session-history-importer.js';
+import {
+  createCodexSessionHistoryImporter,
+  validateCodexSessions
+} from '../../services/codex-session-history-importer.js';
 import { bootstrapKnowledgeBase } from '../../services/bootstrap-organizer.js';
 import { startServer, stopServer, isServerRunning } from '../server/index.js';
 import { SQLiteEventStore } from '../../core/sqlite-event-store.js';
@@ -40,6 +43,7 @@ import {
   writeCodexValidationReport,
   type CodexValidationReportFormat
 } from './codex-validation-output.js';
+import { runCodexImportOnce } from './codex-import-runner.js';
 
 // ============================================================
 // Hook Installation Utilities
@@ -1084,6 +1088,44 @@ codexCmd
       await runCodexValidationCommand(options);
     } catch (error) {
       console.error('Codex replay failed:', error instanceof Error ? error.message : error);
+      process.exit(1);
+    }
+  });
+
+codexCmd
+  .command('import')
+  .description('Explicitly import Codex JSONL sessions into claude-memory-layer memory (mutates memory)')
+  .option('-p, --project <path>', 'Import sessions whose session_meta.payload.cwd matches this project (default: cwd)')
+  .option('-s, --session <file>', 'Import one Codex session JSONL file')
+  .option('-a, --all', 'Import all Codex sessions into global memory unless --project is supplied')
+  .option('--sessions-dir <path>', 'Codex sessions directory (default: ~/.codex/sessions)')
+  .option('-l, --limit <number>', 'Limit messages imported per session')
+  .option('-f, --force', 'Delete existing events for each imported session before reimporting')
+  .option('-v, --verbose', 'Show detailed progress')
+  .option('--no-process-embeddings', 'Skip processing pending embeddings after import')
+  .action(async (options) => {
+    const startTime = Date.now();
+    try {
+      if (options.all && !options.project && !options.session) {
+        console.log('\n📥 Importing all Codex sessions into global memory');
+        console.log('   ⚠️  Use --project to keep memory scoped to one project.\n');
+      } else {
+        console.log(`\n📥 Importing Codex sessions for: ${options.project || process.cwd()}\n`);
+      }
+
+      const outcome = await runCodexImportOnce(options, {
+        cwd: () => process.cwd(),
+        getDefaultMemoryService,
+        getMemoryServiceForProject,
+        createImporter: createCodexSessionHistoryImporter,
+        onProgress: renderProgress
+      });
+
+      printImportSummary(outcome.result, outcome.embedCount);
+      const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+      console.log(`\n⏱️  Codex import completed in ${elapsed}s (${outcome.mode}, ${outcome.storageScope} storage)`);
+    } catch (error) {
+      console.error('Codex import failed:', error instanceof Error ? error.message : error);
       process.exit(1);
     }
   });

--- a/src/apps/cli/index.ts
+++ b/src/apps/cli/index.ts
@@ -20,6 +20,10 @@ import {
   createCodexSessionHistoryImporter,
   validateCodexSessions
 } from '../../services/codex-session-history-importer.js';
+import {
+  createHermesSessionHistoryImporter,
+  validateHermesSessions
+} from '../../services/hermes-session-history-importer.js';
 import { bootstrapKnowledgeBase } from '../../services/bootstrap-organizer.js';
 import { startServer, stopServer, isServerRunning } from '../server/index.js';
 import { SQLiteEventStore } from '../../core/sqlite-event-store.js';
@@ -43,7 +47,13 @@ import {
   writeCodexValidationReport,
   type CodexValidationReportFormat
 } from './codex-validation-output.js';
+import {
+  formatHermesValidationReport,
+  writeHermesValidationReport,
+  type HermesValidationReportFormat
+} from './hermes-validation-output.js';
 import { runCodexImportOnce } from './codex-import-runner.js';
+import { runHermesImportOnce } from './hermes-import-runner.js';
 
 // ============================================================
 // Hook Installation Utilities
@@ -106,6 +116,15 @@ type CodexValidateCommandOptions = {
   anonymizeProjects?: boolean;
 };
 
+type HermesValidateCommandOptions = {
+  project?: string;
+  stateDb?: string;
+  limit?: string;
+  format?: string;
+  output?: string;
+  dryRun?: boolean;
+};
+
 function parsePositiveIntegerOption(value: string | undefined, optionName: string): number | undefined {
   if (!value) return undefined;
   const parsed = Number.parseInt(value, 10);
@@ -116,6 +135,14 @@ function parsePositiveIntegerOption(value: string | undefined, optionName: strin
 }
 
 function parseCodexValidationReportFormat(value: string | undefined): CodexValidationReportFormat {
+  const normalized = (value ?? 'markdown').toLowerCase();
+  if (normalized !== 'json' && normalized !== 'markdown') {
+    throw new Error('Invalid --format: expected json or markdown');
+  }
+  return normalized;
+}
+
+function parseHermesValidationReportFormat(value: string | undefined): HermesValidationReportFormat {
   const normalized = (value ?? 'markdown').toLowerCase();
   if (normalized !== 'json' && normalized !== 'markdown') {
     throw new Error('Invalid --format: expected json or markdown');
@@ -142,6 +169,28 @@ async function runCodexValidationCommand(options: CodexValidateCommandOptions): 
   if (options.output) {
     const outputPath = path.resolve(options.output);
     writeCodexValidationReport(outputPath, report, format);
+    console.log(`\nReport written to ${outputPath}`);
+  }
+}
+
+async function runHermesValidationCommand(options: HermesValidateCommandOptions): Promise<void> {
+  if (options.dryRun === false) {
+    throw new Error('Hermes validation is read-only; use explicit import commands for mutation');
+  }
+
+  const format = parseHermesValidationReportFormat(options.format);
+  const report = await validateHermesSessions({
+    stateDbPath: options.stateDb,
+    projectPath: options.project,
+    limit: parsePositiveIntegerOption(options.limit, 'limit')
+  });
+
+  const rendered = formatHermesValidationReport(report, format);
+  process.stdout.write(rendered.endsWith('\n') ? rendered : `${rendered}\n`);
+
+  if (options.output) {
+    const outputPath = path.resolve(options.output);
+    writeHermesValidationReport(outputPath, report, format);
     console.log(`\nReport written to ${outputPath}`);
   }
 }
@@ -1126,6 +1175,88 @@ codexCmd
       console.log(`\n⏱️  Codex import completed in ${elapsed}s (${outcome.mode}, ${outcome.storageScope} storage)`);
     } catch (error) {
       console.error('Codex import failed:', error instanceof Error ? error.message : error);
+      process.exit(1);
+    }
+  });
+
+// ============================================================
+// Hermes Validation Commands
+// ============================================================
+
+const hermesCmd = program
+  .command('hermes')
+  .description('Read-only Hermes SessionDB scan/replay validation and explicit import');
+
+hermesCmd
+  .command('validate')
+  .description('Dry-run validate Hermes ~/.hermes/state.db sessions without importing or mutating memory')
+  .option('-p, --project <path>', 'Filter sessions by project path in Hermes session context')
+  .option('--state-db <path>', 'Hermes state database path (default: ~/.hermes/state.db)')
+  .option('-l, --limit <number>', 'Limit number of matching sessions to scan')
+  .option('--format <format>', 'Report format: json or markdown', 'markdown')
+  .option('-o, --output <path>', 'Write report to file')
+  .option('--dry-run', 'Read-only validation mode (default; no imports or writes)', true)
+  .action(async (options: HermesValidateCommandOptions) => {
+    try {
+      await runHermesValidationCommand(options);
+    } catch (error) {
+      console.error('Hermes validation failed:', error instanceof Error ? error.message : error);
+      process.exit(1);
+    }
+  });
+
+hermesCmd
+  .command('replay')
+  .description('Alias for read-only Hermes SessionDB validation/replay report')
+  .option('-p, --project <path>', 'Filter sessions by project path in Hermes session context')
+  .option('--state-db <path>', 'Hermes state database path (default: ~/.hermes/state.db)')
+  .option('-l, --limit <number>', 'Limit number of matching sessions to scan')
+  .option('--format <format>', 'Report format: json or markdown', 'markdown')
+  .option('-o, --output <path>', 'Write report to file')
+  .option('--dry-run', 'Read-only validation mode (default; no imports or writes)', true)
+  .action(async (options: HermesValidateCommandOptions) => {
+    try {
+      await runHermesValidationCommand(options);
+    } catch (error) {
+      console.error('Hermes replay failed:', error instanceof Error ? error.message : error);
+      process.exit(1);
+    }
+  });
+
+hermesCmd
+  .command('import')
+  .description('Explicitly import Hermes SessionDB sessions into claude-memory-layer memory (mutates memory)')
+  .option('-p, --project <path>', 'Import sessions whose Hermes context matches this project (default: cwd)')
+  .option('-s, --session <id>', 'Import one Hermes session id')
+  .option('-a, --all', 'Import all Hermes sessions into global memory unless --project is supplied')
+  .option('--state-db <path>', 'Hermes state database path (default: ~/.hermes/state.db)')
+  .option('-l, --limit <number>', 'Limit memories imported across matching sessions')
+  .option('-f, --force', 'Delete existing events for each imported session before reimporting')
+  .option('-v, --verbose', 'Show detailed progress')
+  .option('--no-process-embeddings', 'Skip processing pending embeddings after import')
+  .action(async (options) => {
+    const startTime = Date.now();
+    try {
+      if (options.all && !options.project && !options.session) {
+        console.log('\n📥 Importing all Hermes sessions into global memory');
+        console.log('   ⚠️  Use --project to keep memory scoped to one project.\n');
+      } else {
+        console.log(`\n📥 Importing Hermes sessions for: ${options.project || process.cwd()}\n`);
+      }
+
+      const outcome = await runHermesImportOnce(options, {
+        cwd: () => process.cwd(),
+        getDefaultMemoryService,
+        getMemoryServiceForProject,
+        createImporter: createHermesSessionHistoryImporter,
+        onProgress: renderProgress
+      });
+
+      printImportSummary(outcome.result, outcome.embedCount);
+      const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+      console.log(`\n⏱️  Hermes import completed in ${elapsed}s (${outcome.mode}, ${outcome.storageScope} storage)`);
+    } catch (error) {
+      console.error('Hermes import failed:', error instanceof Error ? error.message : error);
       process.exit(1);
     }
   });

--- a/src/core/product-validation-matrix.ts
+++ b/src/core/product-validation-matrix.ts
@@ -5,7 +5,7 @@
  * same surface -> requirement -> evidence map that tests assert stays covered.
  */
 
-export type ProductValidationArea = 'claude' | 'codex' | 'cli' | 'safety';
+export type ProductValidationArea = 'claude' | 'codex' | 'hermes' | 'cli' | 'safety';
 export type ProductValidationStatus = 'ready' | 'covered' | 'partial' | 'planned';
 export type ProductValidationEvidenceKind = 'test' | 'source' | 'command' | 'doc';
 
@@ -125,21 +125,73 @@ export const productValidationMatrix: readonly ProductValidationSurface[] = [
     ]
   },
   {
+    id: 'hermes.adapter.scan',
+    area: 'hermes',
+    title: 'Hermes adapter scan',
+    status: 'ready',
+    requirements: [
+      'Read Hermes ~/.hermes/state.db in read-only mode by default.',
+      'Match sessions to a project via Hermes session context/title when available.',
+      'Count unsupported/tool messages, empty assistant messages, missing project context, and truncated content without exposing transcript text.'
+    ],
+    evidence: [
+      { kind: 'test', ref: 'tests/core/hermes-session-history-importer-validation.test.ts', note: 'Dry-run SessionDB fixture covers project matching, unsupported/tool skipping, empty assistant messages, and transcript exclusion.' },
+      { kind: 'source', ref: 'src/services/hermes-session-history-importer.ts', note: 'validateHermesSessions reads SessionDB and emits aggregate replay reports.' }
+    ]
+  },
+  {
+    id: 'hermes.adapter.import',
+    area: 'hermes',
+    title: 'Hermes adapter import',
+    status: 'covered',
+    requirements: [
+      'Import explicit Hermes SessionDB project/session/all selections into memory only through import APIs.',
+      'Default to project-scoped memory for current-project imports and require --all for intentional global imports.',
+      'Skip tool/system records and redact sensitive user/assistant content before storage.'
+    ],
+    evidence: [
+      { kind: 'test', ref: 'tests/core/hermes-session-history-importer-validation.test.ts', note: 'Imports only matched user/assistant turns, redacts secrets, and skips tool messages.' },
+      { kind: 'test', ref: 'tests/apps/hermes-import-runner.test.ts', note: 'Asserts project-scoped, session, and explicit global all-session import routing.' },
+      { kind: 'source', ref: 'src/apps/cli/hermes-import-runner.ts', note: 'Safe Hermes import command runner with project/default/global storage decisions.' },
+      { kind: 'source', ref: 'src/services/hermes-session-history-importer.ts', note: 'HermesSessionHistoryImporter importProject/importAll/importSession.' }
+    ]
+  },
+  {
+    id: 'hermes.adapter.replay',
+    area: 'hermes',
+    title: 'Hermes adapter replay',
+    status: 'ready',
+    requirements: [
+      'Normalize Hermes SessionDB user/assistant rows into aggregate replay counts.',
+      'Keep Hermes raw transcript source-of-truth in SessionDB and treat CML as explicit derived memory.',
+      'Emit validation reports without transcript content or secrets.'
+    ],
+    evidence: [
+      { kind: 'test', ref: 'tests/core/hermes-session-history-importer-validation.test.ts', note: 'Validation report excludes prompt/response text and synthetic secrets.' },
+      { kind: 'source', ref: 'src/apps/cli/hermes-validation-output.ts', note: 'JSON/Markdown report output helpers for Hermes aggregate replay.' },
+      { kind: 'doc', ref: 'docs/HERMES_MEMORY_INGESTION_ANALYSIS.md', note: 'Documents explicit import first; live sync later if needed.' }
+    ]
+  },
+  {
     id: 'cli.api.reporting',
     area: 'cli',
     title: 'CLI / API / reporting',
     status: 'ready',
     requirements: [
       'Expose user-facing Codex validation commands with --project, --sessions-dir, --limit, --format, --output, and --dry-run options.',
-      'Expose explicit Codex import commands with --project, --session, --all, --sessions-dir, --limit, --force, and --no-process-embeddings options.',
-      'Render JSON and Markdown reports with totals, warnings, top projects, and source paths.'
+      'Expose user-facing Hermes validation commands with --project, --state-db, --limit, --format, --output, and --dry-run options.',
+      'Expose explicit Codex and Hermes import commands with project, session, all-session, limit, force, and no-process-embeddings options.',
+      'Render JSON and Markdown reports with totals, warnings, top projects/sources, and source paths.'
     ],
     evidence: [
-      { kind: 'test', ref: 'tests/apps/codex-validation-output.test.ts', note: 'JSON/Markdown report formatting.' },
+      { kind: 'test', ref: 'tests/apps/codex-validation-output.test.ts', note: 'Codex JSON/Markdown report formatting.' },
       { kind: 'test', ref: 'tests/apps/codex-import-runner.test.ts', note: 'Codex import CLI runner behavior and storage-scope routing.' },
-      { kind: 'source', ref: 'src/apps/cli/index.ts', note: 'codex validate/replay/import commands.' },
-      { kind: 'source', ref: 'src/apps/cli/codex-validation-output.ts', note: 'Report output helpers.' },
-      { kind: 'source', ref: 'src/apps/cli/codex-import-runner.ts', note: 'Codex import runner.' }
+      { kind: 'test', ref: 'tests/apps/hermes-import-runner.test.ts', note: 'Hermes import CLI runner behavior and storage-scope routing.' },
+      { kind: 'source', ref: 'src/apps/cli/index.ts', note: 'codex and hermes validate/replay/import commands.' },
+      { kind: 'source', ref: 'src/apps/cli/codex-validation-output.ts', note: 'Codex report output helpers.' },
+      { kind: 'source', ref: 'src/apps/cli/hermes-validation-output.ts', note: 'Hermes report output helpers.' },
+      { kind: 'source', ref: 'src/apps/cli/codex-import-runner.ts', note: 'Codex import runner.' },
+      { kind: 'source', ref: 'src/apps/cli/hermes-import-runner.ts', note: 'Hermes import runner.' }
     ]
   },
   {
@@ -160,7 +212,7 @@ export const productValidationMatrix: readonly ProductValidationSurface[] = [
 ];
 
 function emptyAreaCounts(): Record<ProductValidationArea, number> {
-  return { claude: 0, codex: 0, cli: 0, safety: 0 };
+  return { claude: 0, codex: 0, hermes: 0, cli: 0, safety: 0 };
 }
 
 function emptyStatusCounts(): Record<ProductValidationStatus, number> {

--- a/src/core/product-validation-matrix.ts
+++ b/src/core/product-validation-matrix.ts
@@ -96,12 +96,15 @@ export const productValidationMatrix: readonly ProductValidationSurface[] = [
     id: 'codex.adapter.import',
     area: 'codex',
     title: 'Codex adapter import',
-    status: 'partial',
+    status: 'covered',
     requirements: [
       'Import explicit Codex session files/project sessions into memory only through import APIs.',
+      'Expose a user-facing codex import command for project, session, and all-session imports.',
       'Preserve turn grouping and truncate oversized assistant content before storage.'
     ],
     evidence: [
+      { kind: 'test', ref: 'tests/apps/codex-import-runner.test.ts', note: 'Asserts project-scoped, session, and explicit global all-session import routing.' },
+      { kind: 'source', ref: 'src/apps/cli/codex-import-runner.ts', note: 'Safe Codex import command runner with project/default/global storage decisions.' },
       { kind: 'source', ref: 'src/services/codex-session-history-importer.ts', note: 'CodexSessionHistoryImporter importProject/importAll/importSessionFile.' },
       { kind: 'doc', ref: 'docs/PRODUCT_VALIDATION_MATRIX.md', note: 'Documents that validation/replay is read-only; mutation remains explicit import-only.' }
     ]
@@ -128,12 +131,15 @@ export const productValidationMatrix: readonly ProductValidationSurface[] = [
     status: 'ready',
     requirements: [
       'Expose user-facing Codex validation commands with --project, --sessions-dir, --limit, --format, --output, and --dry-run options.',
+      'Expose explicit Codex import commands with --project, --session, --all, --sessions-dir, --limit, --force, and --no-process-embeddings options.',
       'Render JSON and Markdown reports with totals, warnings, top projects, and source paths.'
     ],
     evidence: [
       { kind: 'test', ref: 'tests/apps/codex-validation-output.test.ts', note: 'JSON/Markdown report formatting.' },
-      { kind: 'source', ref: 'src/apps/cli/index.ts', note: 'codex validate/replay commands.' },
-      { kind: 'source', ref: 'src/apps/cli/codex-validation-output.ts', note: 'Report output helpers.' }
+      { kind: 'test', ref: 'tests/apps/codex-import-runner.test.ts', note: 'Codex import CLI runner behavior and storage-scope routing.' },
+      { kind: 'source', ref: 'src/apps/cli/index.ts', note: 'codex validate/replay/import commands.' },
+      { kind: 'source', ref: 'src/apps/cli/codex-validation-output.ts', note: 'Report output helpers.' },
+      { kind: 'source', ref: 'src/apps/cli/codex-import-runner.ts', note: 'Codex import runner.' }
     ]
   },
   {

--- a/src/extensions/mcp/handlers.ts
+++ b/src/extensions/mcp/handlers.ts
@@ -3,32 +3,46 @@
  * Implementation of tool calls
  */
 
-import { getDefaultMemoryService } from '../../services/memory-service.js';
+import {
+  getDefaultMemoryService,
+  getMemoryServiceForProject,
+  type MemoryService
+} from '../../services/memory-service.js';
 import { generateCitationId } from '../../core/citation-generator.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
 type ToolResult = CallToolResult;
+
+type MemoryToolArgs = Record<string, unknown>;
+
+function resolveMemoryService(args: MemoryToolArgs): MemoryService {
+  const projectPath = typeof args.projectPath === 'string' ? args.projectPath.trim() : '';
+  if (projectPath.length > 0) {
+    return getMemoryServiceForProject(projectPath);
+  }
+  return getDefaultMemoryService();
+}
 
 export async function handleToolCall(
   name: string,
   args: Record<string, unknown>
 ): Promise<ToolResult> {
   try {
-    const memoryService = getDefaultMemoryService();
+    const memoryService = resolveMemoryService(args);
     await memoryService.initialize();
 
     switch (name) {
       case 'mem-search':
-        return await handleMemSearch(args);
+        return await handleMemSearch(memoryService, args);
 
       case 'mem-timeline':
-        return await handleMemTimeline(args);
+        return await handleMemTimeline(memoryService, args);
 
       case 'mem-details':
-        return await handleMemDetails(args);
+        return await handleMemDetails(memoryService, args);
 
       case 'mem-stats':
-        return await handleMemStats();
+        return await handleMemStats(memoryService);
 
       default:
         return {
@@ -44,11 +58,10 @@ export async function handleToolCall(
   }
 }
 
-async function handleMemSearch(args: Record<string, unknown>): Promise<ToolResult> {
+async function handleMemSearch(memoryService: MemoryService, args: Record<string, unknown>): Promise<ToolResult> {
   const query = args.query as string;
   const topK = Math.min((args.topK as number) || 5, 20);
 
-  const memoryService = getDefaultMemoryService();
   const result = await memoryService.retrieveMemories(query, {
     topK,
     sessionId: args.sessionId as string
@@ -81,11 +94,10 @@ async function handleMemSearch(args: Record<string, unknown>): Promise<ToolResul
   };
 }
 
-async function handleMemTimeline(args: Record<string, unknown>): Promise<ToolResult> {
+async function handleMemTimeline(memoryService: MemoryService, args: Record<string, unknown>): Promise<ToolResult> {
   const ids = args.ids as string[];
   const windowSize = (args.windowSize as number) || 3;
 
-  const memoryService = getDefaultMemoryService();
   const recentEvents = await memoryService.getRecentEvents(10000);
 
   const lines: string[] = [
@@ -135,10 +147,9 @@ async function handleMemTimeline(args: Record<string, unknown>): Promise<ToolRes
   };
 }
 
-async function handleMemDetails(args: Record<string, unknown>): Promise<ToolResult> {
+async function handleMemDetails(memoryService: MemoryService, args: Record<string, unknown>): Promise<ToolResult> {
   const ids = args.ids as string[];
 
-  const memoryService = getDefaultMemoryService();
   const recentEvents = await memoryService.getRecentEvents(10000);
 
   const lines: string[] = [];
@@ -177,8 +188,7 @@ async function handleMemDetails(args: Record<string, unknown>): Promise<ToolResu
   };
 }
 
-async function handleMemStats(): Promise<ToolResult> {
-  const memoryService = getDefaultMemoryService();
+async function handleMemStats(memoryService: MemoryService): Promise<ToolResult> {
   const stats = await memoryService.getStats();
   const recentEvents = await memoryService.getRecentEvents(10000);
 

--- a/src/extensions/mcp/tools.ts
+++ b/src/extensions/mcp/tools.ts
@@ -5,6 +5,11 @@
 
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 
+const projectPathProperty = {
+  type: 'string',
+  description: 'Optional: absolute project path to search a project-scoped claude-memory-layer store instead of the global store'
+} as const;
+
 export const tools: Tool[] = [
   {
     name: 'mem-search',
@@ -24,6 +29,7 @@ export const tools: Tool[] = [
           type: 'string',
           description: 'Optional: filter by specific session ID'
         },
+        projectPath: projectPathProperty,
         eventType: {
           type: 'string',
           enum: ['user_prompt', 'agent_response', 'tool_observation', 'session_summary'],
@@ -47,7 +53,8 @@ export const tools: Tool[] = [
         windowSize: {
           type: 'number',
           description: 'Number of items before/after each ID (default: 3)'
-        }
+        },
+        projectPath: projectPathProperty
       },
       required: ['ids']
     }
@@ -62,7 +69,8 @@ export const tools: Tool[] = [
           type: 'array',
           items: { type: 'string' },
           description: 'Memory IDs to fetch full details for'
-        }
+        },
+        projectPath: projectPathProperty
       },
       required: ['ids']
     }
@@ -72,7 +80,9 @@ export const tools: Tool[] = [
     description: 'Get statistics about the memory storage (total events, sessions, etc.)',
     inputSchema: {
       type: 'object',
-      properties: {}
+      properties: {
+        projectPath: projectPathProperty
+      }
     }
   }
 ];

--- a/src/services/codex-session-history-importer.ts
+++ b/src/services/codex-session-history-importer.ts
@@ -507,17 +507,23 @@ export async function validateCodexSessions(options: CodexValidationOptions = {}
   return report;
 }
 
+export interface CodexSessionHistoryImporterOptions {
+  sessionsDir?: string;
+}
+
 export class CodexSessionHistoryImporter {
   private readonly memoryService: MemoryService;
-  private readonly codexDir: string;
+  private readonly sessionsRoot: string;
 
-  constructor(memoryService: MemoryService) {
+  constructor(memoryService: MemoryService, options: CodexSessionHistoryImporterOptions = {}) {
     this.memoryService = memoryService;
-    this.codexDir = path.join(os.homedir(), '.codex');
+    this.sessionsRoot = options.sessionsDir
+      ? path.resolve(options.sessionsDir)
+      : path.join(os.homedir(), '.codex', 'sessions');
   }
 
   private getSessionsRoot(): string {
-    return path.join(this.codexDir, 'sessions');
+    return this.sessionsRoot;
   }
 
   private listSessionFilesRecursive(rootDir: string): string[] {
@@ -911,6 +917,9 @@ export class CodexSessionHistoryImporter {
   }
 }
 
-export function createCodexSessionHistoryImporter(memoryService: MemoryService): CodexSessionHistoryImporter {
-  return new CodexSessionHistoryImporter(memoryService);
+export function createCodexSessionHistoryImporter(
+  memoryService: MemoryService,
+  options: CodexSessionHistoryImporterOptions = {}
+): CodexSessionHistoryImporter {
+  return new CodexSessionHistoryImporter(memoryService, options);
 }

--- a/src/services/hermes-session-history-importer.ts
+++ b/src/services/hermes-session-history-importer.ts
@@ -1,0 +1,702 @@
+/**
+ * Hermes SessionDB Importer
+ *
+ * Imports explicit, read-only snapshots from Hermes Agent's ~/.hermes/state.db
+ * into claude-memory-layer. This intentionally does not tail/live-sync Hermes:
+ * SessionDB remains the raw source of truth; imports are opt-in and project-scoped.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createHash, randomUUID } from 'crypto';
+import { createDatabase, type Database } from '../core/db-wrapper.js';
+import { applyPrivacyFilter, truncateOutput } from '../core/privacy/index.js';
+import { registerSession } from '../core/registry/session-registry.js';
+import type { Config } from '../core/types.js';
+import { MemoryService } from './memory-service.js';
+import { isWorthStoringPrompt, type ImportOptions, type ImportResult } from './session-history-importer.js';
+
+export const HERMES_VALIDATION_DEFAULT_MAX_CONTENT_CHARS = 10_000;
+const HERMES_MEMORY_SESSION_PREFIX = 'hermes:';
+
+const DEFAULT_PRIVACY_CONFIG: Config['privacy'] = {
+  excludePatterns: ['password', 'secret', 'api_key', 'token', 'bearer'],
+  anonymize: false,
+  privateTags: {
+    enabled: true,
+    marker: '[PRIVATE]',
+    preserveLineCount: false,
+    supportedFormats: ['xml']
+  }
+};
+
+export interface HermesSessionHistoryImporterOptions {
+  stateDbPath?: string;
+}
+
+export interface HermesValidationOptions {
+  stateDbPath?: string;
+  projectPath?: string;
+  limit?: number;
+  maxContentChars?: number;
+  now?: Date;
+}
+
+export interface HermesValidationSource {
+  stateDbPath: string;
+  projectPath?: string;
+  projectFilterApplied: boolean;
+  sourcePaths: string[];
+}
+
+export interface HermesValidationLimits {
+  sessionLimit?: number;
+  maxContentChars: number;
+}
+
+export interface HermesValidationTotals {
+  sessionsScanned: number;
+  sessionsMatched: number;
+  messagesRead: number;
+  messagesNormalized: number;
+  turnsNormalized: number;
+  userMessages: number;
+  assistantMessages: number;
+  skippedUnsupportedMessages: number;
+  emptyAssistantMessages: number;
+  truncatedMessages: number;
+  missingProjectContext: number;
+  warnings: number;
+}
+
+export interface HermesSourceSummary {
+  source: string;
+  sessions: number;
+  messagesNormalized: number;
+  turnsNormalized: number;
+  userMessages: number;
+  assistantMessages: number;
+  skippedUnsupportedMessages: number;
+  truncatedMessages: number;
+  emptyAssistantMessages: number;
+}
+
+export interface HermesSessionReplaySummary {
+  sessionId: string;
+  source: string;
+  matched: boolean;
+  messagesRead: number;
+  messagesNormalized: number;
+  turnsNormalized: number;
+  userMessages: number;
+  assistantMessages: number;
+  skippedUnsupportedMessages: number;
+  emptyAssistantMessages: number;
+  truncatedMessages: number;
+  missingProjectContext: boolean;
+  warnings: string[];
+}
+
+export interface HermesSessionValidationReport {
+  generatedAt: string;
+  dryRun: true;
+  willMutate: false;
+  source: HermesValidationSource;
+  limits: HermesValidationLimits;
+  totals: HermesValidationTotals;
+  topSources: HermesSourceSummary[];
+  sessions: HermesSessionReplaySummary[];
+  warnings: string[];
+}
+
+type HermesSessionRow = {
+  id: string;
+  source: string;
+  user_id: string | null;
+  model: string | null;
+  system_prompt: string | null;
+  started_at: number;
+  ended_at?: number | null;
+  title?: string | null;
+};
+
+type HermesMessageRow = {
+  id: number;
+  session_id: string;
+  role: string;
+  content: string | null;
+  tool_name: string | null;
+  timestamp: number;
+};
+
+type NormalizedHermesMessage = {
+  role: 'user' | 'assistant';
+  content: string;
+  truncated: boolean;
+};
+
+function normalizeMaybeRealpath(p: string): string {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return path.resolve(p);
+  }
+}
+
+function hashLabel(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 12);
+}
+
+function makeMemorySessionId(sessionId: string): string {
+  return sessionId.startsWith(HERMES_MEMORY_SESSION_PREFIX)
+    ? sessionId
+    : `${HERMES_MEMORY_SESSION_PREFIX}${sessionId}`;
+}
+
+function timestampToIso(timestamp: number | null | undefined): string | undefined {
+  if (typeof timestamp !== 'number' || !Number.isFinite(timestamp)) return undefined;
+  return new Date(timestamp * 1000).toISOString();
+}
+
+function getProjectMatchVariants(projectPath: string): string[] {
+  const variants = new Set<string>();
+  variants.add(projectPath);
+  variants.add(path.resolve(projectPath));
+  variants.add(normalizeMaybeRealpath(projectPath));
+  variants.add(projectPath.replace(/\\/g, '/'));
+  variants.add(path.resolve(projectPath).replace(/\\/g, '/'));
+  return [...variants].filter(Boolean).map((v) => v.toLowerCase());
+}
+
+function getSessionProjectHaystack(session: HermesSessionRow): string {
+  return [session.system_prompt, session.title]
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .join('\n')
+    .replace(/\\/g, '/')
+    .toLowerCase();
+}
+
+function hasProjectContext(session: HermesSessionRow): boolean {
+  return Boolean(
+    (typeof session.system_prompt === 'string' && session.system_prompt.trim().length > 0) ||
+    (typeof session.title === 'string' && session.title.trim().length > 0)
+  );
+}
+
+function matchesProject(session: HermesSessionRow, projectPath?: string): boolean {
+  if (!projectPath) return true;
+  const haystack = getSessionProjectHaystack(session);
+  if (!haystack) return false;
+  return getProjectMatchVariants(projectPath).some((variant) => haystack.includes(variant));
+}
+
+function parseHermesEncodedContent(content: string | null): string | null {
+  if (typeof content !== 'string') return null;
+  if (content.length === 0) return null;
+
+  const trimmed = content.trim();
+  if ((trimmed.startsWith('[') && trimmed.endsWith(']')) || (trimmed.startsWith('{') && trimmed.endsWith('}'))) {
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      const extracted = extractTextFromStructuredContent(parsed);
+      if (extracted) return extracted;
+    } catch {
+      // Plain text that happens to look like JSON; keep it below.
+    }
+  }
+
+  return content;
+}
+
+function extractTextFromStructuredContent(value: unknown): string | null {
+  if (typeof value === 'string') return value.length > 0 ? value : null;
+  if (Array.isArray(value)) {
+    const texts = value
+      .map((item) => extractTextFromStructuredContent(item))
+      .filter((item): item is string => Boolean(item));
+    return texts.length > 0 ? texts.join('\n') : null;
+  }
+  if (typeof value === 'object' && value !== null) {
+    const record = value as Record<string, unknown>;
+    if (typeof record.text === 'string' && record.text.length > 0) return record.text;
+    if (typeof record.content === 'string' && record.content.length > 0) return record.content;
+    if (Array.isArray(record.content)) return extractTextFromStructuredContent(record.content);
+  }
+  return null;
+}
+
+function normalizeHermesMessage(
+  row: HermesMessageRow,
+  maxContentChars = HERMES_VALIDATION_DEFAULT_MAX_CONTENT_CHARS
+): NormalizedHermesMessage | 'empty-assistant' | 'unsupported' | 'trivial-user' {
+  if (row.role !== 'user' && row.role !== 'assistant') return 'unsupported';
+  const extracted = parseHermesEncodedContent(row.content);
+  if (!extracted || extracted.trim().length === 0) {
+    return row.role === 'assistant' ? 'empty-assistant' : 'trivial-user';
+  }
+  if (row.role === 'user' && !isWorthStoringPrompt(extracted)) return 'trivial-user';
+
+  const truncated = extracted.length > maxContentChars;
+  return {
+    role: row.role,
+    content: truncated ? `${extracted.slice(0, maxContentChars)}...[truncated]` : extracted,
+    truncated
+  };
+}
+
+function sanitizeForMemory(content: string): string {
+  const filtered = applyPrivacyFilter(content, DEFAULT_PRIVACY_CONFIG).content;
+  return truncateOutput(filtered, { maxLength: HERMES_VALIDATION_DEFAULT_MAX_CONTENT_CHARS, maxLines: 200 });
+}
+
+export function getDefaultHermesStateDbPath(): string {
+  return path.join(os.homedir(), '.hermes', 'state.db');
+}
+
+function openHermesDbReadOnly(stateDbPath: string): Database {
+  if (!fs.existsSync(stateDbPath)) {
+    throw new Error(`Hermes state database not found: ${stateDbPath}`);
+  }
+  return createDatabase(stateDbPath, { readOnly: true });
+}
+
+function listHermesSessions(db: Database): HermesSessionRow[] {
+  return db.prepare(`
+    SELECT id, source, user_id, model, system_prompt, started_at, ended_at, title
+    FROM sessions
+    ORDER BY started_at DESC, id DESC
+  `).all() as HermesSessionRow[];
+}
+
+function getHermesSession(db: Database, sessionId: string): HermesSessionRow | null {
+  const row = db.prepare(`
+    SELECT id, source, user_id, model, system_prompt, started_at, ended_at, title
+    FROM sessions
+    WHERE id = ?
+  `).get(sessionId) as HermesSessionRow | undefined;
+  return row ?? null;
+}
+
+function listHermesMessages(db: Database, sessionId: string): HermesMessageRow[] {
+  return db.prepare(`
+    SELECT id, session_id, role, content, tool_name, timestamp
+    FROM messages
+    WHERE session_id = ?
+    ORDER BY timestamp ASC, id ASC
+  `).all(sessionId) as HermesMessageRow[];
+}
+
+function createEmptyImportResult(): ImportResult {
+  return {
+    totalSessions: 0,
+    totalMessages: 0,
+    importedPrompts: 0,
+    importedResponses: 0,
+    skippedDuplicates: 0,
+    errors: []
+  };
+}
+
+function createEmptySessionSummary(session: HermesSessionRow, matched: boolean): HermesSessionReplaySummary {
+  return {
+    sessionId: session.id,
+    source: session.source,
+    matched,
+    messagesRead: 0,
+    messagesNormalized: 0,
+    turnsNormalized: 0,
+    userMessages: 0,
+    assistantMessages: 0,
+    skippedUnsupportedMessages: 0,
+    emptyAssistantMessages: 0,
+    truncatedMessages: 0,
+    missingProjectContext: !hasProjectContext(session),
+    warnings: []
+  };
+}
+
+function addToSourceSummary(
+  summaries: Map<string, HermesSourceSummary>,
+  sessionSummary: HermesSessionReplaySummary
+): void {
+  const current = summaries.get(sessionSummary.source) ?? {
+    source: sessionSummary.source,
+    sessions: 0,
+    messagesNormalized: 0,
+    turnsNormalized: 0,
+    userMessages: 0,
+    assistantMessages: 0,
+    skippedUnsupportedMessages: 0,
+    truncatedMessages: 0,
+    emptyAssistantMessages: 0
+  };
+
+  current.sessions += 1;
+  current.messagesNormalized += sessionSummary.messagesNormalized;
+  current.turnsNormalized += sessionSummary.turnsNormalized;
+  current.userMessages += sessionSummary.userMessages;
+  current.assistantMessages += sessionSummary.assistantMessages;
+  current.skippedUnsupportedMessages += sessionSummary.skippedUnsupportedMessages;
+  current.truncatedMessages += sessionSummary.truncatedMessages;
+  current.emptyAssistantMessages += sessionSummary.emptyAssistantMessages;
+  summaries.set(sessionSummary.source, current);
+}
+
+export async function validateHermesSessions(options: HermesValidationOptions = {}): Promise<HermesSessionValidationReport> {
+  const stateDbPath = options.stateDbPath ?? getDefaultHermesStateDbPath();
+  const maxContentChars = options.maxContentChars ?? HERMES_VALIDATION_DEFAULT_MAX_CONTENT_CHARS;
+  const warnings: string[] = [];
+  const totals: HermesValidationTotals = {
+    sessionsScanned: 0,
+    sessionsMatched: 0,
+    messagesRead: 0,
+    messagesNormalized: 0,
+    turnsNormalized: 0,
+    userMessages: 0,
+    assistantMessages: 0,
+    skippedUnsupportedMessages: 0,
+    emptyAssistantMessages: 0,
+    truncatedMessages: 0,
+    missingProjectContext: 0,
+    warnings: 0
+  };
+
+  const db = openHermesDbReadOnly(stateDbPath);
+  try {
+    const sourceSummaries = new Map<string, HermesSourceSummary>();
+    const sessionSummaries: HermesSessionReplaySummary[] = [];
+    const sessions = listHermesSessions(db);
+    const sessionLimit = options.limit ?? Infinity;
+    let matchedCount = 0;
+
+    for (const session of sessions) {
+      totals.sessionsScanned++;
+      const missingContext = !hasProjectContext(session);
+      if (missingContext) totals.missingProjectContext++;
+
+      const matched = matchesProject(session, options.projectPath);
+      if (!matched) continue;
+      if (matchedCount >= sessionLimit) continue;
+      matchedCount++;
+      totals.sessionsMatched++;
+
+      const summary = createEmptySessionSummary(session, true);
+      const messages = listHermesMessages(db, session.id);
+      for (const message of messages) {
+        summary.messagesRead++;
+        totals.messagesRead++;
+
+        const normalized = normalizeHermesMessage(message, maxContentChars);
+        if (normalized === 'unsupported') {
+          summary.skippedUnsupportedMessages++;
+          totals.skippedUnsupportedMessages++;
+          continue;
+        }
+        if (normalized === 'empty-assistant') {
+          summary.emptyAssistantMessages++;
+          totals.emptyAssistantMessages++;
+          continue;
+        }
+        if (normalized === 'trivial-user') {
+          continue;
+        }
+
+        summary.messagesNormalized++;
+        totals.messagesNormalized++;
+        if (normalized.truncated) {
+          summary.truncatedMessages++;
+          totals.truncatedMessages++;
+        }
+        if (normalized.role === 'user') {
+          summary.userMessages++;
+          summary.turnsNormalized++;
+          totals.userMessages++;
+          totals.turnsNormalized++;
+        } else {
+          summary.assistantMessages++;
+          totals.assistantMessages++;
+        }
+      }
+
+      sessionSummaries.push(summary);
+      addToSourceSummary(sourceSummaries, summary);
+    }
+
+    if (totals.missingProjectContext > 0) {
+      warnings.push(`${totals.missingProjectContext} Hermes session(s) have no project context in system prompt/title`);
+    }
+    totals.warnings = warnings.length;
+
+    return {
+      generatedAt: (options.now ?? new Date()).toISOString(),
+      dryRun: true,
+      willMutate: false,
+      source: {
+        stateDbPath,
+        projectPath: options.projectPath,
+        projectFilterApplied: Boolean(options.projectPath),
+        sourcePaths: [stateDbPath]
+      },
+      limits: {
+        sessionLimit: options.limit,
+        maxContentChars
+      },
+      totals,
+      topSources: [...sourceSummaries.values()].sort((a, b) => b.sessions - a.sessions || b.messagesNormalized - a.messagesNormalized),
+      sessions: sessionSummaries,
+      warnings
+    };
+  } finally {
+    db.close();
+  }
+}
+
+export class HermesSessionHistoryImporter {
+  private readonly memoryService: MemoryService;
+  private readonly stateDbPath: string;
+
+  constructor(memoryService: MemoryService, options: HermesSessionHistoryImporterOptions = {}) {
+    this.memoryService = memoryService;
+    this.stateDbPath = options.stateDbPath ?? getDefaultHermesStateDbPath();
+  }
+
+  async importProject(projectPath: string, options: ImportOptions = {}): Promise<ImportResult> {
+    const db = openHermesDbReadOnly(this.stateDbPath);
+    try {
+      const sessions = listHermesSessions(db).filter((session) => matchesProject(session, projectPath));
+      return await this.importSessionRows(db, sessions, { ...options, projectPath });
+    } finally {
+      db.close();
+    }
+  }
+
+  async importAll(options: ImportOptions = {}): Promise<ImportResult> {
+    const db = openHermesDbReadOnly(this.stateDbPath);
+    try {
+      return await this.importSessionRows(db, listHermesSessions(db), options);
+    } finally {
+      db.close();
+    }
+  }
+
+  async importSession(sessionId: string, options: ImportOptions = {}): Promise<ImportResult> {
+    const db = openHermesDbReadOnly(this.stateDbPath);
+    try {
+      const sourceSessionId = sessionId.startsWith(HERMES_MEMORY_SESSION_PREFIX)
+        ? sessionId.slice(HERMES_MEMORY_SESSION_PREFIX.length)
+        : sessionId;
+      const session = getHermesSession(db, sourceSessionId);
+      if (!session) {
+        return { ...createEmptyImportResult(), totalSessions: 1, errors: [`Hermes session not found: ${sessionId}`] };
+      }
+      return await this.importSessionRows(db, [session], options);
+    } finally {
+      db.close();
+    }
+  }
+
+  async listAvailableSessions(projectPath?: string): Promise<Array<{
+    sessionId: string;
+    source: string;
+    startedAt: Date;
+    messageCount: number;
+  }>> {
+    const db = openHermesDbReadOnly(this.stateDbPath);
+    try {
+      return listHermesSessions(db)
+        .filter((session) => matchesProject(session, projectPath))
+        .map((session) => ({
+          sessionId: session.id,
+          source: session.source,
+          startedAt: new Date(session.started_at * 1000),
+          messageCount: listHermesMessages(db, session.id).length
+        }));
+    } finally {
+      db.close();
+    }
+  }
+
+  private async importSessionRows(
+    db: Database,
+    sessions: HermesSessionRow[],
+    options: ImportOptions = {}
+  ): Promise<ImportResult> {
+    const result = createEmptyImportResult();
+    const onProgress = options.onProgress;
+    const limit = options.limit ?? Infinity;
+    let storedCount = 0;
+
+    onProgress?.({ phase: 'scan', message: `Found ${sessions.length} Hermes session(s)` });
+
+    for (let i = 0; i < sessions.length; i++) {
+      if (storedCount >= limit) break;
+      const session = sessions[i];
+      onProgress?.({ phase: 'session-start', sessionIndex: i, totalSessions: sessions.length, filePath: this.stateDbPath });
+
+      const memorySessionId = makeMemorySessionId(session.id);
+      const sessionResult = await this.importOneSession(db, session, memorySessionId, options, i, () => storedCount, (next) => { storedCount = next; });
+
+      result.totalSessions++;
+      result.totalMessages += sessionResult.totalMessages;
+      result.importedPrompts += sessionResult.importedPrompts;
+      result.importedResponses += sessionResult.importedResponses;
+      result.skippedDuplicates += sessionResult.skippedDuplicates;
+      result.errors.push(...sessionResult.errors);
+
+      onProgress?.({
+        phase: 'session-done',
+        sessionIndex: i,
+        importedPrompts: sessionResult.importedPrompts,
+        importedResponses: sessionResult.importedResponses,
+        skipped: sessionResult.skippedDuplicates
+      });
+    }
+
+    onProgress?.({ phase: 'done', result });
+    return result;
+  }
+
+  private async importOneSession(
+    db: Database,
+    session: HermesSessionRow,
+    memorySessionId: string,
+    options: ImportOptions,
+    sessionIndex: number,
+    getStoredCount: () => number,
+    setStoredCount: (next: number) => void
+  ): Promise<ImportResult> {
+    const result = { ...createEmptyImportResult(), totalSessions: 1 };
+    const effectiveProjectPath = options.projectPath;
+
+    if (options.force) {
+      const deleted = await this.memoryService.deleteSessionEvents(memorySessionId);
+      if (options.verbose && deleted > 0) {
+        console.log(`  Deleted ${deleted} existing events for session ${memorySessionId}`);
+      }
+    }
+
+    await this.memoryService.startSession(memorySessionId, effectiveProjectPath);
+
+    const messages = listHermesMessages(db, session.id);
+    let currentTurnId: string | null = null;
+    let textBuffer: Array<{ content: string; row: HermesMessageRow }> = [];
+    let lastProgressAt = 0;
+
+    const flushTextBuffer = async () => {
+      if (getStoredCount() >= (options.limit ?? Infinity)) {
+        textBuffer = [];
+        return;
+      }
+      if (textBuffer.length === 0 || !currentTurnId) return;
+
+      const contentBlocks = textBuffer.map((item) => item.content);
+      const substantive = contentBlocks.filter((content) => content.length >= 100);
+      const merged = substantive.length > 0
+        ? substantive.join('\n\n')
+        : contentBlocks.reduce((a, b) => a.length >= b.length ? a : b, '');
+      if (!merged) {
+        textBuffer = [];
+        return;
+      }
+
+      const lastRow = textBuffer[textBuffer.length - 1].row;
+      const appendResult = await this.memoryService.storeAgentResponse(
+        memorySessionId,
+        sanitizeForMemory(merged),
+        {
+          importedFrom: this.stateDbPath,
+          originalTimestamp: timestampToIso(lastRow.timestamp),
+          sourceMessageId: lastRow.id,
+          turnId: currentTurnId,
+          source: 'hermes',
+          hermesSource: session.source,
+          sourceSessionId: session.id,
+          sourceSessionHash: hashLabel(session.id)
+        }
+      );
+
+      if (appendResult.success && appendResult.isDuplicate) {
+        result.skippedDuplicates++;
+      } else {
+        result.importedResponses++;
+      }
+      setStoredCount(getStoredCount() + 1);
+      textBuffer = [];
+    };
+
+    for (const message of messages) {
+      if (getStoredCount() >= (options.limit ?? Infinity)) break;
+      result.totalMessages++;
+      const normalized = normalizeHermesMessage(message);
+
+      if (normalized === 'unsupported' || normalized === 'empty-assistant') {
+        continue;
+      }
+      if (normalized === 'trivial-user') {
+        result.skippedDuplicates++;
+        continue;
+      }
+
+      if (normalized.role === 'user') {
+        await flushTextBuffer();
+        currentTurnId = randomUUID();
+        const appendResult = await this.memoryService.storeUserPrompt(
+          memorySessionId,
+          sanitizeForMemory(normalized.content),
+          {
+            importedFrom: this.stateDbPath,
+            originalTimestamp: timestampToIso(message.timestamp),
+            sourceMessageId: message.id,
+            turnId: currentTurnId,
+            source: 'hermes',
+            hermesSource: session.source,
+            sourceSessionId: session.id,
+            sourceSessionHash: hashLabel(session.id)
+          }
+        );
+
+        if (appendResult.success && appendResult.isDuplicate) {
+          result.skippedDuplicates++;
+        } else {
+          result.importedPrompts++;
+        }
+        setStoredCount(getStoredCount() + 1);
+      } else {
+        textBuffer.push({ content: normalized.content, row: message });
+      }
+
+      const now = Date.now();
+      if (now - lastProgressAt > 200) {
+        lastProgressAt = now;
+        options.onProgress?.({
+          phase: 'session-progress',
+          sessionIndex,
+          messagesProcessed: result.totalMessages,
+          imported: result.importedPrompts + result.importedResponses,
+          skipped: result.skippedDuplicates
+        });
+      }
+    }
+
+    await flushTextBuffer();
+    await this.memoryService.endSession(memorySessionId);
+
+    if (effectiveProjectPath) {
+      registerSession(memorySessionId, effectiveProjectPath);
+    }
+
+    if (options.verbose) {
+      console.log(`Imported ${result.importedPrompts} prompts, ${result.importedResponses} responses from Hermes session ${session.id}`);
+    }
+
+    return result;
+  }
+}
+
+export function createHermesSessionHistoryImporter(
+  memoryService: MemoryService,
+  options: HermesSessionHistoryImporterOptions = {}
+): HermesSessionHistoryImporter {
+  return new HermesSessionHistoryImporter(memoryService, options);
+}

--- a/tests/apps/codex-import-runner.test.ts
+++ b/tests/apps/codex-import-runner.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ImportResult } from '../../src/services/session-history-importer.js';
+
+const { runCodexImportOnce } = await import('../../src/apps/cli/codex-import-runner.js');
+
+function makeImportResult(overrides: Partial<ImportResult> = {}): ImportResult {
+  return {
+    totalSessions: 1,
+    totalMessages: 2,
+    importedPrompts: 1,
+    importedResponses: 1,
+    skippedDuplicates: 0,
+    errors: [],
+    ...overrides
+  };
+}
+
+function makeService() {
+  return {
+    initialize: vi.fn(async () => undefined),
+    shutdown: vi.fn(async () => undefined),
+    processPendingEmbeddings: vi.fn(async () => 2),
+    ensureEmbeddingModelForImport: vi.fn(async () => ({ changed: false, previousModel: null, currentModel: 'test', enqueued: 0 }))
+  };
+}
+
+describe('Codex import runner', () => {
+  let projectService: ReturnType<typeof makeService>;
+  let globalService: ReturnType<typeof makeService>;
+  let importer: {
+    importProject: ReturnType<typeof vi.fn>;
+    importAll: ReturnType<typeof vi.fn>;
+    importSessionFile: ReturnType<typeof vi.fn>;
+  };
+  let deps: Parameters<typeof runCodexImportOnce>[1];
+
+  beforeEach(() => {
+    projectService = makeService();
+    globalService = makeService();
+    importer = {
+      importProject: vi.fn(async () => makeImportResult()),
+      importAll: vi.fn(async () => makeImportResult({ totalSessions: 3 })),
+      importSessionFile: vi.fn(async () => makeImportResult())
+    };
+    deps = {
+      cwd: () => '/repo/current',
+      getDefaultMemoryService: vi.fn(() => globalService as never),
+      getMemoryServiceForProject: vi.fn(() => projectService as never),
+      createImporter: vi.fn(() => importer as never),
+      onProgress: vi.fn()
+    };
+  });
+
+  it('imports the current project from Codex sessions into the project-scoped memory service', async () => {
+    const outcome = await runCodexImportOnce({ sessionsDir: '/tmp/codex-sessions', limit: '9' }, deps);
+
+    expect(deps?.getMemoryServiceForProject).toHaveBeenCalledWith('/repo/current');
+    expect(deps?.getDefaultMemoryService).not.toHaveBeenCalled();
+    expect(deps?.createImporter).toHaveBeenCalledWith(projectService, { sessionsDir: '/tmp/codex-sessions' });
+    expect(projectService.initialize).toHaveBeenCalledTimes(1);
+    expect(projectService.ensureEmbeddingModelForImport).toHaveBeenCalledWith({ autoMigrate: true });
+    expect(importer.importProject).toHaveBeenCalledWith('/repo/current', expect.objectContaining({
+      projectPath: '/repo/current',
+      limit: 9,
+      onProgress: deps?.onProgress
+    }));
+    expect(projectService.processPendingEmbeddings).toHaveBeenCalledTimes(1);
+    expect(projectService.shutdown).toHaveBeenCalledTimes(1);
+    expect(outcome).toMatchObject({ mode: 'project', storageScope: 'project', embedCount: 2 });
+  });
+
+  it('uses global storage only for explicit all-session imports without a project', async () => {
+    const outcome = await runCodexImportOnce({ all: true, processEmbeddings: false }, deps);
+
+    expect(deps?.getDefaultMemoryService).toHaveBeenCalledTimes(1);
+    expect(deps?.getMemoryServiceForProject).not.toHaveBeenCalled();
+    expect(importer.importAll).toHaveBeenCalledWith(expect.objectContaining({ force: undefined }));
+    expect(globalService.processPendingEmbeddings).not.toHaveBeenCalled();
+    expect(globalService.shutdown).toHaveBeenCalledTimes(1);
+    expect(outcome).toMatchObject({ mode: 'all', storageScope: 'global', embedCount: 0 });
+  });
+
+  it('imports a single Codex session file into the selected project scope', async () => {
+    await runCodexImportOnce({ project: '/repo/selected', session: '/tmp/session.jsonl', force: true }, deps);
+
+    expect(deps?.getMemoryServiceForProject).toHaveBeenCalledWith('/repo/selected');
+    expect(importer.importSessionFile).toHaveBeenCalledWith('/tmp/session.jsonl', expect.objectContaining({
+      projectPath: '/repo/selected',
+      force: true
+    }));
+  });
+});

--- a/tests/apps/hermes-import-runner.test.ts
+++ b/tests/apps/hermes-import-runner.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ImportResult } from '../../src/services/session-history-importer.js';
+
+const { runHermesImportOnce } = await import('../../src/apps/cli/hermes-import-runner.js');
+
+function makeImportResult(overrides: Partial<ImportResult> = {}): ImportResult {
+  return {
+    totalSessions: 1,
+    totalMessages: 2,
+    importedPrompts: 1,
+    importedResponses: 1,
+    skippedDuplicates: 0,
+    errors: [],
+    ...overrides
+  };
+}
+
+function makeService() {
+  return {
+    initialize: vi.fn(async () => undefined),
+    shutdown: vi.fn(async () => undefined),
+    processPendingEmbeddings: vi.fn(async () => 2),
+    ensureEmbeddingModelForImport: vi.fn(async () => ({ changed: false, previousModel: null, currentModel: 'test', enqueued: 0 }))
+  };
+}
+
+describe('Hermes import runner', () => {
+  let projectService: ReturnType<typeof makeService>;
+  let globalService: ReturnType<typeof makeService>;
+  let importer: {
+    importProject: ReturnType<typeof vi.fn>;
+    importAll: ReturnType<typeof vi.fn>;
+    importSession: ReturnType<typeof vi.fn>;
+  };
+  let deps: Parameters<typeof runHermesImportOnce>[1];
+
+  beforeEach(() => {
+    projectService = makeService();
+    globalService = makeService();
+    importer = {
+      importProject: vi.fn(async () => makeImportResult()),
+      importAll: vi.fn(async () => makeImportResult({ totalSessions: 3 })),
+      importSession: vi.fn(async () => makeImportResult())
+    };
+    deps = {
+      cwd: () => '/repo/current',
+      getDefaultMemoryService: vi.fn(() => globalService as never),
+      getMemoryServiceForProject: vi.fn(() => projectService as never),
+      createImporter: vi.fn(() => importer as never),
+      onProgress: vi.fn()
+    };
+  });
+
+  it('imports the current project from Hermes state.db into the project-scoped memory service', async () => {
+    const outcome = await runHermesImportOnce({ stateDb: '/tmp/hermes-state.db', limit: '9' }, deps);
+
+    expect(deps?.getMemoryServiceForProject).toHaveBeenCalledWith('/repo/current');
+    expect(deps?.getDefaultMemoryService).not.toHaveBeenCalled();
+    expect(deps?.createImporter).toHaveBeenCalledWith(projectService, { stateDbPath: '/tmp/hermes-state.db' });
+    expect(projectService.initialize).toHaveBeenCalledTimes(1);
+    expect(projectService.ensureEmbeddingModelForImport).toHaveBeenCalledWith({ autoMigrate: true });
+    expect(importer.importProject).toHaveBeenCalledWith('/repo/current', expect.objectContaining({
+      projectPath: '/repo/current',
+      limit: 9,
+      onProgress: deps?.onProgress
+    }));
+    expect(projectService.processPendingEmbeddings).toHaveBeenCalledTimes(1);
+    expect(projectService.shutdown).toHaveBeenCalledTimes(1);
+    expect(outcome).toMatchObject({ mode: 'project', storageScope: 'project', embedCount: 2 });
+  });
+
+  it('uses global storage only for explicit all-session imports without a project', async () => {
+    const outcome = await runHermesImportOnce({ all: true, processEmbeddings: false }, deps);
+
+    expect(deps?.getDefaultMemoryService).toHaveBeenCalledTimes(1);
+    expect(deps?.getMemoryServiceForProject).not.toHaveBeenCalled();
+    expect(importer.importAll).toHaveBeenCalledWith(expect.objectContaining({ force: undefined }));
+    expect(globalService.processPendingEmbeddings).not.toHaveBeenCalled();
+    expect(globalService.shutdown).toHaveBeenCalledTimes(1);
+    expect(outcome).toMatchObject({ mode: 'all', storageScope: 'global', embedCount: 0 });
+  });
+
+  it('imports a single Hermes session into the selected project scope', async () => {
+    await runHermesImportOnce({ project: '/repo/selected', session: '20260505_010203_abcd1234', force: true }, deps);
+
+    expect(deps?.getMemoryServiceForProject).toHaveBeenCalledWith('/repo/selected');
+    expect(importer.importSession).toHaveBeenCalledWith('20260505_010203_abcd1234', expect.objectContaining({
+      projectPath: '/repo/selected',
+      force: true
+    }));
+  });
+});

--- a/tests/core/hermes-session-history-importer-validation.test.ts
+++ b/tests/core/hermes-session-history-importer-validation.test.ts
@@ -1,0 +1,252 @@
+import Database = require('better-sqlite3');
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createHermesSessionHistoryImporter,
+  validateHermesSessions
+} from '../../src/services/hermes-session-history-importer.js';
+
+const tempDirs: string[] = [];
+
+function tempDir() {
+  const dir = mkdtempSync(join(tmpdir(), 'cml-hermes-validation-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function createHermesStateDb(dbPath: string, projectA: string, projectB: string) {
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY,
+      source TEXT NOT NULL,
+      user_id TEXT,
+      model TEXT,
+      model_config TEXT,
+      system_prompt TEXT,
+      parent_session_id TEXT,
+      started_at REAL NOT NULL,
+      ended_at REAL,
+      end_reason TEXT,
+      message_count INTEGER DEFAULT 0,
+      tool_call_count INTEGER DEFAULT 0,
+      title TEXT
+    );
+
+    CREATE TABLE messages (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      role TEXT NOT NULL,
+      content TEXT,
+      tool_call_id TEXT,
+      tool_calls TEXT,
+      tool_name TEXT,
+      timestamp REAL NOT NULL,
+      token_count INTEGER,
+      finish_reason TEXT,
+      reasoning TEXT,
+      reasoning_content TEXT,
+      reasoning_details TEXT,
+      codex_reasoning_items TEXT,
+      codex_message_items TEXT
+    );
+  `);
+
+  const insertSession = db.prepare(`
+    INSERT INTO sessions (id, source, user_id, model, system_prompt, started_at, title, message_count)
+    VALUES (@id, @source, @userId, @model, @systemPrompt, @startedAt, @title, @messageCount)
+  `);
+  const insertMessage = db.prepare(`
+    INSERT INTO messages (session_id, role, content, tool_name, timestamp)
+    VALUES (@sessionId, @role, @content, @toolName, @timestamp)
+  `);
+
+  insertSession.run({
+    id: 'session-a',
+    source: 'discord',
+    userId: 'user-a',
+    model: 'gpt-5.5',
+    systemPrompt: `Project Context\nCurrent Session Context\n${projectA}`,
+    startedAt: 1_779_000_000,
+    title: 'claude-memory-layer thread',
+    messageCount: 4
+  });
+  insertMessage.run({
+    sessionId: 'session-a',
+    role: 'user',
+    content: `please build Hermes SessionDB adapter password=sensitive-fixture-value for ${projectA}`,
+    toolName: null,
+    timestamp: 1_779_000_001
+  });
+  insertMessage.run({
+    sessionId: 'session-a',
+    role: 'assistant',
+    content: 'implemented a safe adapter with token=sensitive-fixture-value and no live sync by default',
+    toolName: null,
+    timestamp: 1_779_000_002
+  });
+  insertMessage.run({
+    sessionId: 'session-a',
+    role: 'tool',
+    content: 'raw terminal output should never be imported',
+    toolName: 'terminal',
+    timestamp: 1_779_000_003
+  });
+  insertMessage.run({
+    sessionId: 'session-a',
+    role: 'assistant',
+    content: '',
+    toolName: null,
+    timestamp: 1_779_000_004
+  });
+
+  insertSession.run({
+    id: 'session-b',
+    source: 'discord',
+    userId: 'user-b',
+    model: 'gpt-5.5',
+    systemPrompt: `Project Context\n${projectB}`,
+    startedAt: 1_779_000_100,
+    title: 'other project thread',
+    messageCount: 1
+  });
+  insertMessage.run({
+    sessionId: 'session-b',
+    role: 'user',
+    content: 'this belongs to another project and should not match project a',
+    toolName: null,
+    timestamp: 1_779_000_101
+  });
+
+  insertSession.run({
+    id: 'session-no-project',
+    source: 'cli',
+    userId: 'user-c',
+    model: 'gpt-5.5',
+    systemPrompt: null,
+    startedAt: 1_779_000_200,
+    title: null,
+    messageCount: 1
+  });
+  insertMessage.run({
+    sessionId: 'session-no-project',
+    role: 'user',
+    content: 'session without project context should be counted as missing context',
+    toolName: null,
+    timestamp: 1_779_000_201
+  });
+
+  db.close();
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('Hermes SessionDB validation/import', () => {
+  it('dry-runs matching Hermes sessions by project context without exposing transcript content', async () => {
+    const dir = tempDir();
+    const stateDbPath = join(dir, 'state.db');
+    const projectA = join(dir, 'project-a');
+    const projectB = join(dir, 'project-b');
+    createHermesStateDb(stateDbPath, projectA, projectB);
+
+    const report = await validateHermesSessions({
+      stateDbPath,
+      projectPath: projectA,
+      now: new Date('2026-05-05T00:00:00.000Z')
+    });
+
+    expect(report.dryRun).toBe(true);
+    expect(report.willMutate).toBe(false);
+    expect(report.source.stateDbPath).toBe(stateDbPath);
+    expect(report.source.projectPath).toBe(projectA);
+    expect(report.source.projectFilterApplied).toBe(true);
+    expect(report.totals.sessionsScanned).toBe(3);
+    expect(report.totals.sessionsMatched).toBe(1);
+    expect(report.totals.messagesRead).toBe(4);
+    expect(report.totals.messagesNormalized).toBe(2);
+    expect(report.totals.turnsNormalized).toBe(1);
+    expect(report.totals.userMessages).toBe(1);
+    expect(report.totals.assistantMessages).toBe(1);
+    expect(report.totals.skippedUnsupportedMessages).toBe(1);
+    expect(report.totals.emptyAssistantMessages).toBe(1);
+    expect(report.totals.missingProjectContext).toBe(1);
+    expect(report.topSources[0]).toMatchObject({ source: 'discord', sessions: 1, userMessages: 1, assistantMessages: 1 });
+
+    const serialized = JSON.stringify(report);
+    expect(serialized).not.toContain('please build Hermes SessionDB adapter');
+    expect(serialized).not.toContain('implemented a safe adapter');
+    expect(serialized).not.toContain('sensitive-fixture-value');
+    expect(serialized).not.toContain('raw terminal output');
+    expect(serialized).not.toContain('another project');
+  });
+
+  it('imports only matched user/assistant turns, redacts secrets, and skips tool messages', async () => {
+    const dir = tempDir();
+    const stateDbPath = join(dir, 'state.db');
+    const projectA = join(dir, 'project-a');
+    const projectB = join(dir, 'project-b');
+    createHermesStateDb(stateDbPath, projectA, projectB);
+
+    const memoryService = {
+      startSession: vi.fn(async (_sessionId: string, _projectPath?: string) => undefined),
+      endSession: vi.fn(async (_sessionId: string) => undefined),
+      deleteSessionEvents: vi.fn(async (_sessionId: string) => 0),
+      storeUserPrompt: vi.fn(async (
+        _sessionId: string,
+        _content: string,
+        _metadata?: Record<string, unknown>
+      ) => ({ success: true, isDuplicate: false })),
+      storeAgentResponse: vi.fn(async (
+        _sessionId: string,
+        _content: string,
+        _metadata?: Record<string, unknown>
+      ) => ({ success: true, isDuplicate: false }))
+    };
+
+    const importer = createHermesSessionHistoryImporter(memoryService as never, { stateDbPath });
+    const result = await importer.importProject(projectA, { force: true });
+
+    expect(memoryService.deleteSessionEvents).toHaveBeenCalledWith('hermes:session-a');
+    expect(memoryService.startSession).toHaveBeenCalledWith('hermes:session-a', projectA);
+    expect(memoryService.endSession).toHaveBeenCalledWith('hermes:session-a');
+    expect(memoryService.storeUserPrompt).toHaveBeenCalledTimes(1);
+    expect(memoryService.storeAgentResponse).toHaveBeenCalledTimes(1);
+
+    const [promptSessionId, promptContent, promptMetadata] = memoryService.storeUserPrompt.mock.calls[0];
+    expect(promptSessionId).toBe('hermes:session-a');
+    expect(promptContent).toContain('[REDACTED]');
+    expect(promptContent).not.toContain('sensitive-fixture-value');
+    expect(promptMetadata).toMatchObject({
+      source: 'hermes',
+      hermesSource: 'discord',
+      sourceSessionId: 'session-a',
+      importedFrom: stateDbPath
+    });
+
+    const [, responseContent, responseMetadata] = memoryService.storeAgentResponse.mock.calls[0];
+    expect(responseContent).toContain('[REDACTED]');
+    expect(responseContent).not.toContain('sensitive-fixture-value');
+    expect(responseMetadata).toMatchObject({
+      source: 'hermes',
+      hermesSource: 'discord',
+      sourceSessionId: 'session-a',
+      importedFrom: stateDbPath
+    });
+
+    expect(result).toMatchObject({
+      totalSessions: 1,
+      totalMessages: 4,
+      importedPrompts: 1,
+      importedResponses: 1,
+      skippedDuplicates: 0,
+      errors: []
+    });
+  });
+});

--- a/tests/core/product-validation-matrix.test.ts
+++ b/tests/core/product-validation-matrix.test.ts
@@ -13,6 +13,9 @@ const requiredSurfaces = [
   'codex.adapter.scan',
   'codex.adapter.import',
   'codex.adapter.replay',
+  'hermes.adapter.scan',
+  'hermes.adapter.import',
+  'hermes.adapter.replay',
   'cli.api.reporting',
   'safety.dryRun'
 ];
@@ -37,13 +40,16 @@ describe('product validation matrix', () => {
     const summary = getProductValidationMatrixSummary(productValidationMatrix);
     expect(summary.totalSurfaces).toBeGreaterThanOrEqual(requiredSurfaces.length);
     expect(summary.surfacesByArea.codex).toBeGreaterThanOrEqual(3);
+    expect(summary.surfacesByArea.hermes).toBeGreaterThanOrEqual(3);
     expect(summary.surfacesByArea.claude).toBeGreaterThanOrEqual(3);
     expect(summary.evidenceCount).toBeGreaterThanOrEqual(requiredSurfaces.length);
 
     const markdown = renderProductValidationMatrixMarkdown(productValidationMatrix);
     expect(markdown).toContain('# Product Validation Matrix');
     expect(markdown).toContain('Codex adapter replay');
+    expect(markdown).toContain('Hermes adapter replay');
     expect(markdown).toContain('Safety / dry-run');
     expect(markdown).toContain('tests/core/codex-session-history-importer-validation.test.ts');
+    expect(markdown).toContain('tests/core/hermes-session-history-importer-validation.test.ts');
   });
 });

--- a/tests/extensions/mcp-project-aware-tools.test.ts
+++ b/tests/extensions/mcp-project-aware-tools.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  function createService() {
+    return {
+      initialize: vi.fn(async () => undefined),
+      retrieveMemories: vi.fn(),
+      getRecentEvents: vi.fn(),
+      getStats: vi.fn()
+    };
+  }
+
+  const defaultService = createService();
+  const projectService = createService();
+
+  return {
+    defaultService,
+    projectService,
+    getDefaultMemoryService: vi.fn(() => defaultService),
+    getMemoryServiceForProject: vi.fn(() => projectService)
+  };
+});
+
+vi.mock('../../src/services/memory-service.js', () => ({
+  getDefaultMemoryService: mocks.getDefaultMemoryService,
+  getMemoryServiceForProject: mocks.getMemoryServiceForProject
+}));
+
+const { handleToolCall } = await import('../../src/extensions/mcp/handlers.js');
+const { tools } = await import('../../src/extensions/mcp/tools.js');
+
+function resetService(service: typeof mocks.defaultService) {
+  service.initialize.mockReset().mockResolvedValue(undefined);
+  service.retrieveMemories.mockReset().mockResolvedValue({ memories: [] });
+  service.getRecentEvents.mockReset().mockResolvedValue([]);
+  service.getStats.mockReset().mockResolvedValue({ totalEvents: 0, vectorCount: 0 });
+}
+
+describe('MCP project-aware memory tools', () => {
+  beforeEach(() => {
+    resetService(mocks.defaultService);
+    resetService(mocks.projectService);
+    mocks.getDefaultMemoryService.mockClear();
+    mocks.getMemoryServiceForProject.mockClear();
+  });
+
+  it('advertises optional projectPath on all memory tools', () => {
+    for (const tool of tools) {
+      expect(tool.inputSchema).toMatchObject({ type: 'object' });
+      const properties = tool.inputSchema.properties as Record<string, unknown>;
+      expect(properties.projectPath).toMatchObject({
+        type: 'string',
+        description: expect.stringContaining('project')
+      });
+    }
+  });
+
+  it('uses the project-scoped memory service when mem-search receives projectPath', async () => {
+    mocks.projectService.retrieveMemories.mockResolvedValue({
+      memories: [
+        {
+          score: 0.91,
+          event: {
+            id: 'event-project-1',
+            sessionId: 'session-a',
+            eventType: 'user_prompt',
+            timestamp: new Date('2026-05-05T00:00:00.000Z'),
+            content: 'project scoped memory result',
+            metadata: {}
+          }
+        }
+      ]
+    });
+
+    const result = await handleToolCall('mem-search', {
+      query: 'project scoped memory',
+      projectPath: '/repo/app',
+      topK: 7,
+      sessionId: 'session-a'
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(mocks.getMemoryServiceForProject).toHaveBeenCalledWith('/repo/app');
+    expect(mocks.getDefaultMemoryService).not.toHaveBeenCalled();
+    expect(mocks.projectService.initialize).toHaveBeenCalledTimes(1);
+    expect(mocks.projectService.retrieveMemories).toHaveBeenCalledWith('project scoped memory', {
+      topK: 7,
+      sessionId: 'session-a'
+    });
+    expect(result.content[0]?.text).toContain('project scoped memory result');
+  });
+
+  it('falls back to the global memory service when projectPath is absent', async () => {
+    await handleToolCall('mem-stats', {});
+
+    expect(mocks.getDefaultMemoryService).toHaveBeenCalledTimes(1);
+    expect(mocks.getMemoryServiceForProject).not.toHaveBeenCalled();
+    expect(mocks.defaultService.initialize).toHaveBeenCalledTimes(1);
+    expect(mocks.defaultService.getStats).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add optional `projectPath` support to MCP memory tools so Claude Code, Codex, and Hermes can query the same project-scoped memory backend.
- Register Codex import CLI for explicit JSONL session ingestion.
- Add Hermes SessionDB validate/replay/import CLI with read-only validation, explicit mutation, project/session scoping, and privacy filtering.
- Update README, validation matrix, and Hermes ingestion analysis docs.

## Validation
- `npm test -- --run tests/core/hermes-session-history-importer-validation.test.ts tests/apps/hermes-import-runner.test.ts tests/core/product-validation-matrix.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm test -- --run`
- `git diff --check`

## Notes
- `npm run lint` is currently blocked because `eslint` executable is not installed in this repo environment.
- Hermes import keeps `~/.hermes/state.db` as the raw source of truth and stores only redacted user/assistant turns by default.