### PR TITLE
feat: add project context MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,9 +437,22 @@ node dist/mcp/index.js
 | 도구 | 설명 |
 |------|------|
 | `mem-search` | 메모리 검색 (`projectPath`를 주면 프로젝트별 저장소 검색) |
-| `mem-timeline` | 타임라인 조회 (`projectPath` 지원) |
+| `mem-timeline` | 특정 memory IDs 주변 chronological context 조회 (`projectPath` 지원) |
 | `mem-details` | 상세 정보 조회 (`projectPath` 지원) |
 | `mem-stats` | 통계 조회 (`projectPath` 지원) |
+| `mem-context-pack` | 작업 시작용 compact context pack. query 관련 memory + 최근 project timeline + follow-up refs를 한 번에 반환 |
+| `mem-project-timeline` | 최근 project memory를 session/source/event-count/safe-preview 기준으로 요약 |
+| `mem-source-ref` | `mem:<citation>` 또는 `event:<id>`를 privacy-safe source reference와 redacted preview로 해석 |
+
+예시 workflow:
+
+```text
+1. 새 작업 시작: mem-context-pack(projectPath, query)
+2. 최근 흐름 확인: mem-project-timeline(projectPath)
+3. 근거가 더 필요할 때: mem-source-ref(projectPath, ids=["mem:abc123"])
+```
+
+이 workflow는 Hermes/Codex/Claude Code가 같은 project-scoped memory backend를 공유할 때 특히 유용합니다. `mem-source-ref`는 raw transcript를 그대로 덤프하지 않고 allowlisted metadata와 privacy-filtered preview만 반환합니다.
 
 ## Web Viewer
 

--- a/docs/HERMES_MEMORY_INGESTION_ANALYSIS.md
+++ b/docs/HERMES_MEMORY_INGESTION_ANALYSIS.md
@@ -14,7 +14,7 @@
    - Hermes의 원본 transcript source-of-truth는 `~/.hermes/state.db`로 둔다.
    - claude-memory-layer는 선택된 Hermes 세션을 project-scoped memory store로 복제/파생한다.
    - 현재 CLI는 `--project`, `--session`, `--all`, `--state-db`, `--limit`, `--force`를 제공한다.
-2. 그 다음 **“최근 맥락/주제 지도 + wiki-link식 상세 ref 읽기” MCP read-only tool**을 만든다.
+2. 그 다음 **“최근 맥락/주제 지도 + wiki-link식 상세 ref 읽기” MCP read-only tool**을 만든다. *(2차 구현 완료: `mem-context-pack`, `mem-project-timeline`, `mem-source-ref`)*
    - 이 기능은 Hermes의 `session_search`와 겹치지만 완전 중복은 아니다.
    - 특히 Claude Code/Codex/Hermes가 같은 프로젝트 memory backend를 공유하려면 의미가 있다.
 3. 마지막으로 필요성이 검증되면 **Hermes external memory provider plugin 방식의 opt-in live sync**를 추가한다.
@@ -154,8 +154,11 @@ Installed plugins: byterover, hindsight, holographic, honcho, mem0, openviking, 
 - `mem-timeline`
 - `mem-details`
 - `mem-stats`
+- `mem-context-pack`
+- `mem-project-timeline`
+- `mem-source-ref`
 
-`projectPath`가 있으면 project store를 조회하고, 없으면 default store를 조회한다.
+`projectPath`가 있으면 project store를 조회하고, 없으면 default store를 조회한다. 특히 context navigator 계열(`mem-context-pack`, `mem-project-timeline`, `mem-source-ref`)은 Hermes/Codex가 작업 시작 전에 project-scoped memory를 빠르게 회수하고, 필요한 근거만 citation/ref로 따라가도록 설계됐다.
 
 ### 2.3 Claude/Codex ingestion
 
@@ -317,45 +320,45 @@ TDD:
 - privacy redaction 검증
 - source/project/session filters 검증
 
-### Phase 2 — topic map + recent context + wiki-link MCP tools
+### Phase 2 — context pack + project timeline + source-ref MCP tools
 
 목표: CML이 “검색 결과 목록”에서 “현재 작업 맥락을 이어주는 context navigator”로 발전.
 
-신규 MCP tools 후보:
+2차 구현 범위:
 
 1. `mem-context-pack`
-   - input: `projectPath`, `query?`, `sessionId?`, `recentHours?`, `topK?`
+   - input: `projectPath`, `query?`, `sessionId?`, `topK?`, `recentLimit?`, `sessionLimit?`
    - output:
-     - 최근 맥락 요약
-     - 주요 topic/decision/open task/code context
-     - 근거 event/session refs
-     - 더 자세히 볼 수 있는 refs
+     - query 관련 memory citations
+     - 최근 project timeline/session summary
+     - follow-up `mem-source-ref` lookup hints
 
-2. `mem-session-topics`
-   - input: `projectPath`, `sessionId`
+2. `mem-project-timeline`
+   - input: `projectPath`, `limit?`, `sessionLimit?`
    - output:
-     - chronological topic segments
-     - 각 segment의 핵심 질문/결론/파일/툴
-     - `memory://project/<hash>/session/<id>/segment/<n>` refs
+     - session별 window, source agent/import source, event counts
+     - privacy-filtered last preview
 
-3. `mem-read-ref`
-   - input: `ref`
+3. `mem-source-ref`
+   - input: `ids`, `projectPath?`, `maxContentChars?`, `lookupLimit?`
+   - 지원 ID 형식: full event ID, `event:<id>`, `mem:<citation>`, bare citation, `[mem:<citation>]`
    - output:
-     - 해당 event/timeline/segment/session detail
-     - 원문은 필요한 만큼만, secrets redacted
+     - source ref, session/type/timestamp
+     - allowlisted metadata only
+     - redacted preview only
 
 예상 UX:
 
 ```text
 최근 claude-memory-layer 맥락:
 1. Codex/Hermes MCP 등록과 projectPath 지원을 구현/검증했다.
-   refs: memory://project/.../session/.../segment/1
-2. Codex import CLI를 TDD로 추가하고 full test 통과했다.
-   refs: memory://project/.../session/.../segment/2
-3. 남은 이슈: eslint missing, generated memory/ untracked, Hermes ingestion 설계.
-   refs: memory://project/.../session/.../segment/3
+   refs: mem:abc123
+2. Hermes explicit import/validate/replay CLI를 TDD로 추가했다.
+   refs: mem:def456
+3. 남은 이슈: eslint missing, privacy hardening, optional live provider.
+   refs: mem:789abc
 
-더 자세히 필요하면 mem-read-ref로 ref를 열어라.
+더 자세히 필요하면 mem-source-ref로 ref를 열어라.
 ```
 
 이 기능은 Hermes `session_search`와 다르다.
