### PR TITLE
[verified] suppress stale continuation handoffs

### DIFF
--- a/src/core/retrieval-quality.ts
+++ b/src/core/retrieval-quality.ts
@@ -17,6 +17,7 @@ const LOW_SIGNAL_CONTEXT_PATTERNS = [
   /<environment_context\b[\s\S]*<\/environment_context>/i,
   /<turn_aborted>/i,
   /^#\s*AGENTS\.md\s+instructions\b[\s\S]*<INSTRUCTIONS>/i,
+  /^\s*(?:understood[,\s.]*)?(?:stopping|stopped|pausing|paused)\s+here\b[\s\S]{0,180}\blet\s+me\s+know\s+when\s+you(?:'d|\s+would)?\s+like\s+to\s+continue\b/i,
   /^➜\s+\S+\s+git:\([^)]*\)\s+/i,
   /^\$\s+\S+/i
 ];

--- a/tests/core/retrieval-quality.test.ts
+++ b/tests/core/retrieval-quality.test.ts
@@ -24,6 +24,8 @@ describe('retrieval quality guards', () => {
     expect(isLowSignalContextContent('prefix <environment_context><cwd>/repo/app</cwd></environment_context> suffix')).toBe(true);
     expect(isLowSignalContextContent('<command-name>/model</command-name>\n<local-command-stdout>opus</local-command-stdout>')).toBe(true);
     expect(isLowSignalContextContent('# AGENTS.md instructions for /repo/app <INSTRUCTIONS> ## Skills A skill is local instructions.')).toBe(true);
+    expect(isLowSignalContextContent('Understood, stopping here. Let me know when you would like to continue with the design doc review.')).toBe(true);
+    expect(isLowSignalContextContent('Implementation note: suppress the stale phrase "Understood, stopping here. Let me know when you would like to continue." from context packs.')).toBe(false);
     expect(isLowSignalContextContent('Merged PR #15 and synced local main.')).toBe(false);
   });
 });

--- a/tests/extensions/mcp-context-tools.test.ts
+++ b/tests/extensions/mcp-context-tools.test.ts
@@ -313,6 +313,13 @@ describe('MCP project context tools', () => {
       timestamp: new Date('2026-05-06T04:02:00.000Z'),
       content: 'Current CML state: PR #17 merged, main synced, MCP runtime reloaded; continue with freshness-aware relevance filtering.'
     });
+    const staleContinuationHandoff = event({
+      id: '78787878-7878-4787-8787-787878787878',
+      sessionId: 'session-old-handoff',
+      eventType: 'agent_response',
+      timestamp: new Date('2026-05-04T15:10:00.000Z'),
+      content: 'Understood, stopping here. Let me know when you would like to continue with the design doc review and edits.'
+    });
     const extraStrongButLowerPriority = event({
       id: '67676767-6767-4676-8676-676767676767',
       sessionId: 'session-current',
@@ -323,6 +330,7 @@ describe('MCP project context tools', () => {
 
     mocks.projectService.retrieveMemories.mockResolvedValue({
       memories: [
+        { event: staleContinuationHandoff, score: 0.99 },
         { event: weakRecentPublish, score: 0.62 },
         { event: strongFreshnessPlan, score: 0.82 },
         { event: strongPrState, score: 0.8 },
@@ -357,6 +365,8 @@ describe('MCP project context tools', () => {
     expect(text).not.toContain('Bumped package version');
     expect(text).not.toContain('DuckDB native module mismatch');
     expect(text).not.toContain('Additional implementation note');
+    expect(text).not.toContain('stopping here');
+    expect(text).not.toContain('design doc review');
   });
 
   it('keeps non-generic context-pack ordering while suppressing low-signal artifacts', async () => {


### PR DESCRIPTION
## Summary
- Suppress stale assistant handoff snippets such as "stopping here / let me know when you would like to continue" from MCP context-pack output.
- Keep the filter anchored to message starts so implementation notes that quote the phrase are preserved.
- Add regression coverage for both the low-signal guard and generic continuation context-pack output.

## Validation
- [x] RED: focused low-signal test failed before implementation
- [x] RED: negative quote-preservation test failed before anchoring the regex
- [x] `npm test -- --run tests/core/retrieval-quality.test.ts tests/extensions/mcp-context-tools.test.ts`
- [x] `npm run typecheck -- --pretty false`
- [x] `git diff --check`
- [x] `npm test -- --run`
- [x] `npm run build`
- [x] `graphify update .`
- [x] static/privacy scan: no findings
- [x] independent pre-commit review: passed
