### PR TITLE
Improve generic context-pack quality

### DIFF
--- a/src/core/retrieval-quality.ts
+++ b/src/core/retrieval-quality.ts
@@ -13,6 +13,18 @@ const COMMAND_ARTIFACT_PATTERNS = [
   /<local-command-stderr>[\s\S]*?<\/local-command-stderr>/i
 ];
 
+const LOW_SIGNAL_CONTEXT_PATTERNS = [
+  /<environment_context\b[\s\S]*<\/environment_context>/i,
+  /<turn_aborted>/i,
+  /^➜\s+\S+\s+git:\([^)]*\)\s+/i,
+  /^\$\s+\S+/i
+];
+
+const CONTINUATION_QUERY_PATTERNS = [
+  /^\s*(?:continue|resume|next|what(?:'s| is)? next|next\s+(?:step|task|action)|recommended\s+(?:next\s+)?(?:step|task|action)|what should (?:we|i) do next)\??\s*$/i,
+  /^\s*(?:이어서(?:\s*진행해줘)?|계속(?:\s*해줘)?|다음\s*(?:단계|작업|추천\s*작업|추천|할\s*일)?(?:은|는)?(?:\s*뭐야)?\??|추천\s*작업(?:은|는)?(?:\s*뭐야)?\??|진행해줘)\s*$/i
+];
+
 const GENERIC_TECHNICAL_TERMS = new Set([
   'api',
   'cli',
@@ -38,6 +50,37 @@ export function isCommandArtifactQuery(query: string): boolean {
   if (normalized.includes('local-command-stdout') || normalized.includes('local-command-stderr')) return true;
   if (normalized.includes('command-name') || normalized.includes('command-message')) return true;
   return COMMAND_ARTIFACT_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
+export function isCommandArtifactContent(content: string): boolean {
+  const trimmed = content.trim();
+  if (!trimmed) return false;
+  const normalized = trimmed.toLowerCase();
+  if (normalized.includes('local-command-stdout') || normalized.includes('local-command-stderr')) return true;
+  if (normalized.includes('command-name') || normalized.includes('command-message')) return true;
+  return COMMAND_ARTIFACT_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
+export function isLowSignalContextContent(content: string): boolean {
+  const trimmed = content.trim();
+  if (!trimmed) return true;
+  if (isCommandArtifactContent(trimmed)) return true;
+  if (LOW_SIGNAL_CONTEXT_PATTERNS.some((pattern) => pattern.test(trimmed))) return true;
+  return false;
+}
+
+export function isGenericContinuationQuery(query: string): boolean {
+  const trimmed = query.trim();
+  if (!trimmed) return false;
+  if (!CONTINUATION_QUERY_PATTERNS.some((pattern) => pattern.test(trimmed))) return false;
+  if (extractTechnicalQueryTerms(trimmed).length > 0) return false;
+
+  const tokens = trimmed.match(/[A-Za-z0-9가-힣#._/-]+/g) ?? [];
+  if (tokens.length > 10) return false;
+
+  return !/[A-Za-z0-9_-]+\.[A-Za-z0-9]+/.test(trimmed) &&
+    !/(?:^|\s)(?:feat|fix|chore|refactor|docs)\/[A-Za-z0-9._-]+/.test(trimmed) &&
+    !/[A-Za-z]:?[\\/]|\/Users\/|\.\/|\.\.\//.test(trimmed);
 }
 
 export function extractTechnicalQueryTerms(query: string): string[] {

--- a/src/extensions/mcp/handlers.ts
+++ b/src/extensions/mcp/handlers.ts
@@ -10,6 +10,10 @@ import {
 } from '../../services/memory-service.js';
 import { generateCitationId } from '../../core/citation-generator.js';
 import { applyPrivacyFilter, maskSensitiveInput } from '../../core/privacy/filter.js';
+import {
+  isGenericContinuationQuery,
+  isLowSignalContextContent
+} from '../../core/retrieval-quality.js';
 import type { Config, EventType, MemoryEvent } from '../../core/types.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
@@ -206,44 +210,48 @@ async function handleMemContextPack(memoryService: MemoryService, args: Record<s
   const recentLimit = numberArg(args.recentLimit, 30, 1, 200);
   const sessionLimit = numberArg(args.sessionLimit, 5, 1, 20);
   const sessionId = optionalString(args.sessionId);
+  const genericContinuationQuery = isGenericContinuationQuery(query);
+  const retrievalTopK = genericContinuationQuery ? Math.min(topK * 3, 12) : topK;
 
   const [searchResult, recentEvents] = await Promise.all([
-    memoryService.retrieveMemories(query, { topK, sessionId, recordTrace: false }),
+    memoryService.retrieveMemories(query, { topK: retrievalTopK, sessionId, recordTrace: false }),
     memoryService.getRecentEvents(recentLimit)
   ]);
+
+  const timelineEvents = genericContinuationQuery
+    ? recentEvents.filter(shouldShowGenericTimelineEvent)
+    : recentEvents;
+  const sessions = summarizeSessions(timelineEvents, sessionLimit);
+  const recentSessionIds = new Set(sessions.map((session) => session.sessionId));
+  const relevantMemories = selectContextPackMemories(searchResult.memories, {
+    genericContinuationQuery,
+    topK,
+    recentSessionIds
+  });
 
   const lines: string[] = [
     '## Project Context Pack',
     '',
     `- Query: ${safeInline(query, 160)}`,
-    `- Relevant memories: ${searchResult.memories.length}`,
+    `- Relevant memories: ${relevantMemories.length}`,
     `- Recent events inspected: ${recentEvents.length}`,
-    `- Recent sessions shown: ${Math.min(sessionLimit, summarizeSessions(recentEvents, sessionLimit).length)}`,
-    '',
-    '### Relevant Memories',
-    ''
+    `- Recent sessions shown: ${Math.min(sessionLimit, sessions.length)}`
   ];
 
-  if (searchResult.memories.length === 0) {
-    lines.push('No relevant memories found.', '');
+  if (genericContinuationQuery) {
+    lines.push('- Generic continuation query: recent project timeline prioritized.');
+  }
+  lines.push('');
+
+  if (genericContinuationQuery) {
+    appendRecentTimeline(lines, sessions);
+    appendRelevantMemories(lines, relevantMemories);
   } else {
-    for (let i = 0; i < searchResult.memories.length; i++) {
-      const match = searchResult.memories[i];
-      lines.push(formatRelevantMemoryLine(match.event, match.score, i + 1));
-    }
+    appendRelevantMemories(lines, relevantMemories);
+    appendRecentTimeline(lines, sessions);
   }
 
-  lines.push('### Recent Project Timeline', '');
-  const sessions = summarizeSessions(recentEvents, sessionLimit);
-  if (sessions.length === 0) {
-    lines.push('No recent project events found.', '');
-  } else {
-    for (const session of sessions) {
-      lines.push(formatSessionSummary(session));
-    }
-  }
-
-  const sourceIds = searchResult.memories
+  const sourceIds = relevantMemories
     .slice(0, 5)
     .map((match) => generateCitationId(match.event.id));
   if (sourceIds.length > 0) {
@@ -327,6 +335,17 @@ async function handleMemSourceRef(memoryService: MemoryService, args: Record<str
   return textResult(lines.join('\n'));
 }
 
+interface ContextPackMemory {
+  event: MemoryEvent;
+  score: number;
+}
+
+interface ContextPackSelectionOptions {
+  genericContinuationQuery: boolean;
+  topK: number;
+  recentSessionIds: Set<string>;
+}
+
 interface SessionSummary {
   sessionId: string;
   firstAt: Date;
@@ -361,6 +380,74 @@ function summarizeSessions(events: MemoryEvent[], sessionLimit: number): Session
     })
     .sort((a, b) => b.lastAt.getTime() - a.lastAt.getTime())
     .slice(0, sessionLimit);
+}
+
+function selectContextPackMemories(
+  memories: ContextPackMemory[],
+  options: ContextPackSelectionOptions
+): ContextPackMemory[] {
+  const selected = memories.filter((memory) => shouldShowContextPackMemory(memory, options));
+  if (!options.genericContinuationQuery) return selected.slice(0, options.topK);
+
+  return selected
+    .slice()
+    .sort((a, b) => contextPackMemoryPriority(b, options) - contextPackMemoryPriority(a, options))
+    .slice(0, options.topK);
+}
+
+function shouldShowGenericTimelineEvent(event: MemoryEvent): boolean {
+  const content = event.content || '';
+  if (isLowSignalContextContent(content)) return false;
+  if (event.eventType === 'tool_observation') return false;
+  if (isGenericContinuationQuery(content)) return false;
+  return true;
+}
+
+function shouldShowContextPackMemory(memory: ContextPackMemory, options: ContextPackSelectionOptions): boolean {
+  if (!options.genericContinuationQuery) return true;
+
+  const content = memory.event.content || '';
+  if (isLowSignalContextContent(content)) return false;
+  if (memory.event.eventType === 'tool_observation') return false;
+  if (isGenericContinuationQuery(content)) return false;
+  if (options.recentSessionIds.has(memory.event.sessionId)) return true;
+  if (memory.event.eventType === 'session_summary') return memory.score >= 0.55;
+  return memory.score >= 0.75;
+}
+
+function contextPackMemoryPriority(memory: ContextPackMemory, options: ContextPackSelectionOptions): number {
+  const recentBoost = options.recentSessionIds.has(memory.event.sessionId) ? 2 : 0;
+  const typeBoost = memory.event.eventType === 'session_summary'
+    ? 0.5
+    : memory.event.eventType === 'agent_response'
+      ? 0.3
+      : 0;
+  return recentBoost + typeBoost + Math.min(memory.score, 1) + memory.event.timestamp.getTime() / 1e15;
+}
+
+function appendRelevantMemories(lines: string[], memories: ContextPackMemory[]): void {
+  lines.push('### Relevant Memories', '');
+  if (memories.length === 0) {
+    lines.push('No relevant memories found.', '');
+    return;
+  }
+
+  for (let i = 0; i < memories.length; i++) {
+    const match = memories[i];
+    lines.push(formatRelevantMemoryLine(match.event, match.score, i + 1));
+  }
+}
+
+function appendRecentTimeline(lines: string[], sessions: SessionSummary[]): void {
+  lines.push('### Recent Project Timeline', '');
+  if (sessions.length === 0) {
+    lines.push('No recent project events found.', '');
+    return;
+  }
+
+  for (const session of sessions) {
+    lines.push(formatSessionSummary(session));
+  }
 }
 
 function countEventTypes(events: MemoryEvent[]): Record<EventType, number> {

--- a/tests/core/retrieval-quality.test.ts
+++ b/tests/core/retrieval-quality.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isGenericContinuationQuery,
+  isLowSignalContextContent
+} from '../../src/core/retrieval-quality.js';
+
+describe('retrieval quality guards', () => {
+  it('recognizes short generic continuation prompts', () => {
+    expect(isGenericContinuationQuery('continue')).toBe(true);
+    expect(isGenericContinuationQuery('what next?')).toBe(true);
+    expect(isGenericContinuationQuery('다음 추천작업은 뭐야?')).toBe(true);
+    expect(isGenericContinuationQuery('이어서 진행해줘')).toBe(true);
+  });
+
+  it('does not classify topic-specific next/recommendation/debug prompts as generic', () => {
+    expect(isGenericContinuationQuery('next task for search UI')).toBe(false);
+    expect(isGenericContinuationQuery('recommendation for auth design')).toBe(false);
+    expect(isGenericContinuationQuery('이 오류 뭐야?')).toBe(false);
+    expect(isGenericContinuationQuery('다음 작업은 retrieval-quality.ts에서 뭐야?')).toBe(false);
+  });
+
+  it('detects low-signal context artifacts', () => {
+    expect(isLowSignalContextContent('<environment_context><cwd>/repo/app</cwd></environment_context>')).toBe(true);
+    expect(isLowSignalContextContent('prefix <environment_context><cwd>/repo/app</cwd></environment_context> suffix')).toBe(true);
+    expect(isLowSignalContextContent('<command-name>/model</command-name>\n<local-command-stdout>opus</local-command-stdout>')).toBe(true);
+    expect(isLowSignalContextContent('Merged PR #15 and synced local main.')).toBe(false);
+  });
+});

--- a/tests/extensions/mcp-context-tools.test.ts
+++ b/tests/extensions/mcp-context-tools.test.ts
@@ -135,6 +135,136 @@ describe('MCP project context tools', () => {
     expect(text.length).toBeLessThan(5000);
   });
 
+  it('prioritizes recent project timeline and suppresses low-signal search noise for generic continuation queries', async () => {
+    const mergedPr = event({
+      id: '44444444-4444-4444-8444-444444444444',
+      sessionId: 'session-latest',
+      eventType: 'agent_response',
+      timestamp: new Date('2026-05-06T03:00:00.000Z'),
+      content: 'Merged CML PR #15 and synced local main; next recommended task is generic context quality hardening.',
+      metadata: { source: 'hermes' }
+    });
+    const genericPrompt = event({
+      id: '55555555-5555-4555-8555-555555555555',
+      sessionId: 'session-latest',
+      timestamp: new Date('2026-05-06T03:01:00.000Z'),
+      content: '다음 추천작업은 뭐야?',
+      metadata: { source: 'hermes' }
+    });
+    const unrelatedMemory = event({
+      id: '66666666-6666-4666-8666-666666666666',
+      sessionId: 'session-old',
+      timestamp: new Date('2026-04-01T00:00:00.000Z'),
+      content: 'FinRL stock trading experiments should tune Alpha AI Trader replay settings.'
+    });
+    const commandArtifact = event({
+      id: '77777777-7777-4777-8777-777777777777',
+      sessionId: 'session-latest',
+      timestamp: new Date('2026-05-06T02:59:00.000Z'),
+      content: '<command-name>/model</command-name>\n<local-command-stdout>Using model opus</local-command-stdout>'
+    });
+    const environmentContext = event({
+      id: '88888888-8888-4888-8888-888888888888',
+      sessionId: 'session-latest',
+      timestamp: new Date('2026-05-06T02:58:00.000Z'),
+      content: '<environment_context><cwd>/repo/app</cwd><shell>zsh</shell></environment_context>'
+    });
+    const latestCommandArtifact = event({
+      id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+      sessionId: 'session-latest',
+      eventType: 'tool_observation',
+      timestamp: new Date('2026-05-06T03:03:00.000Z'),
+      content: '<command-name>/model</command-name>\n<local-command-stdout>Using model opus</local-command-stdout>'
+    });
+    const latestEnvironmentContext = event({
+      id: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+      sessionId: 'session-latest',
+      timestamp: new Date('2026-05-06T03:02:00.000Z'),
+      content: '<environment_context><cwd>/repo/app</cwd><shell>zsh</shell></environment_context>'
+    });
+
+    mocks.projectService.retrieveMemories.mockResolvedValue({
+      memories: [
+        { event: commandArtifact, score: 0.95 },
+        { event: environmentContext, score: 0.9 },
+        { event: unrelatedMemory, score: 0.62 },
+        { event: mergedPr, score: 0.61 }
+      ]
+    });
+    mocks.projectService.getRecentEvents.mockResolvedValue([
+      latestCommandArtifact,
+      latestEnvironmentContext,
+      genericPrompt,
+      mergedPr
+    ]);
+
+    const result = await handleToolCall('mem-context-pack', {
+      projectPath: '/repo/app',
+      query: '다음 추천작업은 뭐야?',
+      topK: 3,
+      recentLimit: 10,
+      sessionLimit: 2
+    });
+
+    const text = textOf(result);
+    expect(result.isError).not.toBe(true);
+    expect(mocks.projectService.retrieveMemories).toHaveBeenCalledWith('다음 추천작업은 뭐야?', {
+      topK: 9,
+      sessionId: undefined,
+      recordTrace: false
+    });
+    expect(text).toContain('Generic continuation query: recent project timeline prioritized.');
+    expect(text.indexOf('### Recent Project Timeline')).toBeLessThan(text.indexOf('### Relevant Memories'));
+    expect(text).toContain('Merged CML PR #15');
+    expect(text).not.toContain('FinRL stock trading');
+    expect(text).not.toContain('<command-name>');
+    expect(text).not.toContain('Using model opus');
+    expect(text).not.toContain('<environment_context>');
+  });
+
+  it('keeps non-generic context-pack memory output behavior unchanged', async () => {
+    const commandArtifact = event({
+      id: '99999999-9999-4999-8999-999999999999',
+      sessionId: 'session-debug',
+      timestamp: new Date('2026-05-06T02:59:00.000Z'),
+      content: '<command-name>/model</command-name>\n<local-command-stdout>Using model opus</local-command-stdout>'
+    });
+    const relevantDebug = event({
+      id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      sessionId: 'session-debug',
+      timestamp: new Date('2026-05-06T03:00:00.000Z'),
+      content: 'Investigated MCP context-pack retrieval ranking for a topic-specific debug query.'
+    });
+
+    mocks.projectService.retrieveMemories.mockResolvedValue({
+      memories: [
+        { event: commandArtifact, score: 0.95 },
+        { event: relevantDebug, score: 0.8 }
+      ]
+    });
+    mocks.projectService.getRecentEvents.mockResolvedValue([relevantDebug]);
+
+    const result = await handleToolCall('mem-context-pack', {
+      projectPath: '/repo/app',
+      query: 'debug command artifact retrieval quality',
+      topK: 2,
+      recentLimit: 10,
+      sessionLimit: 2
+    });
+
+    const text = textOf(result);
+    expect(result.isError).not.toBe(true);
+    expect(mocks.projectService.retrieveMemories).toHaveBeenCalledWith('debug command artifact retrieval quality', {
+      topK: 2,
+      sessionId: undefined,
+      recordTrace: false
+    });
+    expect(text).not.toContain('Generic continuation query');
+    expect(text.indexOf('### Relevant Memories')).toBeLessThan(text.indexOf('### Recent Project Timeline'));
+    expect(text).toContain('<command-name>');
+    expect(text).toContain('Using model opus');
+  });
+
   it('redacts credential-bearing connection strings from context-pack previews', async () => {
     const credentialUri = [
       'mongodb://',


### PR DESCRIPTION
## Summary
- Detect short generic continuation prompts such as `continue`, `what next?`, and `다음 추천작업은 뭐야?`.
- For generic context-pack requests, over-fetch candidates, suppress low-signal memory/timeline artifacts, and show recent project timeline before relevant memories.
- Preserve non-generic mem-context-pack topK, ordering, and output behavior.

## Quality / Privacy Guards
- Filters command artifacts, `environment_context`, `turn_aborted`, tool observations, and generic prompt echoes only for generic continuation context-pack output.
- Adds negative tests so topic-specific prompts like `next task for search UI`, `recommendation for auth design`, and `이 오류 뭐야?` are not treated as generic continuation.

## Verification
- `git diff --check`
- `npm test -- --run tests/extensions/mcp-context-tools.test.ts tests/core/retrieval-quality.test.ts tests/core/retriever-strategy-scope.test.ts tests/core/session-history-importer-filter.test.ts`
- `npm run typecheck -- --pretty false`
- `npm test -- --run`
- `npm run build`
- `graphify update .`
- static/privacy scan: no findings
- independent pre-commit review: passed
