### PR TITLE
[verified] harden MCP context bootstrap privacy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,17 @@
 이 저장소는 **Claude Code용 메모리 플러그인 + CLI + 로컬 대시보드 서버**입니다.
 Codex(또는 다른 코딩 에이전트)가 작업할 때 아래 규칙을 우선으로 따르세요.
 
+## Project Memory Bootstrap
+
+작업 시작/재개 전에 Claude Memory Layer MCP 도구가 사용 가능하면 먼저 프로젝트 맥락을 가져오세요.
+
+- 트리거: `continue`, `next`, `이어서`, `다음 단계`, 버그 수정, PR/merge/검증, 이전 결정/작업 맥락이 중요한 요청
+- 우선 호출: `mem-context-pack` / Hermes 도구명 `mcp_claude_memory_layer_mem_context_pack`
+- 권장 인자: `query=<현재 요청 요약>`, `projectPath=<현재 저장소 루트>`, `topK=5`, `recentLimit=30`, `sessionLimit=5`
+- MCP 도구가 없으면 막히지 말고 기존 AGENTS.md 규칙대로 진행하세요.
+- 결과는 배경 맥락으로만 사용하고, secret/token/credential 또는 transcript DB path 같은 민감한 metadata는 출력하지 마세요.
+- live agent session id를 CML `sessionId`로 넘기지 마세요. source-session 필터가 명시된 경우에만 사용하세요.
+
 ## Quick Commands
 
 ```bash

--- a/src/core/privacy/filter.ts
+++ b/src/core/privacy/filter.ts
@@ -20,6 +20,10 @@ export interface FilterResult {
 
 // Sensitive data patterns
 const SENSITIVE_PATTERNS = [
+  // Credential-bearing URLs/connection strings with userinfo before the host.
+  // Redact the whole URI so usernames, credentials, hosts, paths, and query
+  // params do not leak either.
+  /\b[a-z][a-z0-9+.-]*:\/\/[^\s'"`<>/@]+@[^\s'"`<>]+/gi,
   /password\s*[:=]\s*['"]?[^\s'"]+/gi,
   /api[_-]?key\s*[:=]\s*['"]?[^\s'"]+/gi,
   /secret\s*[:=]\s*['"]?[^\s'"]+/gi,

--- a/tests/extensions/mcp-context-tools.test.ts
+++ b/tests/extensions/mcp-context-tools.test.ts
@@ -135,6 +135,79 @@ describe('MCP project context tools', () => {
     expect(text.length).toBeLessThan(5000);
   });
 
+  it('redacts credential-bearing connection strings from context-pack previews', async () => {
+    const credentialUri = [
+      'mongodb://',
+      'fixture-user',
+      ':',
+      'fixture-credential',
+      '@',
+      'db.example.test:27017/admin?authSource=admin'
+    ].join('');
+    const sensitiveConnection = event({
+      id: 'connection-redaction-1',
+      timestamp: new Date('2026-05-05T01:30:00.000Z'),
+      content: `Run mongo sync with --mongo-uri ${credentialUri} before checking status.`
+    });
+
+    mocks.projectService.retrieveMemories.mockResolvedValue({
+      memories: [{ event: sensitiveConnection, score: 0.9 }]
+    });
+    mocks.projectService.getRecentEvents.mockResolvedValue([sensitiveConnection]);
+
+    const result = await handleToolCall('mem-context-pack', {
+      projectPath: '/repo/app',
+      query: 'mongo sync status',
+      topK: 1,
+      recentLimit: 1,
+      sessionLimit: 1
+    });
+
+    const text = textOf(result);
+    expect(result.isError).not.toBe(true);
+    expect(text).toContain('[REDACTED]');
+    expect(text).not.toContain('fixture-user');
+    expect(text).not.toContain('fixture-credential');
+    expect(text).not.toContain('mongodb://');
+    expect(text).not.toContain('db.example.test');
+    expect(text).not.toContain('authSource=admin');
+  });
+
+  it('redacts password-only credential URLs from context-pack previews', async () => {
+    const passwordOnlyUri = [
+      'redis://',
+      ':',
+      'fixture-credential',
+      '@',
+      'cache.example.test:6379/0'
+    ].join('');
+    const sensitiveConnection = event({
+      id: 'connection-redaction-2',
+      timestamp: new Date('2026-05-05T01:45:00.000Z'),
+      content: `Check queue health with ${passwordOnlyUri} before retrying workers.`
+    });
+
+    mocks.projectService.retrieveMemories.mockResolvedValue({
+      memories: [{ event: sensitiveConnection, score: 0.89 }]
+    });
+    mocks.projectService.getRecentEvents.mockResolvedValue([sensitiveConnection]);
+
+    const result = await handleToolCall('mem-context-pack', {
+      projectPath: '/repo/app',
+      query: 'queue health workers',
+      topK: 1,
+      recentLimit: 1,
+      sessionLimit: 1
+    });
+
+    const text = textOf(result);
+    expect(result.isError).not.toBe(true);
+    expect(text).toContain('[REDACTED]');
+    expect(text).not.toContain('fixture-credential');
+    expect(text).not.toContain('redis://');
+    expect(text).not.toContain('cache.example.test');
+  });
+
   it('summarizes a project timeline by recent sessions and source agent metadata', async () => {
     mocks.projectService.getRecentEvents.mockResolvedValue([
       event({


### PR DESCRIPTION
## Summary
- Add project memory bootstrap guidance to AGENTS.md so agents call the CML MCP context pack before continuation/project work.
- Harden privacy filtering for credential-bearing URI/userinfo connection strings in MCP context-pack previews.
- Add regressions for username+credential and password-only credential URI forms, ensuring the full URI is redacted.

## Validation
- npm test -- --run tests/extensions/mcp-context-tools.test.ts -t "credential"
- npm test -- --run tests/extensions/mcp-context-tools.test.ts
- npm run typecheck -- --pretty false
- git diff --check
- npm test -- --run
- npm run build
- graphify update .
- static/privacy scan: no findings
- independent pre-commit review: passed