@@ -407,10 +410,10 @@ Provider responsibilities:
 
 2. **CML context navigator MCP tools**
    - `mem-context-pack`
-   - `mem-session-topics`
-   - `mem-read-ref`
+   - `mem-project-timeline`
+   - `mem-source-ref`
 
-이 두 가지는 사용자가 말한 “최근 맥락 중심 context + wiki link처럼 더 깊은 memory file/detail 읽기” 니즈에 직접 대응한다.
+이 두 가지는 사용자가 말한 “최근 맥락 중심 context + wiki link처럼 더 깊은 memory file/detail 읽기” 니즈에 직접 대응한다. Phase 2 도구는 raw transcript dumping 대신 citation/ref 기반 follow-up과 redacted preview를 기본으로 한다.
 
 ### 지금 만들지 말 것
 

--- a/docs/PRODUCT_VALIDATION_MATRIX.md
+++ b/docs/PRODUCT_VALIDATION_MATRIX.md
@@ -15,6 +15,9 @@ This document mirrors the tested matrix in `src/core/product-validation-matrix.t
 | Hermes | Hermes adapter scan | ready | Read Hermes `~/.hermes/state.db` in read-only mode, match project context, and aggregate unsupported/empty/truncated counts without transcript content. |
 | Hermes | Hermes adapter import | covered | `hermes import` exposes project/session/all imports while preserving SessionDB as raw source-of-truth and storing only redacted user/assistant turns. |
 | Hermes | Hermes adapter replay | ready | Normalize Hermes SessionDB rows into aggregate replay reports without transcript content or secrets. |
+| MCP | MCP context pack | covered | Combine relevant project memories and recent timeline into agent-ready startup context with citations/follow-up refs. |
+| MCP | MCP project timeline | covered | Summarize recent project memory by session, source agent, event counts, and safe preview. |
+| MCP | MCP source reference | covered | Resolve event/mem citation refs into redacted source previews with safe metadata only. |
 | CLI/API | CLI / API / reporting | ready | Provide `claude-memory-layer codex validate` / `codex replay` and `hermes validate` / `hermes replay` with JSON/Markdown reports. |
 | Safety | Safety / dry-run | ready | Default Codex/Hermes validation is read-only, avoids Claude settings/memory mutation, and can exclude transcript content from reports. |
 
@@ -45,6 +48,16 @@ Reports include only aggregate counts: sessions scanned/matched, records read, m
 
 Reports include only aggregate counts: sessions scanned/matched, messages read/normalized, turns normalized, user/assistant counts, skipped/unsupported messages, empty assistant messages, truncated messages, missing project context, warnings, top sources, and source paths. Transcript text is never included in validation reports.
 
+## MCP context navigator requirements
+
+The MCP server exposes read-only project context navigation for Claude Desktop, Codex, Hermes, and other MCP clients. These tools support the same optional `projectPath` scoping as `mem-search`/`mem-stats`:
+
+- `mem-context-pack`: agent startup context pack. It combines relevant retrieval results (`query`, `topK`, optional `sessionId`) with a bounded recent project timeline (`recentLimit`, `sessionLimit`) and returns follow-up citation refs.
+- `mem-project-timeline`: recent project memory grouped by session, source agent/import source, event counts, and a privacy-filtered last preview.
+- `mem-source-ref`: resolves `event:<id>`, full event IDs, `mem:<citation>`, bare citation IDs, or `[mem:<citation>]` into source metadata and a redacted preview.
+
+The tools are intentionally context/navigation-oriented rather than mutation APIs. `mem-source-ref` uses a narrow safe metadata allowlist and shared privacy filtering before returning previews; raw transcript dumps should use lower-level detail APIs only when explicitly needed.
+
 ## Codex import requirements
 
 `claude-memory-layer codex import` is the explicit mutation path. It supports:
@@ -61,6 +74,9 @@ Reports include only aggregate counts: sessions scanned/matched, messages read/n
 - `tests/core/codex-session-history-importer-validation.test.ts` covers Codex dry-run scan/replay, cwd project matching, malformed lines, unsupported/tool-ish records, empty assistant messages, large/truncated content, missing cwd, all-session summary, and transcript exclusion.
 - `tests/apps/codex-validation-output.test.ts` covers JSON and Markdown reporting helpers.
 - `tests/apps/codex-import-runner.test.ts` covers explicit Codex import routing for project, session, and global all-session modes.
+- `tests/extensions/mcp-context-tools.test.ts` covers MCP context-pack/timeline/source-ref routing, output shape, citation refs, safe previews, and secret redaction.
+- `src/extensions/mcp/tools.ts` defines MCP schemas for search/timeline/details/stats and the context navigator tools.
+- `src/extensions/mcp/handlers.ts` implements project-aware MCP tool dispatch and privacy-safe context navigation formatting.
 - `src/services/codex-session-history-importer.ts` implements read-only scan/normalize/validate helpers in addition to existing explicit Codex import APIs.
 - `src/apps/cli/codex-import-runner.ts` implements the safe import command runner.
 - `src/apps/cli/index.ts` exposes the user-facing commands.

--- a/src/core/engine/retrieval-orchestrator.ts
+++ b/src/core/engine/retrieval-orchestrator.ts
@@ -24,6 +24,11 @@ export interface RetrieveMemoriesOptions {
   projectScopeMode?: ProjectScopeMode;
   allowedProjectHashes?: string[];
   strategy?: RetrievalStrategy;
+  /**
+   * Disable automatic retrieval trace writes for read-only/navigation callers
+   * that may receive secret-bearing ad-hoc queries.
+   */
+  recordTrace?: boolean;
 }
 
 export interface RecordQueryTraceInput {
@@ -100,6 +105,7 @@ export class RetrievalOrchestrator {
     query: string,
     options?: RetrieveMemoriesOptions
   ): Promise<UnifiedRetrievalResult> {
+    const { recordTrace = true, ...retrieverOptions } = options ?? {};
     const lightweightFastRead = this.isLightweightFastRead(options);
     if (!lightweightFastRead) {
       await this.deps.initialize();
@@ -111,35 +117,37 @@ export class RetrievalOrchestrator {
       ? undefined
       : await this.getRerankWeights(options?.adaptiveRerank === true);
     const projectHash = this.deps.getProjectHash();
-    const projectScopeMode = options?.projectScopeMode ?? (projectHash ? 'strict' : 'global');
+    const projectScopeMode = retrieverOptions.projectScopeMode ?? (projectHash ? 'strict' : 'global');
 
     let result: UnifiedRetrievalResult;
 
-    if (options?.includeShared && this.deps.hasSharedStore()) {
+    if (retrieverOptions.includeShared && this.deps.hasSharedStore()) {
       result = await this.deps.retriever.retrieveUnified(query, {
-        ...options,
-        intentRewrite: options.intentRewrite === true,
+        ...retrieverOptions,
+        intentRewrite: retrieverOptions.intentRewrite === true,
         rerankWeights,
         includeShared: true,
         projectHash: projectHash || undefined,
         projectScopeMode,
-        allowedProjectHashes: options.allowedProjectHashes
+        allowedProjectHashes: retrieverOptions.allowedProjectHashes
       });
     } else {
       result = await this.deps.retriever.retrieve(query, {
-        ...options,
-        intentRewrite: options?.intentRewrite === true,
+        ...retrieverOptions,
+        intentRewrite: retrieverOptions.intentRewrite === true,
         rerankWeights,
         projectHash: projectHash || undefined,
         projectScopeMode,
-        allowedProjectHashes: options?.allowedProjectHashes
+        allowedProjectHashes: retrieverOptions.allowedProjectHashes
       });
     }
 
-    try {
-      await this.recordAutomaticTrace(query, result, options, projectHash);
-    } catch {
-      // Non-blocking telemetry.
+    if (recordTrace) {
+      try {
+        await this.recordAutomaticTrace(query, result, options, projectHash);
+      } catch {
+        // Non-blocking telemetry.
+      }
     }
 
     return result;

--- a/src/core/privacy/filter.ts
+++ b/src/core/privacy/filter.ts
@@ -32,6 +32,15 @@ const SENSITIVE_PATTERNS = [
   /sk-[a-zA-Z0-9]{48}/g,   // OpenAI API Key
 ];
 
+function maskSensitiveString(value: string): string {
+  let filtered = value;
+  for (const pattern of SENSITIVE_PATTERNS) {
+    pattern.lastIndex = 0;
+    filtered = filtered.replace(pattern, '[REDACTED]');
+  }
+  return filtered;
+}
+
 /**
  * Apply privacy filter to content
  */
@@ -118,20 +127,18 @@ export function maskSensitiveInput(
       result[key] = '[REDACTED]';
     } else if (typeof value === 'string') {
       // Apply pattern filtering to string values
-      let filtered = value;
-      for (const pattern of SENSITIVE_PATTERNS) {
-        pattern.lastIndex = 0;
-        filtered = filtered.replace(pattern, '[REDACTED]');
-      }
-      result[key] = filtered;
+      result[key] = maskSensitiveString(value);
     } else if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
       result[key] = maskSensitiveInput(value as Record<string, unknown>);
     } else if (Array.isArray(value)) {
-      result[key] = value.map(item =>
-        typeof item === 'object' && item !== null
+      result[key] = value.map(item => {
+        if (typeof item === 'string') {
+          return isSensitiveKey ? '[REDACTED]' : maskSensitiveString(item);
+        }
+        return typeof item === 'object' && item !== null
           ? maskSensitiveInput(item as Record<string, unknown>)
-          : item
-      );
+          : item;
+      });
     } else {
       result[key] = value;
     }

--- a/src/core/product-validation-matrix.ts
+++ b/src/core/product-validation-matrix.ts
@@ -5,7 +5,7 @@
  * same surface -> requirement -> evidence map that tests assert stays covered.
  */
 
-export type ProductValidationArea = 'claude' | 'codex' | 'hermes' | 'cli' | 'safety';
+export type ProductValidationArea = 'claude' | 'codex' | 'hermes' | 'mcp' | 'cli' | 'safety';
 export type ProductValidationStatus = 'ready' | 'covered' | 'partial' | 'planned';
 export type ProductValidationEvidenceKind = 'test' | 'source' | 'command' | 'doc';
 
@@ -173,6 +173,53 @@ export const productValidationMatrix: readonly ProductValidationSurface[] = [
     ]
   },
   {
+    id: 'mcp.context.pack',
+    area: 'mcp',
+    title: 'MCP context pack',
+    status: 'covered',
+    requirements: [
+      'Expose an agent-ready project context pack that combines relevant retrieval results with recent project timeline.',
+      'Support projectPath scoping so Hermes, Codex, and Claude Code can share the same project memory backend.',
+      'Keep output compact and citation-oriented so agents can follow up with source-ref or timeline tools.'
+    ],
+    evidence: [
+      { kind: 'test', ref: 'tests/extensions/mcp-context-tools.test.ts', note: 'Asserts context-pack output, projectPath routing, compact relevant memory citations, and recent timeline inclusion.' },
+      { kind: 'source', ref: 'src/extensions/mcp/handlers.ts', note: 'mem-context-pack handler formats relevant memories plus session summaries.' },
+      { kind: 'source', ref: 'src/extensions/mcp/tools.ts', note: 'MCP tool schema advertises projectPath, topK, recentLimit, and sessionLimit options.' }
+    ]
+  },
+  {
+    id: 'mcp.project.timeline',
+    area: 'mcp',
+    title: 'MCP project timeline',
+    status: 'covered',
+    requirements: [
+      'Summarize recent project memories by session, source agent, event counts, and last safe preview.',
+      'Avoid raw transcript dumps while still giving enough continuity for another agent to resume work.'
+    ],
+    evidence: [
+      { kind: 'test', ref: 'tests/extensions/mcp-context-tools.test.ts', note: 'Asserts session grouping, source-agent metadata, and event type counts.' },
+      { kind: 'source', ref: 'src/extensions/mcp/handlers.ts', note: 'mem-project-timeline groups recent events by session and source.' },
+      { kind: 'source', ref: 'src/extensions/mcp/tools.ts', note: 'MCP tool schema advertises limit/sessionLimit/projectPath options.' }
+    ]
+  },
+  {
+    id: 'mcp.source.ref',
+    area: 'mcp',
+    title: 'MCP source reference',
+    status: 'covered',
+    requirements: [
+      'Resolve event IDs, event: references, and mem citation IDs into source references.',
+      'Return privacy-safe redacted previews and a narrow allowlist of metadata instead of raw transcript content.',
+      'Support projectPath scoping for project-specific memory stores.'
+    ],
+    evidence: [
+      { kind: 'test', ref: 'tests/extensions/mcp-context-tools.test.ts', note: 'Asserts citation lookup, secret redaction, and safe metadata allowlist.' },
+      { kind: 'source', ref: 'src/extensions/mcp/handlers.ts', note: 'mem-source-ref applies privacy filtering and safe metadata selection.' },
+      { kind: 'source', ref: 'src/core/privacy/filter.ts', note: 'Shared privacy filter masks sensitive patterns before output.' }
+    ]
+  },
+  {
     id: 'cli.api.reporting',
     area: 'cli',
     title: 'CLI / API / reporting',
@@ -212,7 +259,7 @@ export const productValidationMatrix: readonly ProductValidationSurface[] = [
 ];
 
 function emptyAreaCounts(): Record<ProductValidationArea, number> {
-  return { claude: 0, codex: 0, hermes: 0, cli: 0, safety: 0 };
+  return { claude: 0, codex: 0, hermes: 0, mcp: 0, cli: 0, safety: 0 };
 }
 
 function emptyStatusCounts(): Record<ProductValidationStatus, number> {

--- a/src/extensions/mcp/handlers.ts
+++ b/src/extensions/mcp/handlers.ts
@@ -9,6 +9,8 @@ import {
   type MemoryService
 } from '../../services/memory-service.js';
 import { generateCitationId } from '../../core/citation-generator.js';
+import { applyPrivacyFilter, maskSensitiveInput } from '../../core/privacy/filter.js';
+import type { Config, EventType, MemoryEvent } from '../../core/types.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
 type ToolResult = CallToolResult;
@@ -44,6 +46,15 @@ export async function handleToolCall(
       case 'mem-stats':
         return await handleMemStats(memoryService);
 
+      case 'mem-context-pack':
+        return await handleMemContextPack(memoryService, args);
+
+      case 'mem-project-timeline':
+        return await handleMemProjectTimeline(memoryService, args);
+
+      case 'mem-source-ref':
+        return await handleMemSourceRef(memoryService, args);
+
       default:
         return {
           content: [{ type: 'text', text: `Unknown tool: ${name}` }],
@@ -64,7 +75,8 @@ async function handleMemSearch(memoryService: MemoryService, args: Record<string
 
   const result = await memoryService.retrieveMemories(query, {
     topK,
-    sessionId: args.sessionId as string
+    sessionId: args.sessionId as string,
+    recordTrace: false
   });
 
   const lines: string[] = [
@@ -186,6 +198,316 @@ async function handleMemDetails(memoryService: MemoryService, args: Record<strin
   return {
     content: [{ type: 'text', text: lines.join('\n') }]
   };
+}
+
+async function handleMemContextPack(memoryService: MemoryService, args: Record<string, unknown>): Promise<ToolResult> {
+  const query = stringArg(args.query, 'recent project context');
+  const topK = numberArg(args.topK, 5, 1, 12);
+  const recentLimit = numberArg(args.recentLimit, 30, 1, 200);
+  const sessionLimit = numberArg(args.sessionLimit, 5, 1, 20);
+  const sessionId = optionalString(args.sessionId);
+
+  const [searchResult, recentEvents] = await Promise.all([
+    memoryService.retrieveMemories(query, { topK, sessionId, recordTrace: false }),
+    memoryService.getRecentEvents(recentLimit)
+  ]);
+
+  const lines: string[] = [
+    '## Project Context Pack',
+    '',
+    `- Query: ${safeInline(query, 160)}`,
+    `- Relevant memories: ${searchResult.memories.length}`,
+    `- Recent events inspected: ${recentEvents.length}`,
+    `- Recent sessions shown: ${Math.min(sessionLimit, summarizeSessions(recentEvents, sessionLimit).length)}`,
+    '',
+    '### Relevant Memories',
+    ''
+  ];
+
+  if (searchResult.memories.length === 0) {
+    lines.push('No relevant memories found.', '');
+  } else {
+    for (let i = 0; i < searchResult.memories.length; i++) {
+      const match = searchResult.memories[i];
+      lines.push(formatRelevantMemoryLine(match.event, match.score, i + 1));
+    }
+  }
+
+  lines.push('### Recent Project Timeline', '');
+  const sessions = summarizeSessions(recentEvents, sessionLimit);
+  if (sessions.length === 0) {
+    lines.push('No recent project events found.', '');
+  } else {
+    for (const session of sessions) {
+      lines.push(formatSessionSummary(session));
+    }
+  }
+
+  const sourceIds = searchResult.memories
+    .slice(0, 5)
+    .map((match) => generateCitationId(match.event.id));
+  if (sourceIds.length > 0) {
+    lines.push('### Follow-up Lookups', '');
+    lines.push(`- Source refs: mem-source-ref ids=[${sourceIds.map((id) => `'${id}'`).join(', ')}]`);
+    lines.push('- Wider timeline: mem-project-timeline with the same projectPath');
+    lines.push('');
+  }
+
+  return textResult(lines.join('\n'));
+}
+
+async function handleMemProjectTimeline(memoryService: MemoryService, args: Record<string, unknown>): Promise<ToolResult> {
+  const limit = numberArg(args.limit, 50, 1, 500);
+  const sessionLimit = numberArg(args.sessionLimit, 10, 1, 50);
+  const recentEvents = await memoryService.getRecentEvents(limit);
+  const sessions = summarizeSessions(recentEvents, sessionLimit);
+
+  const lines: string[] = [
+    '## Project Memory Timeline',
+    '',
+    `Events inspected: ${recentEvents.length}`,
+    `Sessions shown: ${sessions.length}`,
+    ''
+  ];
+
+  if (sessions.length === 0) {
+    lines.push('No recent project events found.', '');
+  } else {
+    for (const session of sessions) {
+      lines.push(formatSessionSummary(session));
+    }
+  }
+
+  return textResult(lines.join('\n'));
+}
+
+async function handleMemSourceRef(memoryService: MemoryService, args: Record<string, unknown>): Promise<ToolResult> {
+  const ids = Array.isArray(args.ids)
+    ? args.ids.map((id) => String(id)).filter((id) => id.trim().length > 0)
+    : [];
+  const maxContentChars = numberArg(args.maxContentChars, 500, 80, 2000);
+  const lookupLimit = numberArg(args.lookupLimit, 10000, 1, 50000);
+  const recentEvents = await memoryService.getRecentEvents(lookupLimit);
+
+  const lines: string[] = ['## Source References', ''];
+
+  if (ids.length === 0) {
+    lines.push('No IDs supplied.', '');
+    return textResult(lines.join('\n'));
+  }
+
+  for (const requestedId of ids) {
+    const event = findEventByReference(recentEvents, requestedId);
+    if (!event) {
+      lines.push(`### ${safeInline(requestedId, 80)} not found`, '');
+      continue;
+    }
+
+    const citationId = generateCitationId(event.id);
+    const metadata = safeMetadata(event.metadata);
+    lines.push(`### [mem:${citationId}]`);
+    lines.push(`- Event ID: ${event.id}`);
+    lines.push(`- Source Ref: event:${event.id}`);
+    lines.push(`- Source Type: ${sourceTypeForEvent(event)}`);
+    lines.push(`- Session: ${event.sessionId}`);
+    lines.push(`- Type: ${event.eventType}`);
+    lines.push(`- Timestamp: ${event.timestamp.toISOString()}`);
+
+    const metadataLines = Object.entries(metadata).map(([key, value]) => `  - ${key}: ${formatMetadataValue(value)}`);
+    if (metadataLines.length > 0) {
+      lines.push('- Safe Metadata:');
+      lines.push(...metadataLines);
+    }
+
+    lines.push('- Redacted Preview:');
+    lines.push(`  > ${safeInline(event.content, maxContentChars)}`);
+    lines.push('');
+  }
+
+  return textResult(lines.join('\n'));
+}
+
+interface SessionSummary {
+  sessionId: string;
+  firstAt: Date;
+  lastAt: Date;
+  events: MemoryEvent[];
+  eventCounts: Record<EventType, number>;
+  source: string;
+  lastPreview: string;
+}
+
+function summarizeSessions(events: MemoryEvent[], sessionLimit: number): SessionSummary[] {
+  const bySession = new Map<string, MemoryEvent[]>();
+  for (const event of events) {
+    const sessionEvents = bySession.get(event.sessionId) || [];
+    sessionEvents.push(event);
+    bySession.set(event.sessionId, sessionEvents);
+  }
+
+  return Array.from(bySession.entries())
+    .map(([sessionId, sessionEvents]) => {
+      const sorted = sessionEvents.slice().sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+      const last = sorted[sorted.length - 1];
+      return {
+        sessionId,
+        firstAt: sorted[0].timestamp,
+        lastAt: last.timestamp,
+        events: sorted,
+        eventCounts: countEventTypes(sorted),
+        source: dominantSource(sorted),
+        lastPreview: safeInline(last.content, 180)
+      };
+    })
+    .sort((a, b) => b.lastAt.getTime() - a.lastAt.getTime())
+    .slice(0, sessionLimit);
+}
+
+function countEventTypes(events: MemoryEvent[]): Record<EventType, number> {
+  return events.reduce((acc, event) => {
+    acc[event.eventType] = (acc[event.eventType] || 0) + 1;
+    return acc;
+  }, {} as Record<EventType, number>);
+}
+
+function dominantSource(events: MemoryEvent[]): string {
+  const counts = new Map<string, number>();
+  for (const event of events) {
+    const source = sourceForEvent(event);
+    counts.set(source, (counts.get(source) || 0) + 1);
+  }
+
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0]?.[0] || 'unknown';
+}
+
+function sourceForEvent(event: MemoryEvent): string {
+  const metadata = event.metadata || {};
+  for (const key of ['sourceAgent', 'agent', 'source']) {
+    const value = metadata[key];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      const safeSource = safeInline(value.trim(), 120);
+      return safeSource.length > 0 ? safeSource : 'unknown';
+    }
+  }
+  return 'native';
+}
+
+function sourceTypeForEvent(event: MemoryEvent): string {
+  if (event.eventType === 'tool_observation') return 'tool_output';
+  if (typeof event.metadata?.importedFrom === 'string') return 'imported_history';
+  if (typeof event.metadata?.transcriptPath === 'string') return 'transcript';
+  return 'raw_event';
+}
+
+function formatRelevantMemoryLine(event: MemoryEvent, score: number, index: number): string {
+  const citationId = generateCitationId(event.id);
+  return [
+    `${index}. [mem:${citationId}] score=${score.toFixed(2)} type=${event.eventType} date=${event.timestamp.toISOString()} session=${event.sessionId}`,
+    `   source=${sourceForEvent(event)}`,
+    `   ${safeInline(event.content, 260)}`,
+    ''
+  ].join('\n');
+}
+
+function formatSessionSummary(session: SessionSummary): string {
+  const countSummary = (Object.entries(session.eventCounts) as Array<[EventType, number]>)
+    .map(([type, count]) => `${type}: ${count}`)
+    .join(', ');
+  return [
+    `- Session: ${session.sessionId}`,
+    `  Window: ${session.firstAt.toISOString()} → ${session.lastAt.toISOString()}`,
+    `  Events: ${session.events.length}`,
+    `  Source: ${session.source}`,
+    `  Counts: ${countSummary || 'n/a'}`,
+    `  Last: ${session.lastPreview}`,
+    ''
+  ].join('\n');
+}
+
+function findEventByReference(events: MemoryEvent[], requestedId: string): MemoryEvent | undefined {
+  const raw = requestedId.trim();
+  const normalized = normalizeReference(raw);
+  return events.find((event) => {
+    const citationId = generateCitationId(event.id);
+    return event.id === normalized ||
+      event.id === raw ||
+      `event:${event.id}` === raw ||
+      citationId === normalized ||
+      `mem:${citationId}` === raw ||
+      `[mem:${citationId}]` === raw;
+  });
+}
+
+function normalizeReference(id: string): string {
+  let normalized = id.trim();
+  const memMatch = normalized.match(/^\[?mem:([A-Za-z0-9]{6})\]?$/);
+  if (memMatch) return memMatch[1];
+  if (normalized.startsWith('event:')) normalized = normalized.slice('event:'.length);
+  return normalized;
+}
+
+const SAFE_METADATA_KEYS = new Set([
+  'source',
+  'sourceAgent',
+  'agent',
+  'model',
+  'provider',
+  'toolName',
+  'turnId',
+  'messageId',
+  'role'
+]);
+
+function safeMetadata(metadata: Record<string, unknown> | undefined): Record<string, unknown> {
+  if (!metadata) return {};
+  const allowed: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (SAFE_METADATA_KEYS.has(key)) allowed[key] = value;
+  }
+  return maskSensitiveInput(allowed);
+}
+
+const MCP_PRIVACY_CONFIG: Config['privacy'] = {
+  excludePatterns: ['password', 'secret', 'api_key', 'api-key', 'token', 'bearer'],
+  anonymize: false,
+  privateTags: {
+    enabled: true,
+    marker: '[REDACTED]',
+    preserveLineCount: false,
+    supportedFormats: ['xml', 'bracket', 'comment']
+  }
+};
+
+function safeInline(content: string, maxLength: number): string {
+  const filtered = applyPrivacyFilter(content, MCP_PRIVACY_CONFIG).content;
+  const normalized = filtered.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, Math.max(0, maxLength - 3))}...`;
+}
+
+function stringArg(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : fallback;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function numberArg(value: unknown, fallback: number, min: number, max: number): number {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(max, Math.max(min, Math.floor(parsed)));
+}
+
+function formatMetadataValue(value: unknown): string {
+  if (Array.isArray(value)) return value.map((item) => formatMetadataValue(item)).join(', ');
+  if (value && typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+function textResult(text: string): ToolResult {
+  return { content: [{ type: 'text', text }] };
 }
 
 async function handleMemStats(memoryService: MemoryService): Promise<ToolResult> {

--- a/src/extensions/mcp/tools.ts
+++ b/src/extensions/mcp/tools.ts
@@ -84,5 +84,77 @@ export const tools: Tool[] = [
         projectPath: projectPathProperty
       }
     }
+  },
+  {
+    name: 'mem-context-pack',
+    description: 'Build a compact, agent-ready project context pack from relevant memories plus recent project timeline. Use at the start of Hermes/Codex work to recover the important project state without reading raw transcripts.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Optional task/topic query. Defaults to recent project context.'
+        },
+        topK: {
+          type: 'number',
+          description: 'Maximum relevant memories to include (default: 5, max: 12)'
+        },
+        recentLimit: {
+          type: 'number',
+          description: 'Maximum recent events to inspect for project timeline (default: 30, max: 200)'
+        },
+        sessionLimit: {
+          type: 'number',
+          description: 'Maximum recent sessions to summarize (default: 5, max: 20)'
+        },
+        sessionId: {
+          type: 'string',
+          description: 'Optional: filter relevant memories by specific session ID'
+        },
+        projectPath: projectPathProperty
+      }
+    }
+  },
+  {
+    name: 'mem-project-timeline',
+    description: 'Summarize recent project memory by session, source agent, event counts, and safe previews. Useful for understanding what happened recently before continuing work.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        limit: {
+          type: 'number',
+          description: 'Maximum recent events to inspect (default: 50, max: 500)'
+        },
+        sessionLimit: {
+          type: 'number',
+          description: 'Maximum sessions to summarize (default: 10, max: 50)'
+        },
+        projectPath: projectPathProperty
+      }
+    }
+  },
+  {
+    name: 'mem-source-ref',
+    description: 'Resolve memory IDs, mem citation IDs, or event: IDs into privacy-safe source references with redacted previews and safe metadata only. Prefer this before mem-details when raw transcript exposure is unnecessary.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ids: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Memory/event IDs to resolve. Accepts full event IDs, event:<id>, mem:<citation>, or bare citation IDs.'
+        },
+        maxContentChars: {
+          type: 'number',
+          description: 'Maximum redacted preview characters per source (default: 500, max: 2000)'
+        },
+        lookupLimit: {
+          type: 'number',
+          description: 'Maximum recent events to scan for ID resolution (default: 10000, max: 50000)'
+        },
+        projectPath: projectPathProperty
+      },
+      required: ['ids']
+    }
   }
 ];

--- a/tests/core/product-validation-matrix.test.ts
+++ b/tests/core/product-validation-matrix.test.ts
@@ -16,6 +16,9 @@ const requiredSurfaces = [
   'hermes.adapter.scan',
   'hermes.adapter.import',
   'hermes.adapter.replay',
+  'mcp.context.pack',
+  'mcp.project.timeline',
+  'mcp.source.ref',
   'cli.api.reporting',
   'safety.dryRun'
 ];
@@ -41,6 +44,7 @@ describe('product validation matrix', () => {
     expect(summary.totalSurfaces).toBeGreaterThanOrEqual(requiredSurfaces.length);
     expect(summary.surfacesByArea.codex).toBeGreaterThanOrEqual(3);
     expect(summary.surfacesByArea.hermes).toBeGreaterThanOrEqual(3);
+    expect(summary.surfacesByArea.mcp).toBeGreaterThanOrEqual(3);
     expect(summary.surfacesByArea.claude).toBeGreaterThanOrEqual(3);
     expect(summary.evidenceCount).toBeGreaterThanOrEqual(requiredSurfaces.length);
 
@@ -48,6 +52,8 @@ describe('product validation matrix', () => {
     expect(markdown).toContain('# Product Validation Matrix');
     expect(markdown).toContain('Codex adapter replay');
     expect(markdown).toContain('Hermes adapter replay');
+    expect(markdown).toContain('MCP context pack');
+    expect(markdown).toContain('MCP source reference');
     expect(markdown).toContain('Safety / dry-run');
     expect(markdown).toContain('tests/core/codex-session-history-importer-validation.test.ts');
     expect(markdown).toContain('tests/core/hermes-session-history-importer-validation.test.ts');

--- a/tests/core/retrieval-orchestrator.test.ts
+++ b/tests/core/retrieval-orchestrator.test.ts
@@ -101,6 +101,35 @@ describe('RetrievalOrchestrator', () => {
     });
   });
 
+  it('can skip automatic trace recording for read-only retrieval callers', async () => {
+    const traces: Array<Record<string, unknown>> = [];
+    const fakeRetriever = {
+      setQueryRewriter() {},
+      async retrieve() {
+        return retrievalResult('readonly-e1');
+      }
+    } as unknown as Retriever;
+
+    const orchestrator = new RetrievalOrchestrator({
+      initialize: async () => {},
+      retriever: fakeRetriever,
+      traceStore: {
+        getHelpfulnessStats: async () => stats(),
+        recordRetrievalTrace: async (input) => { traces.push(input); }
+      },
+      accessStore: noopAccessStore(),
+      getProjectHash: () => 'project-readonly',
+      hasSharedStore: () => false
+    });
+
+    await orchestrator.retrieveMemories('secret-bearing read-only query', {
+      topK: 3,
+      recordTrace: false
+    });
+
+    expect(traces).toEqual([]);
+  });
+
   it('does not run full runtime initialization for local fast retrieval', async () => {
     let initialized = 0;
     let statsReads = 0;

--- a/tests/extensions/mcp-context-tools.test.ts
+++ b/tests/extensions/mcp-context-tools.test.ts
@@ -1,0 +1,259 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { generateCitationId } from '../../src/core/citation-generator.js';
+import type { MemoryEvent } from '../../src/core/types.js';
+
+const mocks = vi.hoisted(() => {
+  function createService() {
+    return {
+      initialize: vi.fn(async () => undefined),
+      retrieveMemories: vi.fn(),
+      getRecentEvents: vi.fn(),
+      getStats: vi.fn()
+    };
+  }
+
+  const defaultService = createService();
+  const projectService = createService();
+
+  return {
+    defaultService,
+    projectService,
+    getDefaultMemoryService: vi.fn(() => defaultService),
+    getMemoryServiceForProject: vi.fn(() => projectService)
+  };
+});
+
+vi.mock('../../src/services/memory-service.js', () => ({
+  getDefaultMemoryService: mocks.getDefaultMemoryService,
+  getMemoryServiceForProject: mocks.getMemoryServiceForProject
+}));
+
+const { handleToolCall } = await import('../../src/extensions/mcp/handlers.js');
+const { tools } = await import('../../src/extensions/mcp/tools.js');
+
+function resetService(service: typeof mocks.defaultService) {
+  service.initialize.mockReset().mockResolvedValue(undefined);
+  service.retrieveMemories.mockReset().mockResolvedValue({ memories: [] });
+  service.getRecentEvents.mockReset().mockResolvedValue([]);
+  service.getStats.mockReset().mockResolvedValue({ totalEvents: 0, vectorCount: 0, levelStats: [] });
+}
+
+function event(overrides: Partial<MemoryEvent>): MemoryEvent {
+  return {
+    id: 'event-1',
+    eventType: 'user_prompt',
+    sessionId: 'session-a',
+    timestamp: new Date('2026-05-05T00:00:00.000Z'),
+    content: 'memory content',
+    canonicalKey: 'canonical:event-1',
+    dedupeKey: 'dedupe:event-1',
+    metadata: {},
+    ...overrides
+  };
+}
+
+function textOf(result: Awaited<ReturnType<typeof handleToolCall>>): string {
+  return String(result.content[0]?.text ?? '');
+}
+
+describe('MCP project context tools', () => {
+  beforeEach(() => {
+    resetService(mocks.defaultService);
+    resetService(mocks.projectService);
+    mocks.getDefaultMemoryService.mockClear();
+    mocks.getMemoryServiceForProject.mockClear();
+  });
+
+  it('advertises context-pack, project-timeline, and source-ref tools with projectPath support', () => {
+    const byName = new Map(tools.map((tool) => [tool.name, tool]));
+
+    for (const name of ['mem-context-pack', 'mem-project-timeline', 'mem-source-ref']) {
+      const tool = byName.get(name);
+      expect(tool).toBeDefined();
+      expect(tool?.inputSchema).toMatchObject({ type: 'object' });
+      const properties = tool?.inputSchema.properties as Record<string, unknown>;
+      expect(properties.projectPath).toMatchObject({
+        type: 'string',
+        description: expect.stringContaining('project')
+      });
+    }
+  });
+
+  it('builds a compact project context pack from relevant search results and recent timeline', async () => {
+    const relevant = event({
+      id: '11111111-1111-4111-8111-111111111111',
+      sessionId: 'session-codex',
+      timestamp: new Date('2026-05-05T01:00:00.000Z'),
+      content: 'Codex import CLI and project-aware MCP integration were implemented.'
+    });
+    const recent = [
+      event({
+        id: '22222222-2222-4222-8222-222222222222',
+        sessionId: 'session-hermes',
+        eventType: 'agent_response',
+        timestamp: new Date('2026-05-05T02:00:00.000Z'),
+        content: 'Hermes adapter verification passed with targeted tests.',
+        metadata: { importedFrom: 'hermes' }
+      }),
+      relevant,
+      event({
+        id: '33333333-3333-4333-8333-333333333333',
+        sessionId: 'session-old',
+        timestamp: new Date('2026-05-04T02:00:00.000Z'),
+        content: 'Older cleanup note.',
+        metadata: { importedFrom: 'claude-code' }
+      })
+    ];
+
+    mocks.projectService.retrieveMemories.mockResolvedValue({ memories: [{ event: relevant, score: 0.93 }] });
+    mocks.projectService.getRecentEvents.mockResolvedValue(recent);
+
+    const result = await handleToolCall('mem-context-pack', {
+      projectPath: '/repo/app',
+      query: 'Codex Hermes MCP integration',
+      topK: 2,
+      recentLimit: 3,
+      sessionLimit: 2
+    });
+
+    const text = textOf(result);
+    expect(result.isError).not.toBe(true);
+    expect(mocks.getMemoryServiceForProject).toHaveBeenCalledWith('/repo/app');
+    expect(mocks.projectService.retrieveMemories).toHaveBeenCalledWith('Codex Hermes MCP integration', {
+      topK: 2,
+      sessionId: undefined,
+      recordTrace: false
+    });
+    expect(mocks.projectService.getRecentEvents).toHaveBeenCalledWith(3);
+    expect(text).toContain('## Project Context Pack');
+    expect(text).toContain('### Relevant Memories');
+    expect(text).toContain('Codex import CLI');
+    expect(text).toContain('### Recent Project Timeline');
+    expect(text).toContain('Hermes adapter verification');
+    expect(text).toContain(`[mem:${generateCitationId(relevant.id)}]`);
+    expect(text.length).toBeLessThan(5000);
+  });
+
+  it('summarizes a project timeline by recent sessions and source agent metadata', async () => {
+    mocks.projectService.getRecentEvents.mockResolvedValue([
+      event({
+        id: 'a1',
+        sessionId: 'session-a',
+        eventType: 'user_prompt',
+        timestamp: new Date('2026-05-05T01:00:00.000Z'),
+        content: 'Implement Hermes context tools.',
+        metadata: { importedFrom: '/Users/example/.hermes/state.db', source: 'hermes' }
+      }),
+      event({
+        id: 'a2',
+        sessionId: 'session-a',
+        eventType: 'agent_response',
+        timestamp: new Date('2026-05-05T01:02:00.000Z'),
+        content: 'Added tests for context tools.',
+        metadata: { importedFrom: '/Users/example/.hermes/state.db', source: 'hermes' }
+      }),
+      event({
+        id: 'b1',
+        sessionId: 'session-b',
+        eventType: 'user_prompt',
+        timestamp: new Date('2026-05-05T00:30:00.000Z'),
+        content: 'Review Codex memory import.',
+        metadata: { importedFrom: '/Users/example/.codex/sessions/project.jsonl', source: 'codex' }
+      })
+    ]);
+
+    const result = await handleToolCall('mem-project-timeline', {
+      projectPath: '/repo/app',
+      limit: 10,
+      sessionLimit: 2
+    });
+
+    const text = textOf(result);
+    expect(result.isError).not.toBe(true);
+    expect(mocks.projectService.getRecentEvents).toHaveBeenCalledWith(10);
+    expect(text).toContain('## Project Memory Timeline');
+    expect(text).toContain('session-a');
+    expect(text).toContain('Events: 2');
+    expect(text).toContain('Source: hermes');
+    expect(text).toContain('user_prompt: 1');
+    expect(text).toContain('agent_response: 1');
+    expect(text).toContain('session-b');
+    expect(text).toContain('Source: codex');
+    expect(text).not.toContain('/Users/example');
+    expect(text).not.toContain('.codex/sessions');
+  });
+
+  it('redacts sensitive source-agent metadata in timeline summaries', async () => {
+    mocks.projectService.getRecentEvents.mockResolvedValue([
+      event({
+        id: 'source-redaction-1',
+        sessionId: 'session-source-redaction',
+        timestamp: new Date('2026-05-05T04:00:00.000Z'),
+        content: 'Timeline source label should be safe.',
+        metadata: { sourceAgent: 'token=leaky-source-fixture' }
+      })
+    ]);
+
+    const result = await handleToolCall('mem-project-timeline', {
+      projectPath: '/repo/app',
+      limit: 10,
+      sessionLimit: 1
+    });
+
+    const text = textOf(result);
+    expect(result.isError).not.toBe(true);
+    expect(text).toContain('Source: [REDACTED]');
+    expect(text).not.toContain('leaky-source-fixture');
+  });
+
+  it('resolves source references with redacted preview and safe metadata only', async () => {
+    const sensitive = event({
+      id: '44444444-4444-4444-8444-444444444444',
+      sessionId: 'session-sensitive',
+      timestamp: new Date('2026-05-05T03:00:00.000Z'),
+      content: 'Debug note with api_key=sensitive-fixture-value token=abc123 password=pw but useful MCP context.',
+      metadata: {
+        importedFrom: '/Users/example/.hermes/state.db',
+        source: ['discord', 'token=leaky-array-fixture'],
+        transcriptPath: '/tmp/private-transcript.jsonl',
+        secret: 'sensitive-fixture-value'
+      }
+    });
+    mocks.projectService.getRecentEvents.mockResolvedValue([sensitive]);
+
+    const result = await handleToolCall('mem-source-ref', {
+      projectPath: '/repo/app',
+      ids: [sensitive.id],
+      maxContentChars: 240
+    });
+
+    const text = textOf(result);
+    expect(result.isError).not.toBe(true);
+    expect(text).toContain('## Source References');
+    expect(text).toContain(`[mem:${generateCitationId(sensitive.id)}]`);
+    expect(text).toContain('[REDACTED]');
+    expect(text).not.toContain('importedFrom');
+    expect(text).not.toContain('/Users/example');
+    expect(text).toContain('source: discord');
+    expect(text).not.toContain('leaky-array-fixture');
+    expect(text).not.toContain('sensitive-fixture-value');
+    expect(text).not.toContain('abc123');
+    expect(text).not.toContain('password=pw');
+    expect(text).not.toContain('transcriptPath');
+    expect(text).not.toContain('secret:');
+  });
+
+  it('resolves source references by short citation id', async () => {
+    const target = event({ id: '55555555-5555-4555-8555-555555555555', content: 'Citation lookup target.' });
+    mocks.projectService.getRecentEvents.mockResolvedValue([target]);
+
+    const result = await handleToolCall('mem-source-ref', {
+      projectPath: '/repo/app',
+      ids: [generateCitationId(target.id)]
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(textOf(result)).toContain('Citation lookup target');
+  });
+});

--- a/tests/extensions/mcp-project-aware-tools.test.ts
+++ b/tests/extensions/mcp-project-aware-tools.test.ts
@@ -85,7 +85,8 @@ describe('MCP project-aware memory tools', () => {
     expect(mocks.projectService.initialize).toHaveBeenCalledTimes(1);
     expect(mocks.projectService.retrieveMemories).toHaveBeenCalledWith('project scoped memory', {
       topK: 7,
-      sessionId: 'session-a'
+      sessionId: 'session-a',
+      recordTrace: false
     });
     expect(result.content[0]?.text).toContain('project scoped memory result');
   });


### PR DESCRIPTION
## Summary
- Add project-aware MCP context navigator tools: `mem-context-pack`, `mem-project-timeline`, and `mem-source-ref`
- Add read-only retrieval trace opt-out for MCP navigation calls via `recordTrace: false`
- Harden privacy filtering for source labels, metadata arrays, and path-bearing metadata such as `importedFrom`
- Update product validation matrix docs/tests included in the verified branch

## Validation
- `npm test -- --run tests/core/retrieval-orchestrator.test.ts tests/extensions/mcp-context-tools.test.ts tests/extensions/mcp-project-aware-tools.test.ts`
- `npm run typecheck -- --pretty false`
- `npm test -- --run`
- `npm run build`
- `graphify update .`
- `git diff --check`
- static/security/privacy scan over intended diff
- independent pre-commit review: no blockers

## Privacy notes
- MCP `mem-search` and `mem-context-pack` do not persist automatic retrieval traces.
- `importedFrom` is excluded from source labels and safe metadata to avoid leaking local paths.
- Sensitive strings inside arrays are redacted before source-reference output.