### PR TITLE
[verified] filter noisy context-pack candidates

### DIFF
--- a/src/core/retrieval-quality.ts
+++ b/src/core/retrieval-quality.ts
@@ -16,6 +16,7 @@ const COMMAND_ARTIFACT_PATTERNS = [
 const LOW_SIGNAL_CONTEXT_PATTERNS = [
   /<environment_context\b[\s\S]*<\/environment_context>/i,
   /<turn_aborted>/i,
+  /^#\s*AGENTS\.md\s+instructions\b[\s\S]*<INSTRUCTIONS>/i,
   /^➜\s+\S+\s+git:\([^)]*\)\s+/i,
   /^\$\s+\S+/i
 ];

--- a/src/extensions/mcp/handlers.ts
+++ b/src/extensions/mcp/handlers.ts
@@ -210,23 +210,27 @@ async function handleMemContextPack(memoryService: MemoryService, args: Record<s
   const recentLimit = numberArg(args.recentLimit, 30, 1, 200);
   const sessionLimit = numberArg(args.sessionLimit, 5, 1, 20);
   const sessionId = optionalString(args.sessionId);
+  const projectPath = optionalString(args.projectPath);
   const genericContinuationQuery = isGenericContinuationQuery(query);
-  const retrievalTopK = genericContinuationQuery ? Math.min(topK * 3, 12) : topK;
+  const retrievalTopK = Math.min(topK * 3, 12);
 
   const [searchResult, recentEvents] = await Promise.all([
     memoryService.retrieveMemories(query, { topK: retrievalTopK, sessionId, recordTrace: false }),
     memoryService.getRecentEvents(recentLimit)
   ]);
 
-  const timelineEvents = genericContinuationQuery
-    ? recentEvents.filter(shouldShowGenericTimelineEvent)
-    : recentEvents;
+  const timelineEvents = recentEvents.filter((event) => shouldShowContextPackTimelineEvent(
+    event,
+    projectPath,
+    genericContinuationQuery
+  ));
   const sessions = summarizeSessions(timelineEvents, sessionLimit);
   const recentSessionIds = new Set(sessions.map((session) => session.sessionId));
   const relevantMemories = selectContextPackMemories(searchResult.memories, {
     genericContinuationQuery,
     topK,
-    recentSessionIds
+    recentSessionIds,
+    projectPath
   });
 
   const lines: string[] = [
@@ -344,6 +348,7 @@ interface ContextPackSelectionOptions {
   genericContinuationQuery: boolean;
   topK: number;
   recentSessionIds: Set<string>;
+  projectPath?: string;
 }
 
 interface SessionSummary {
@@ -395,24 +400,57 @@ function selectContextPackMemories(
     .slice(0, options.topK);
 }
 
-function shouldShowGenericTimelineEvent(event: MemoryEvent): boolean {
+function shouldShowContextPackTimelineEvent(
+  event: MemoryEvent,
+  projectPath: string | undefined,
+  genericContinuationQuery: boolean
+): boolean {
   const content = event.content || '';
   if (isLowSignalContextContent(content)) return false;
   if (event.eventType === 'tool_observation') return false;
-  if (isGenericContinuationQuery(content)) return false;
+  if (mentionsDifferentWorkspaceProject(content, projectPath)) return false;
+  if (genericContinuationQuery && isGenericContinuationQuery(content)) return false;
   return true;
 }
 
 function shouldShowContextPackMemory(memory: ContextPackMemory, options: ContextPackSelectionOptions): boolean {
-  if (!options.genericContinuationQuery) return true;
-
   const content = memory.event.content || '';
   if (isLowSignalContextContent(content)) return false;
   if (memory.event.eventType === 'tool_observation') return false;
+  if (mentionsDifferentWorkspaceProject(content, options.projectPath)) return false;
+  if (!options.genericContinuationQuery) return true;
+
   if (isGenericContinuationQuery(content)) return false;
   if (options.recentSessionIds.has(memory.event.sessionId)) return true;
   if (memory.event.eventType === 'session_summary') return memory.score >= 0.55;
   return memory.score >= 0.75;
+}
+
+function mentionsDifferentWorkspaceProject(content: string, projectPath?: string): boolean {
+  const currentProject = basenameOfPath(projectPath);
+  if (!currentProject) return false;
+
+  const workspaceProjectNames = Array.from(content.matchAll(/[\\/](?:workspace|workspaces|projects)[\\/]([^\\/\s'"`<>]+)/gi))
+    .map((match) => normalizeProjectName(match[1]))
+    .filter((name) => name.length > 0);
+
+  if (workspaceProjectNames.length === 0) return false;
+  return !workspaceProjectNames.includes(currentProject);
+}
+
+function basenameOfPath(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const parts = value
+    .replace(/\\/g, '/')
+    .split('/')
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const last = parts[parts.length - 1];
+  return last ? normalizeProjectName(last) : undefined;
+}
+
+function normalizeProjectName(value: string): string {
+  return value.trim().replace(/[.,;:!?]+$/g, '').toLowerCase();
 }
 
 function contextPackMemoryPriority(memory: ContextPackMemory, options: ContextPackSelectionOptions): number {

--- a/tests/core/retrieval-quality.test.ts
+++ b/tests/core/retrieval-quality.test.ts
@@ -23,6 +23,7 @@ describe('retrieval quality guards', () => {
     expect(isLowSignalContextContent('<environment_context><cwd>/repo/app</cwd></environment_context>')).toBe(true);
     expect(isLowSignalContextContent('prefix <environment_context><cwd>/repo/app</cwd></environment_context> suffix')).toBe(true);
     expect(isLowSignalContextContent('<command-name>/model</command-name>\n<local-command-stdout>opus</local-command-stdout>')).toBe(true);
+    expect(isLowSignalContextContent('# AGENTS.md instructions for /repo/app <INSTRUCTIONS> ## Skills A skill is local instructions.')).toBe(true);
     expect(isLowSignalContextContent('Merged PR #15 and synced local main.')).toBe(false);
   });
 });

--- a/tests/extensions/mcp-context-tools.test.ts
+++ b/tests/extensions/mcp-context-tools.test.ts
@@ -121,7 +121,7 @@ describe('MCP project context tools', () => {
     expect(result.isError).not.toBe(true);
     expect(mocks.getMemoryServiceForProject).toHaveBeenCalledWith('/repo/app');
     expect(mocks.projectService.retrieveMemories).toHaveBeenCalledWith('Codex Hermes MCP integration', {
-      topK: 2,
+      topK: 6,
       sessionId: undefined,
       recordTrace: false
     });
@@ -157,6 +157,13 @@ describe('MCP project context tools', () => {
       timestamp: new Date('2026-04-01T00:00:00.000Z'),
       content: 'FinRL stock trading experiments should tune Alpha AI Trader replay settings.'
     });
+    const crossProjectRecentMemory = event({
+      id: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+      sessionId: 'session-latest',
+      eventType: 'agent_response',
+      timestamp: new Date('2026-05-06T03:04:00.000Z'),
+      content: 'Created Alpha AI Trader specs at /Users/example/workspace/alpha-ai-trader/specs/ai-korea-stock-trader/plan.md.'
+    });
     const commandArtifact = event({
       id: '77777777-7777-4777-8777-777777777777',
       sessionId: 'session-latest',
@@ -187,6 +194,7 @@ describe('MCP project context tools', () => {
       memories: [
         { event: commandArtifact, score: 0.95 },
         { event: environmentContext, score: 0.9 },
+        { event: crossProjectRecentMemory, score: 0.93 },
         { event: unrelatedMemory, score: 0.62 },
         { event: mergedPr, score: 0.61 }
       ]
@@ -217,17 +225,25 @@ describe('MCP project context tools', () => {
     expect(text.indexOf('### Recent Project Timeline')).toBeLessThan(text.indexOf('### Relevant Memories'));
     expect(text).toContain('Merged CML PR #15');
     expect(text).not.toContain('FinRL stock trading');
+    expect(text).not.toContain('Alpha AI Trader specs');
+    expect(text).not.toContain('alpha-ai-trader');
     expect(text).not.toContain('<command-name>');
     expect(text).not.toContain('Using model opus');
     expect(text).not.toContain('<environment_context>');
   });
 
-  it('keeps non-generic context-pack memory output behavior unchanged', async () => {
+  it('keeps non-generic context-pack ordering while suppressing low-signal artifacts', async () => {
     const commandArtifact = event({
       id: '99999999-9999-4999-8999-999999999999',
       sessionId: 'session-debug',
       timestamp: new Date('2026-05-06T02:59:00.000Z'),
       content: '<command-name>/model</command-name>\n<local-command-stdout>Using model opus</local-command-stdout>'
+    });
+    const agentsDump = event({
+      id: '99999999-9999-4999-8999-999999999998',
+      sessionId: 'session-debug',
+      timestamp: new Date('2026-05-06T02:58:00.000Z'),
+      content: '# AGENTS.md instructions for /repo/app <INSTRUCTIONS> ## Skills A skill is a set of local instructions.'
     });
     const relevantDebug = event({
       id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
@@ -235,14 +251,27 @@ describe('MCP project context tools', () => {
       timestamp: new Date('2026-05-06T03:00:00.000Z'),
       content: 'Investigated MCP context-pack retrieval ranking for a topic-specific debug query.'
     });
+    const crossProjectTimeline = event({
+      id: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+      sessionId: 'session-debug',
+      eventType: 'agent_response',
+      timestamp: new Date('2026-05-06T03:01:00.000Z'),
+      content: 'Created Alpha AI Trader specs at /Users/example/workspace/alpha-ai-trader/specs/ai-korea-stock-trader/plan.md.'
+    });
 
     mocks.projectService.retrieveMemories.mockResolvedValue({
       memories: [
         { event: commandArtifact, score: 0.95 },
+        { event: agentsDump, score: 0.9 },
         { event: relevantDebug, score: 0.8 }
       ]
     });
-    mocks.projectService.getRecentEvents.mockResolvedValue([relevantDebug]);
+    mocks.projectService.getRecentEvents.mockResolvedValue([
+      commandArtifact,
+      agentsDump,
+      crossProjectTimeline,
+      relevantDebug
+    ]);
 
     const result = await handleToolCall('mem-context-pack', {
       projectPath: '/repo/app',
@@ -255,14 +284,19 @@ describe('MCP project context tools', () => {
     const text = textOf(result);
     expect(result.isError).not.toBe(true);
     expect(mocks.projectService.retrieveMemories).toHaveBeenCalledWith('debug command artifact retrieval quality', {
-      topK: 2,
+      topK: 6,
       sessionId: undefined,
       recordTrace: false
     });
     expect(text).not.toContain('Generic continuation query');
     expect(text.indexOf('### Relevant Memories')).toBeLessThan(text.indexOf('### Recent Project Timeline'));
-    expect(text).toContain('<command-name>');
-    expect(text).toContain('Using model opus');
+    expect(text).toContain('Investigated MCP context-pack retrieval ranking');
+    expect(text).not.toContain('<command-name>');
+    expect(text).not.toContain('Using model opus');
+    expect(text).not.toContain('AGENTS.md instructions');
+    expect(text).not.toContain('<INSTRUCTIONS>');
+    expect(text).not.toContain('Alpha AI Trader specs');
+    expect(text).not.toContain('alpha-ai-trader');
   });
 
   it('redacts credential-bearing connection strings from context-pack previews', async () => {


### PR DESCRIPTION
## Summary
- Overfetch MCP context-pack candidates before post-filtering so useful memories survive quality filters.
- Suppress low-signal context-pack noise: command/tool artifacts, environment/AGENTS instruction dumps, and cross-project workspace path snippets.
- Keep generic continuation prompts timeline-first while applying the same project-scope/noise filters to relevant memories and timeline entries.

## Validation
- [x] `npm test -- --run tests/extensions/mcp-context-tools.test.ts tests/core/retrieval-quality.test.ts`
- [x] `npm run typecheck -- --pretty false`
- [x] `git diff --check`
- [x] `npm test -- --run`
- [x] `npm run build`
- [x] `graphify update .`
- [x] static/privacy scan: no findings
- [x] independent pre-commit review: passed
