### PR TITLE
Add latest session freshness import

### DIFF
--- a/src/apps/cli/codex-import-runner.ts
+++ b/src/apps/cli/codex-import-runner.ts
@@ -15,6 +15,7 @@ export interface CodexImportCommandOptions {
   session?: string;
   all?: boolean;
   limit?: string;
+  sessionLimit?: string;
   force?: boolean;
   verbose?: boolean;
   sessionsDir?: string;
@@ -49,8 +50,12 @@ const realDeps: CodexImportRunnerDeps = {
 
 function parsePositiveInteger(value: string | undefined, name: string): number | undefined {
   if (value === undefined) return undefined;
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
+  const normalized = value.trim();
+  if (!/^\d+$/.test(normalized)) {
+    throw new Error(`Invalid --${name}: expected a positive integer`);
+  }
+  const parsed = Number.parseInt(normalized, 10);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
     throw new Error(`Invalid --${name}: expected a positive integer`);
   }
   return parsed;
@@ -76,6 +81,7 @@ export async function runCodexImportOnce(
 
   const importOptions: ImportOptions = {
     limit: parsePositiveInteger(options.limit, 'limit'),
+    sessionLimit: parsePositiveInteger(options.sessionLimit, 'session-limit'),
     force: options.force,
     verbose: options.verbose,
     onProgress: deps.onProgress

--- a/src/apps/cli/hermes-import-runner.ts
+++ b/src/apps/cli/hermes-import-runner.ts
@@ -15,6 +15,7 @@ export interface HermesImportCommandOptions {
   session?: string;
   all?: boolean;
   limit?: string;
+  sessionLimit?: string;
   force?: boolean;
   verbose?: boolean;
   stateDb?: string;
@@ -50,8 +51,12 @@ const realDeps: HermesImportRunnerDeps = {
 
 function parsePositiveInteger(value: string | undefined, name: string): number | undefined {
   if (value === undefined) return undefined;
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
+  const normalized = value.trim();
+  if (!/^\d+$/.test(normalized)) {
+    throw new Error(`Invalid --${name}: expected a positive integer`);
+  }
+  const parsed = Number.parseInt(normalized, 10);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
     throw new Error(`Invalid --${name}: expected a positive integer`);
   }
   return parsed;
@@ -81,6 +86,7 @@ export async function runHermesImportOnce(
 
   const importOptions: ImportOptions = {
     limit: parsePositiveInteger(options.limit, 'limit'),
+    sessionLimit: parsePositiveInteger(options.sessionLimit, 'session-limit'),
     force: options.force,
     verbose: options.verbose,
     onProgress: deps.onProgress

--- a/src/apps/cli/index.ts
+++ b/src/apps/cli/index.ts
@@ -126,9 +126,13 @@ type HermesValidateCommandOptions = {
 };
 
 function parsePositiveIntegerOption(value: string | undefined, optionName: string): number | undefined {
-  if (!value) return undefined;
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
+  if (value === undefined) return undefined;
+  const normalized = value.trim();
+  if (!/^\d+$/.test(normalized)) {
+    throw new Error(`Invalid --${optionName}: expected a positive integer`);
+  }
+  const parsed = Number.parseInt(normalized, 10);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
     throw new Error(`Invalid --${optionName}: expected a positive integer`);
   }
   return parsed;
@@ -949,6 +953,7 @@ program
   .option('-s, --session <file>', 'Import specific session file (JSONL)')
   .option('-a, --all', 'Import all sessions from all projects')
   .option('-l, --limit <number>', 'Limit messages per session')
+  .option('--session-limit <number>', 'Limit recent matching sessions to import')
   .option('-f, --force', 'Force reimport: delete existing events and reimport with turn_id grouping')
   .option('--embedding-model <name>', 'Embedding model override (default: jinaai/jina-embeddings-v5-text-nano-text-matching, or env CLAUDE_MEMORY_EMBEDDING_MODEL; fallback env: CLAUDE_MEMORY_EMBEDDING_FALLBACK_MODEL)')
   .option('-v, --verbose', 'Show detailed progress')
@@ -967,7 +972,8 @@ program
     const importer = createSessionHistoryImporter(service);
 
     const importOpts = {
-      limit: options.limit ? parseInt(options.limit) : undefined,
+      limit: parsePositiveIntegerOption(options.limit, 'limit'),
+      sessionLimit: parsePositiveIntegerOption(options.sessionLimit, 'session-limit'),
       force: options.force,
       verbose: options.verbose,
       onProgress: renderProgress
@@ -1148,7 +1154,8 @@ codexCmd
   .option('-s, --session <file>', 'Import one Codex session JSONL file')
   .option('-a, --all', 'Import all Codex sessions into global memory unless --project is supplied')
   .option('--sessions-dir <path>', 'Codex sessions directory (default: ~/.codex/sessions)')
-  .option('-l, --limit <number>', 'Limit messages imported per session')
+  .option('-l, --limit <number>', 'Limit memories imported across selected matching sessions')
+  .option('--session-limit <number>', 'Limit recent matching sessions to import')
   .option('-f, --force', 'Delete existing events for each imported session before reimporting')
   .option('-v, --verbose', 'Show detailed progress')
   .option('--no-process-embeddings', 'Skip processing pending embeddings after import')
@@ -1230,7 +1237,8 @@ hermesCmd
   .option('-s, --session <id>', 'Import one Hermes session id')
   .option('-a, --all', 'Import all Hermes sessions into global memory unless --project is supplied')
   .option('--state-db <path>', 'Hermes state database path (default: ~/.hermes/state.db)')
-  .option('-l, --limit <number>', 'Limit memories imported across matching sessions')
+  .option('-l, --limit <number>', 'Limit messages imported per selected Hermes session')
+  .option('--session-limit <number>', 'Limit recent matching sessions to import')
   .option('-f, --force', 'Delete existing events for each imported session before reimporting')
   .option('-v, --verbose', 'Show detailed progress')
   .option('--no-process-embeddings', 'Skip processing pending embeddings after import')

--- a/src/extensions/mcp/handlers.ts
+++ b/src/extensions/mcp/handlers.ts
@@ -3,11 +3,16 @@
  * Implementation of tool calls
  */
 
+import * as path from 'node:path';
+
 import {
   getDefaultMemoryService,
   getMemoryServiceForProject,
   type MemoryService
 } from '../../services/memory-service.js';
+import { createSessionHistoryImporter, type ImportResult } from '../../services/session-history-importer.js';
+import { createCodexSessionHistoryImporter } from '../../services/codex-session-history-importer.js';
+import { createHermesSessionHistoryImporter } from '../../services/hermes-session-history-importer.js';
 import { generateCitationId } from '../../core/citation-generator.js';
 import { applyPrivacyFilter, maskSensitiveInput } from '../../core/privacy/filter.js';
 import {
@@ -34,6 +39,16 @@ export async function handleToolCall(
   args: Record<string, unknown>
 ): Promise<ToolResult> {
   try {
+    if (name === 'mem-import-latest') {
+      const projectPath = optionalString(args.projectPath);
+      if (!projectPath || !path.isAbsolute(projectPath)) {
+        return {
+          content: [{ type: 'text', text: 'Error: mem-import-latest requires an explicit absolute projectPath.' }],
+          isError: true
+        };
+      }
+    }
+
     const memoryService = resolveMemoryService(args);
     await memoryService.initialize();
 
@@ -53,6 +68,9 @@ export async function handleToolCall(
       case 'mem-context-pack':
         return await handleMemContextPack(memoryService, args);
 
+      case 'mem-import-latest':
+        return await handleMemImportLatest(memoryService, args);
+
       case 'mem-project-timeline':
         return await handleMemProjectTimeline(memoryService, args);
 
@@ -67,7 +85,7 @@ export async function handleToolCall(
     }
   } catch (error) {
     return {
-      content: [{ type: 'text', text: `Error: ${(error as Error).message}` }],
+      content: [{ type: 'text', text: `Error: ${safeErrorSummary(error)}` }],
       isError: true
     };
   }
@@ -263,6 +281,90 @@ async function handleMemContextPack(memoryService: MemoryService, args: Record<s
     lines.push(`- Source refs: mem-source-ref ids=[${sourceIds.map((id) => `'${id}'`).join(', ')}]`);
     lines.push('- Wider timeline: mem-project-timeline with the same projectPath');
     lines.push('');
+  }
+
+  return textResult(lines.join('\n'));
+}
+
+type LatestImportSource = 'claude' | 'codex' | 'hermes';
+
+interface LatestImportSummary {
+  source: LatestImportSource;
+  result?: ImportResult;
+  error?: string;
+}
+
+async function handleMemImportLatest(memoryService: MemoryService, args: Record<string, unknown>): Promise<ToolResult> {
+  const projectPath = optionalString(args.projectPath);
+  if (!projectPath) {
+    return {
+      content: [{ type: 'text', text: 'Error: mem-import-latest requires an explicit projectPath.' }],
+      isError: true
+    };
+  }
+
+  const sources = sourceListArg(args.sources);
+  const sessionLimit = numberArg(args.sessionLimit, 1, 1, 10);
+  const messageLimit = numberArg(args.messageLimit, 200, 1, 1000);
+  const force = args.force === true;
+  const processEmbeddings = args.processEmbeddings === true;
+  const summaries: LatestImportSummary[] = [];
+
+  for (const source of sources) {
+    try {
+      if (source === 'claude') {
+        const importer = createSessionHistoryImporter(memoryService);
+        summaries.push({
+          source,
+          result: await importer.importProject(projectPath, { projectPath, sessionLimit, limit: messageLimit, force })
+        });
+      } else if (source === 'codex') {
+        const importer = createCodexSessionHistoryImporter(memoryService, { sessionsDir: optionalString(args.sessionsDir) });
+        summaries.push({
+          source,
+          result: await importer.importProject(projectPath, { projectPath, sessionLimit, limit: messageLimit, force })
+        });
+      } else {
+        const importer = createHermesSessionHistoryImporter(memoryService, { stateDbPath: optionalString(args.stateDb) });
+        summaries.push({
+          source,
+          result: await importer.importProject(projectPath, { projectPath, sessionLimit, limit: messageLimit, force })
+        });
+      }
+    } catch (error) {
+      summaries.push({ source, error: safeErrorSummary(error) });
+    }
+  }
+
+  const embeddingsProcessed = processEmbeddings
+    ? await memoryService.processPendingEmbeddings()
+    : undefined;
+
+  const lines: string[] = [
+    '## Latest Session Import',
+    '',
+    '- Project: supplied',
+    `- Sources: ${sources.join(', ')}`,
+    `- Recent session limit per source: ${sessionLimit}`,
+    `- Message limit per source: ${messageLimit}`,
+    `- Force reimport: ${force ? 'yes' : 'no'}`,
+    `- Embeddings: ${processEmbeddings ? `processed ${embeddingsProcessed ?? 0}` : 'skipped'}`,
+    '',
+    '### Source Results',
+    ''
+  ];
+
+  for (const summary of summaries) {
+    if (summary.result) {
+      lines.push(formatImportSummary(summary.source, summary.result));
+    } else {
+      lines.push(`- ${summary.source}: failed (${summary.error ?? 'details suppressed'})`);
+    }
+  }
+
+  const failedCount = summaries.filter((summary) => summary.error).length;
+  if (failedCount > 0) {
+    lines.push('', `Warnings: ${failedCount} source(s) failed; local path details were suppressed.`);
   }
 
   return textResult(lines.join('\n'));
@@ -640,6 +742,39 @@ function stringArg(value: unknown, fallback: string): string {
 
 function optionalString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function sourceListArg(value: unknown): LatestImportSource[] {
+  const fallback: LatestImportSource[] = ['hermes', 'codex'];
+  if (value === undefined) return fallback;
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error('Invalid sources: expected a non-empty array of claude, codex, or hermes');
+  }
+
+  const allowed = new Set<LatestImportSource>(['claude', 'codex', 'hermes']);
+  const selected: LatestImportSource[] = [];
+  for (const item of value) {
+    const normalized = String(item).trim().toLowerCase() as LatestImportSource;
+    if (!allowed.has(normalized)) {
+      throw new Error('Invalid source: expected claude, codex, or hermes');
+    }
+    if (!selected.includes(normalized)) selected.push(normalized);
+  }
+  return selected;
+}
+
+function formatImportSummary(source: LatestImportSource, result: ImportResult): string {
+  return `- ${source}: sessions=${result.totalSessions} messages=${result.totalMessages} prompts=${result.importedPrompts} responses=${result.importedResponses} skipped=${result.skippedDuplicates} errors=${result.errors.length}`;
+}
+
+function safeErrorSummary(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  const scrubbedPaths = raw
+    .replace(/[A-Za-z]:[\\/][^\s'"`<>)]*/g, '[path]')
+    .replace(/~[\\/][^\s'"`<>)]*/g, '[path]')
+    .replace(/(^|[\s([{=,:;])\/(?!\/)[^\s'"`<>)]*/g, '$1[path]')
+    .replace(/(^|[\s([{=,:;])(?:\.{1,2}[\\/])?[^\s'"`<>)]*\.(?:db|sqlite|jsonl|log|txt)\b[^\s'"`<>)]*/g, '$1[path]');
+  return safeInline(scrubbedPaths, 180) || 'details suppressed';
 }
 
 function numberArg(value: unknown, fallback: number, min: number, max: number): number {

--- a/src/extensions/mcp/tools.ts
+++ b/src/extensions/mcp/tools.ts
@@ -116,6 +116,49 @@ export const tools: Tool[] = [
     }
   },
   {
+    name: 'mem-import-latest',
+    description: 'Explicitly import the latest local Claude Code, Codex, and/or Hermes session history into project-scoped memory before retrieving context. This mutates memory; use for freshness jobs before mem-context-pack.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Required absolute project path. Import is always project-scoped to avoid cross-project memory mixing.'
+        },
+        sources: {
+          type: 'array',
+          items: { type: 'string', enum: ['claude', 'codex', 'hermes'] },
+          description: 'Sources to import (default: hermes and codex)'
+        },
+        sessionLimit: {
+          type: 'number',
+          description: 'Maximum recent matching sessions per source to import (default: 1, max: 10)'
+        },
+        messageLimit: {
+          type: 'number',
+          description: 'Maximum messages/memories per source import (default: 200, max: 1000)'
+        },
+        force: {
+          type: 'boolean',
+          description: 'Force reimport by deleting existing events for imported sessions first (default: false)'
+        },
+        processEmbeddings: {
+          type: 'boolean',
+          description: 'Process pending embeddings after import (default: false for fast freshness imports)'
+        },
+        sessionsDir: {
+          type: 'string',
+          description: 'Optional Codex sessions directory override'
+        },
+        stateDb: {
+          type: 'string',
+          description: 'Optional Hermes state database path override'
+        }
+      },
+      required: ['projectPath']
+    }
+  },
+  {
     name: 'mem-project-timeline',
     description: 'Summarize recent project memory by session, source agent, event counts, and safe previews. Useful for understanding what happened recently before continuing work.',
     inputSchema: {

--- a/src/services/codex-session-history-importer.ts
+++ b/src/services/codex-session-history-importer.ts
@@ -214,6 +214,32 @@ export function listCodexSessionFilesRecursive(rootDir: string): string[] {
   return out.sort();
 }
 
+function getFileMtimeMs(filePath: string): number {
+  try {
+    return fs.statSync(filePath).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+function selectRecentCodexSessionFiles(files: string[], sessionLimit?: number): string[] {
+  if (sessionLimit === undefined) return files;
+  const limit = Number.isFinite(sessionLimit) && sessionLimit > 0 ? Math.floor(sessionLimit) : undefined;
+  if (limit === undefined) return files;
+  return [...files]
+    .sort((a, b) => getFileMtimeMs(b) - getFileMtimeMs(a) || b.localeCompare(a))
+    .slice(0, limit);
+}
+
+function normalizePositiveImportLimit(limit?: number): number | undefined {
+  if (limit === undefined) return undefined;
+  return Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : undefined;
+}
+
+function countStoredEntries(result: ImportResult): number {
+  return result.importedPrompts + result.importedResponses + result.skippedDuplicates;
+}
+
 export async function readCodexSessionMeta(filePath: string): Promise<CodexSessionMeta> {
   const fileStream = fs.createReadStream(filePath, { encoding: 'utf-8' });
   const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
@@ -629,26 +655,33 @@ export class CodexSessionHistoryImporter {
       }
     }
 
-    result.totalSessions = matchingFiles.length;
+    const selectedFiles = selectRecentCodexSessionFiles(matchingFiles, options.sessionLimit);
     onProgress?.({ phase: 'scan', message: `Found ${matchingFiles.length} Codex session(s) for this project` });
 
     const effectiveProjectPath = options.projectPath ?? projectPath;
+    const totalLimit = normalizePositiveImportLimit(options.limit);
+    let storedAcrossSessions = 0;
 
-    for (let i = 0; i < matchingFiles.length; i++) {
-      const filePath = matchingFiles[i];
+    for (let i = 0; i < selectedFiles.length; i++) {
+      if (totalLimit !== undefined && storedAcrossSessions >= totalLimit) break;
+      const filePath = selectedFiles[i];
+      const remainingLimit = totalLimit === undefined ? undefined : totalLimit - storedAcrossSessions;
       try {
-        onProgress?.({ phase: 'session-start', sessionIndex: i, totalSessions: matchingFiles.length, filePath });
+        onProgress?.({ phase: 'session-start', sessionIndex: i, totalSessions: selectedFiles.length, filePath });
         const sessionResult = await this.importSessionFile(filePath, {
           ...options,
+          limit: remainingLimit,
           projectPath: effectiveProjectPath,
           _sessionIndex: i,
         } as ImportOptions & { _sessionIndex: number });
 
+        result.totalSessions++;
         result.totalMessages += sessionResult.totalMessages;
         result.importedPrompts += sessionResult.importedPrompts;
         result.importedResponses += sessionResult.importedResponses;
         result.skippedDuplicates += sessionResult.skippedDuplicates;
         result.errors.push(...sessionResult.errors);
+        storedAcrossSessions += countStoredEntries(sessionResult);
 
         onProgress?.({
           phase: 'session-done',
@@ -684,23 +717,31 @@ export class CodexSessionHistoryImporter {
 
     onProgress?.({ phase: 'scan', message: 'Scanning all Codex sessions...' });
     const sessionFiles = this.listSessionFilesRecursive(sessionsRoot);
-    result.totalSessions = sessionFiles.length;
+    const selectedFiles = selectRecentCodexSessionFiles(sessionFiles, options.sessionLimit);
     onProgress?.({ phase: 'scan', message: `Found ${sessionFiles.length} Codex session file(s)` });
 
-    for (let i = 0; i < sessionFiles.length; i++) {
-      const filePath = sessionFiles[i];
+    const totalLimit = normalizePositiveImportLimit(options.limit);
+    let storedAcrossSessions = 0;
+
+    for (let i = 0; i < selectedFiles.length; i++) {
+      if (totalLimit !== undefined && storedAcrossSessions >= totalLimit) break;
+      const filePath = selectedFiles[i];
+      const remainingLimit = totalLimit === undefined ? undefined : totalLimit - storedAcrossSessions;
       try {
-        onProgress?.({ phase: 'session-start', sessionIndex: i, totalSessions: sessionFiles.length, filePath });
+        onProgress?.({ phase: 'session-start', sessionIndex: i, totalSessions: selectedFiles.length, filePath });
         const sessionResult = await this.importSessionFile(filePath, {
           ...options,
+          limit: remainingLimit,
           _sessionIndex: i,
         } as ImportOptions & { _sessionIndex: number });
 
+        result.totalSessions++;
         result.totalMessages += sessionResult.totalMessages;
         result.importedPrompts += sessionResult.importedPrompts;
         result.importedResponses += sessionResult.importedResponses;
         result.skippedDuplicates += sessionResult.skippedDuplicates;
         result.errors.push(...sessionResult.errors);
+        storedAcrossSessions += countStoredEntries(sessionResult);
 
         onProgress?.({
           phase: 'session-done',

--- a/src/services/hermes-session-history-importer.ts
+++ b/src/services/hermes-session-history-importer.ts
@@ -524,18 +524,28 @@ export class HermesSessionHistoryImporter {
   ): Promise<ImportResult> {
     const result = createEmptyImportResult();
     const onProgress = options.onProgress;
-    const limit = options.limit ?? Infinity;
-    let storedCount = 0;
+    const sessionLimit = options.sessionLimit ?? Infinity;
+    const selectedSessions = Number.isFinite(sessionLimit) && sessionLimit > 0
+      ? sessions.slice(0, Math.floor(sessionLimit))
+      : sessions;
 
     onProgress?.({ phase: 'scan', message: `Found ${sessions.length} Hermes session(s)` });
 
-    for (let i = 0; i < sessions.length; i++) {
-      if (storedCount >= limit) break;
-      const session = sessions[i];
-      onProgress?.({ phase: 'session-start', sessionIndex: i, totalSessions: sessions.length, filePath: this.stateDbPath });
+    for (let i = 0; i < selectedSessions.length; i++) {
+      const session = selectedSessions[i];
+      onProgress?.({ phase: 'session-start', sessionIndex: i, totalSessions: selectedSessions.length, filePath: this.stateDbPath });
 
+      let sessionStoredCount = 0;
       const memorySessionId = makeMemorySessionId(session.id);
-      const sessionResult = await this.importOneSession(db, session, memorySessionId, options, i, () => storedCount, (next) => { storedCount = next; });
+      const sessionResult = await this.importOneSession(
+        db,
+        session,
+        memorySessionId,
+        options,
+        i,
+        () => sessionStoredCount,
+        (next) => { sessionStoredCount = next; }
+      );
 
       result.totalSessions++;
       result.totalMessages += sessionResult.totalMessages;

--- a/src/services/session-history-importer.ts
+++ b/src/services/session-history-importer.ts
@@ -26,6 +26,8 @@ export interface ImportOptions {
   projectPath?: string;
   sessionId?: string;
   limit?: number;
+  /** Limit how many matching sessions are imported. Useful for freshness jobs that only need the latest active session. */
+  sessionLimit?: number;
   skipExisting?: boolean;
   force?: boolean;
   verbose?: boolean;
@@ -80,6 +82,30 @@ export function isWorthStoringPrompt(content: string): boolean {
   if (trimmed.length < 15) return false;
   if (!/[a-zA-Z가-힣]{2,}/.test(trimmed)) return false;
   return true;
+}
+
+function getFileMtimeMs(filePath: string): number {
+  try {
+    return fs.statSync(filePath).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+function selectRecentSessionFiles(files: string[], sessionLimit?: number): string[] {
+  if (sessionLimit === undefined) return files;
+  return [...files]
+    .sort((a, b) => getFileMtimeMs(b) - getFileMtimeMs(a) || b.localeCompare(a))
+    .slice(0, sessionLimit);
+}
+
+function parseSessionLimit(value?: number): number | undefined {
+  if (value === undefined) return undefined;
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : undefined;
+}
+
+function applySessionLimit(files: string[], options: ImportOptions): string[] {
+  return selectRecentSessionFiles(files, parseSessionLimit(options.sessionLimit));
 }
 
 function classifyEntry(entry: ClaudeMessage): 'user_prompt' | 'tool_result' | 'agent_text' | 'tool_use' | 'thinking' | 'skip' {
@@ -162,7 +188,8 @@ export class SessionHistoryImporter {
       allSessionFiles.push(...files);
     }
     const sessionFiles = [...new Set(allSessionFiles)];
-    result.totalSessions = sessionFiles.length;
+    const selectedSessionFiles = applySessionLimit(sessionFiles, options);
+    result.totalSessions = selectedSessionFiles.length;
     onProgress?.({
       phase: 'scan',
       message: `Found ${sessionFiles.length} sessions in ${projectDirs.length} matched project folder(s)`
@@ -176,11 +203,11 @@ export class SessionHistoryImporter {
       console.log(`Found ${sessionFiles.length} session files across matched folders`);
     }
 
-    // Import each session
-    for (let i = 0; i < sessionFiles.length; i++) {
-      const sessionFile = sessionFiles[i];
+    // Import each selected session
+    for (let i = 0; i < selectedSessionFiles.length; i++) {
+      const sessionFile = selectedSessionFiles[i];
       try {
-        onProgress?.({ phase: 'session-start', sessionIndex: i, totalSessions: sessionFiles.length, filePath: sessionFile });
+        onProgress?.({ phase: 'session-start', sessionIndex: i, totalSessions: selectedSessionFiles.length, filePath: sessionFile });
         const sessionResult = await this.importSessionFile(sessionFile, {
           ...options,
           _sessionIndex: i,
@@ -412,16 +439,22 @@ export class SessionHistoryImporter {
       console.log(`Found ${projectDirs.length} project directories, ${allSessionFiles.length} sessions`);
     }
 
-    // Import all session files with progress tracking
-    for (let i = 0; i < allSessionFiles.length; i++) {
-      const sessionFile = allSessionFiles[i];
+    const selectedSessionFiles = applySessionLimit(allSessionFiles, options);
+    result.totalSessions = selectedSessionFiles.length;
+    onProgress?.({
+      phase: 'scan',
+      message: `Selected ${selectedSessionFiles.length} of ${allSessionFiles.length} session(s) for import`
+    });
+
+    // Import selected session files with progress tracking
+    for (let i = 0; i < selectedSessionFiles.length; i++) {
+      const sessionFile = selectedSessionFiles[i];
       try {
-        onProgress?.({ phase: 'session-start', sessionIndex: i, totalSessions: allSessionFiles.length, filePath: sessionFile });
+        onProgress?.({ phase: 'session-start', sessionIndex: i, totalSessions: selectedSessionFiles.length, filePath: sessionFile });
         const sessionResult = await this.importSessionFile(sessionFile, {
           ...options,
           _sessionIndex: i,
         } as ImportOptions & { _sessionIndex: number });
-        result.totalSessions++;
         result.totalMessages += sessionResult.totalMessages;
         result.importedPrompts += sessionResult.importedPrompts;
         result.importedResponses += sessionResult.importedResponses;

--- a/tests/apps/codex-import-runner.test.ts
+++ b/tests/apps/codex-import-runner.test.ts
@@ -52,7 +52,7 @@ describe('Codex import runner', () => {
   });
 
   it('imports the current project from Codex sessions into the project-scoped memory service', async () => {
-    const outcome = await runCodexImportOnce({ sessionsDir: '/tmp/codex-sessions', limit: '9' }, deps);
+    const outcome = await runCodexImportOnce({ sessionsDir: '/tmp/codex-sessions', limit: '9', sessionLimit: '1' }, deps);
 
     expect(deps?.getMemoryServiceForProject).toHaveBeenCalledWith('/repo/current');
     expect(deps?.getDefaultMemoryService).not.toHaveBeenCalled();
@@ -62,6 +62,7 @@ describe('Codex import runner', () => {
     expect(importer.importProject).toHaveBeenCalledWith('/repo/current', expect.objectContaining({
       projectPath: '/repo/current',
       limit: 9,
+      sessionLimit: 1,
       onProgress: deps?.onProgress
     }));
     expect(projectService.processPendingEmbeddings).toHaveBeenCalledTimes(1);
@@ -88,5 +89,11 @@ describe('Codex import runner', () => {
       projectPath: '/repo/selected',
       force: true
     }));
+  });
+
+  it('rejects non-decimal integer limits instead of partially parsing them', async () => {
+    await expect(runCodexImportOnce({ limit: '1foo' }, deps)).rejects.toThrow('Invalid --limit');
+    await expect(runCodexImportOnce({ sessionLimit: '1.5' }, deps)).rejects.toThrow('Invalid --session-limit');
+    await expect(runCodexImportOnce({ sessionLimit: '1e2' }, deps)).rejects.toThrow('Invalid --session-limit');
   });
 });

--- a/tests/apps/hermes-import-runner.test.ts
+++ b/tests/apps/hermes-import-runner.test.ts
@@ -52,7 +52,7 @@ describe('Hermes import runner', () => {
   });
 
   it('imports the current project from Hermes state.db into the project-scoped memory service', async () => {
-    const outcome = await runHermesImportOnce({ stateDb: '/tmp/hermes-state.db', limit: '9' }, deps);
+    const outcome = await runHermesImportOnce({ stateDb: '/tmp/hermes-state.db', limit: '9', sessionLimit: '1' }, deps);
 
     expect(deps?.getMemoryServiceForProject).toHaveBeenCalledWith('/repo/current');
     expect(deps?.getDefaultMemoryService).not.toHaveBeenCalled();
@@ -62,6 +62,7 @@ describe('Hermes import runner', () => {
     expect(importer.importProject).toHaveBeenCalledWith('/repo/current', expect.objectContaining({
       projectPath: '/repo/current',
       limit: 9,
+      sessionLimit: 1,
       onProgress: deps?.onProgress
     }));
     expect(projectService.processPendingEmbeddings).toHaveBeenCalledTimes(1);
@@ -88,5 +89,11 @@ describe('Hermes import runner', () => {
       projectPath: '/repo/selected',
       force: true
     }));
+  });
+
+  it('rejects non-decimal integer limits instead of partially parsing them', async () => {
+    await expect(runHermesImportOnce({ limit: '1foo' }, deps)).rejects.toThrow('Invalid --limit');
+    await expect(runHermesImportOnce({ sessionLimit: '1.5' }, deps)).rejects.toThrow('Invalid --session-limit');
+    await expect(runHermesImportOnce({ sessionLimit: '1e2' }, deps)).rejects.toThrow('Invalid --session-limit');
   });
 });

--- a/tests/core/codex-session-history-importer-validation.test.ts
+++ b/tests/core/codex-session-history-importer-validation.test.ts
@@ -1,9 +1,9 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { validateCodexSessions } from '../../src/services/codex-session-history-importer.js';
+import { createCodexSessionHistoryImporter, validateCodexSessions } from '../../src/services/codex-session-history-importer.js';
 
 const tempDirs: string[] = [];
 
@@ -110,5 +110,76 @@ describe('Codex session validation replay', () => {
     expect(report.totals.missingProjectCwd).toBe(1);
     expect(report.topProjects).toHaveLength(2);
     expect(report.warnings.some((warning) => warning.includes('missing cwd'))).toBe(true);
+  });
+
+  it('imports only the most recently modified matching Codex session when sessionLimit is set', async () => {
+    const sessionsDir = tempDir();
+    const projectA = join(sessionsDir, 'project-a');
+    const oldFile = join(sessionsDir, 'rollout-2026-05-05T00-00-00-session-old.jsonl');
+    const latestFile = join(sessionsDir, 'rollout-2026-05-05T00-10-00-session-latest.jsonl');
+
+    writeJsonl(oldFile, [
+      { type: 'session_meta', payload: { id: 'session-old', cwd: projectA } },
+      { type: 'response_item', timestamp: '2026-05-05T00:00:01.000Z', payload: { type: 'message', role: 'user', content: 'old Codex project session should not be imported now' } }
+    ]);
+    writeJsonl(latestFile, [
+      { type: 'session_meta', payload: { id: 'session-latest', cwd: projectA } },
+      { type: 'response_item', timestamp: '2026-05-05T00:10:01.000Z', payload: { type: 'message', role: 'user', content: 'latest Codex project session should be imported now' } }
+    ]);
+    utimesSync(oldFile, new Date('2026-05-05T00:00:00.000Z'), new Date('2026-05-05T00:00:00.000Z'));
+    utimesSync(latestFile, new Date('2026-05-05T00:10:00.000Z'), new Date('2026-05-05T00:10:00.000Z'));
+
+    const memoryService = {
+      startSession: vi.fn(async (_sessionId: string, _projectPath?: string) => undefined),
+      endSession: vi.fn(async (_sessionId: string) => undefined),
+      deleteSessionEvents: vi.fn(async (_sessionId: string) => 0),
+      storeUserPrompt: vi.fn(async () => ({ success: true, isDuplicate: false })),
+      storeAgentResponse: vi.fn(async () => ({ success: true, isDuplicate: false }))
+    };
+    const importer = createCodexSessionHistoryImporter(memoryService as never, { sessionsDir });
+
+    const result = await importer.importProject(projectA, { sessionLimit: 1 });
+
+    expect(result.totalSessions).toBe(1);
+    expect(memoryService.startSession).toHaveBeenCalledTimes(1);
+    expect(memoryService.startSession).toHaveBeenCalledWith('session-latest', projectA);
+    expect(memoryService.storeUserPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies Codex import limit across selected matching sessions', async () => {
+    const sessionsDir = tempDir();
+    const projectA = join(sessionsDir, 'project-a');
+    const oldFile = join(sessionsDir, 'rollout-2026-05-05T00-00-00-session-old.jsonl');
+    const latestFile = join(sessionsDir, 'rollout-2026-05-05T00-10-00-session-latest.jsonl');
+
+    writeJsonl(oldFile, [
+      { type: 'session_meta', payload: { id: 'session-old', cwd: projectA } },
+      { type: 'response_item', timestamp: '2026-05-05T00:00:01.000Z', payload: { type: 'message', role: 'user', content: 'old prompt should remain outside the global Codex import limit' } },
+      { type: 'response_item', timestamp: '2026-05-05T00:00:02.000Z', payload: { type: 'message', role: 'assistant', content: 'old assistant should remain outside the global Codex import limit' } }
+    ]);
+    writeJsonl(latestFile, [
+      { type: 'session_meta', payload: { id: 'session-latest', cwd: projectA } },
+      { type: 'response_item', timestamp: '2026-05-05T00:10:01.000Z', payload: { type: 'message', role: 'user', content: 'latest prompt should be imported first' } },
+      { type: 'response_item', timestamp: '2026-05-05T00:10:02.000Z', payload: { type: 'message', role: 'assistant', content: 'latest assistant should be imported first' } }
+    ]);
+    utimesSync(oldFile, new Date('2026-05-05T00:00:00.000Z'), new Date('2026-05-05T00:00:00.000Z'));
+    utimesSync(latestFile, new Date('2026-05-05T00:10:00.000Z'), new Date('2026-05-05T00:10:00.000Z'));
+
+    const memoryService = {
+      startSession: vi.fn(async (_sessionId: string, _projectPath?: string) => undefined),
+      endSession: vi.fn(async (_sessionId: string) => undefined),
+      deleteSessionEvents: vi.fn(async (_sessionId: string) => 0),
+      storeUserPrompt: vi.fn(async () => ({ success: true, isDuplicate: false })),
+      storeAgentResponse: vi.fn(async () => ({ success: true, isDuplicate: false }))
+    };
+    const importer = createCodexSessionHistoryImporter(memoryService as never, { sessionsDir });
+
+    const result = await importer.importProject(projectA, { sessionLimit: 2, limit: 2 });
+
+    expect(result.totalSessions).toBe(1);
+    expect(memoryService.startSession).toHaveBeenCalledTimes(1);
+    expect(memoryService.startSession).toHaveBeenCalledWith('session-latest', projectA);
+    expect(memoryService.storeUserPrompt).toHaveBeenCalledTimes(1);
+    expect(memoryService.storeAgentResponse).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/core/hermes-session-history-importer-validation.test.ts
+++ b/tests/core/hermes-session-history-importer-validation.test.ts
@@ -249,4 +249,114 @@ describe('Hermes SessionDB validation/import', () => {
       errors: []
     });
   });
+
+  it('imports only the latest matching Hermes session when sessionLimit is set', async () => {
+    const dir = tempDir();
+    const stateDbPath = join(dir, 'state.db');
+    const projectA = join(dir, 'project-a');
+    const projectB = join(dir, 'project-b');
+    createHermesStateDb(stateDbPath, projectA, projectB);
+
+    const db = new Database(stateDbPath);
+    db.prepare(`
+      INSERT INTO sessions (id, source, user_id, model, system_prompt, started_at, title, message_count)
+      VALUES (@id, @source, @userId, @model, @systemPrompt, @startedAt, @title, @messageCount)
+    `).run({
+      id: 'session-newer-a',
+      source: 'discord',
+      userId: 'user-newer',
+      model: 'gpt-5.5',
+      systemPrompt: `Project Context\n${projectA}`,
+      startedAt: 1_779_000_300,
+      title: 'newer project a thread',
+      messageCount: 1
+    });
+    db.prepare(`
+      INSERT INTO messages (session_id, role, content, tool_name, timestamp)
+      VALUES (@sessionId, @role, @content, @toolName, @timestamp)
+    `).run({
+      sessionId: 'session-newer-a',
+      role: 'user',
+      content: 'latest Hermes project session should be imported now',
+      toolName: null,
+      timestamp: 1_779_000_301
+    });
+    db.close();
+
+    const memoryService = {
+      startSession: vi.fn(async (_sessionId: string, _projectPath?: string) => undefined),
+      endSession: vi.fn(async (_sessionId: string) => undefined),
+      deleteSessionEvents: vi.fn(async (_sessionId: string) => 0),
+      storeUserPrompt: vi.fn(async () => ({ success: true, isDuplicate: false })),
+      storeAgentResponse: vi.fn(async () => ({ success: true, isDuplicate: false }))
+    };
+
+    const importer = createHermesSessionHistoryImporter(memoryService as never, { stateDbPath });
+    const result = await importer.importProject(projectA, { sessionLimit: 1 });
+
+    expect(result.totalSessions).toBe(1);
+    expect(memoryService.startSession).toHaveBeenCalledTimes(1);
+    expect(memoryService.startSession).toHaveBeenCalledWith('hermes:session-newer-a', projectA);
+    expect(memoryService.storeUserPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies Hermes import limit per selected matching session', async () => {
+    const dir = tempDir();
+    const stateDbPath = join(dir, 'state.db');
+    const projectA = join(dir, 'project-a');
+    const projectB = join(dir, 'project-b');
+    createHermesStateDb(stateDbPath, projectA, projectB);
+
+    const db = new Database(stateDbPath);
+    db.prepare(`
+      INSERT INTO sessions (id, source, user_id, model, system_prompt, started_at, title, message_count)
+      VALUES (@id, @source, @userId, @model, @systemPrompt, @startedAt, @title, @messageCount)
+    `).run({
+      id: 'session-newer-a',
+      source: 'discord',
+      userId: 'user-newer',
+      model: 'gpt-5.5',
+      systemPrompt: `Project Context\n${projectA}`,
+      startedAt: 1_779_000_300,
+      title: 'newer project a thread',
+      messageCount: 2
+    });
+    const insertMessage = db.prepare(`
+      INSERT INTO messages (session_id, role, content, tool_name, timestamp)
+      VALUES (@sessionId, @role, @content, @toolName, @timestamp)
+    `);
+    insertMessage.run({
+      sessionId: 'session-newer-a',
+      role: 'user',
+      content: 'latest Hermes project prompt should be imported under per-session limit',
+      toolName: null,
+      timestamp: 1_779_000_301
+    });
+    insertMessage.run({
+      sessionId: 'session-newer-a',
+      role: 'assistant',
+      content: 'latest Hermes response should be skipped by a per-session limit of one',
+      toolName: null,
+      timestamp: 1_779_000_302
+    });
+    db.close();
+
+    const memoryService = {
+      startSession: vi.fn(async (_sessionId: string, _projectPath?: string) => undefined),
+      endSession: vi.fn(async (_sessionId: string) => undefined),
+      deleteSessionEvents: vi.fn(async (_sessionId: string) => 0),
+      storeUserPrompt: vi.fn(async () => ({ success: true, isDuplicate: false })),
+      storeAgentResponse: vi.fn(async () => ({ success: true, isDuplicate: false }))
+    };
+
+    const importer = createHermesSessionHistoryImporter(memoryService as never, { stateDbPath });
+    const result = await importer.importProject(projectA, { sessionLimit: 2, limit: 1 });
+
+    expect(result.totalSessions).toBe(2);
+    expect(memoryService.startSession).toHaveBeenCalledTimes(2);
+    expect(memoryService.startSession).toHaveBeenCalledWith('hermes:session-newer-a', projectA);
+    expect(memoryService.startSession).toHaveBeenCalledWith('hermes:session-a', projectA);
+    expect(memoryService.storeUserPrompt).toHaveBeenCalledTimes(2);
+    expect(memoryService.storeAgentResponse).not.toHaveBeenCalled();
+  });
 });

--- a/tests/core/session-history-importer-filter.test.ts
+++ b/tests/core/session-history-importer-filter.test.ts
@@ -1,9 +1,40 @@
-import { describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   isClaudeLocalCommandArtifact,
-  isWorthStoringPrompt
+  isWorthStoringPrompt,
+  SessionHistoryImporter,
+  type ImportResult
 } from '../../src/services/session-history-importer.js';
+
+const tempDirs: string[] = [];
+
+function tempDir() {
+  const dir = mkdtempSync(join(tmpdir(), 'cml-session-importer-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function makeImportResult(overrides: Partial<ImportResult> = {}): ImportResult {
+  return {
+    totalSessions: 1,
+    totalMessages: 1,
+    importedPrompts: 1,
+    importedResponses: 0,
+    skippedDuplicates: 0,
+    errors: [],
+    ...overrides
+  };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 describe('session history importer prompt filtering', () => {
   it('drops Claude local-command artifacts that dilute retrieval quality', () => {
@@ -15,5 +46,33 @@ describe('session history importer prompt filtering', () => {
 
   it('keeps substantive imported user prompts', () => {
     expect(isWorthStoringPrompt('이 프로젝트에서 memory retrieval 구조를 더 가볍게 개선해줘')).toBe(true);
+  });
+
+  it('imports only the most recently modified matching Claude session when sessionLimit is set', async () => {
+    const dir = tempDir();
+    const older = join(dir, 'older.jsonl');
+    const newest = join(dir, 'newest.jsonl');
+    const oldest = join(dir, 'oldest.jsonl');
+    for (const filePath of [older, newest, oldest]) {
+      writeFileSync(filePath, '{}\n', 'utf8');
+    }
+    utimesSync(oldest, new Date('2026-05-01T00:00:00.000Z'), new Date('2026-05-01T00:00:00.000Z'));
+    utimesSync(older, new Date('2026-05-02T00:00:00.000Z'), new Date('2026-05-02T00:00:00.000Z'));
+    utimesSync(newest, new Date('2026-05-03T00:00:00.000Z'), new Date('2026-05-03T00:00:00.000Z'));
+
+    const importer = new SessionHistoryImporter({} as never) as SessionHistoryImporter & {
+      findProjectDirs: ReturnType<typeof vi.fn>;
+      findSessionFiles: ReturnType<typeof vi.fn>;
+      importSessionFile: ReturnType<typeof vi.fn>;
+    };
+    importer.findProjectDirs = vi.fn(async () => [dir]);
+    importer.findSessionFiles = vi.fn(async () => [older, newest, oldest]);
+    importer.importSessionFile = vi.fn(async () => makeImportResult());
+
+    const result = await importer.importProject('/repo/current', { sessionLimit: 1 });
+
+    expect(result.totalSessions).toBe(1);
+    expect(importer.importSessionFile).toHaveBeenCalledTimes(1);
+    expect(importer.importSessionFile).toHaveBeenCalledWith(newest, expect.objectContaining({ sessionLimit: 1 }));
   });
 });

--- a/tests/extensions/mcp-context-tools.test.ts
+++ b/tests/extensions/mcp-context-tools.test.ts
@@ -9,24 +9,46 @@ const mocks = vi.hoisted(() => {
       initialize: vi.fn(async () => undefined),
       retrieveMemories: vi.fn(),
       getRecentEvents: vi.fn(),
-      getStats: vi.fn()
+      getStats: vi.fn(),
+      processPendingEmbeddings: vi.fn()
     };
   }
 
   const defaultService = createService();
   const projectService = createService();
+  const claudeImporter = { importProject: vi.fn() };
+  const codexImporter = { importProject: vi.fn() };
+  const hermesImporter = { importProject: vi.fn() };
 
   return {
     defaultService,
     projectService,
+    claudeImporter,
+    codexImporter,
+    hermesImporter,
     getDefaultMemoryService: vi.fn(() => defaultService),
-    getMemoryServiceForProject: vi.fn(() => projectService)
+    getMemoryServiceForProject: vi.fn(() => projectService),
+    createSessionHistoryImporter: vi.fn(() => claudeImporter),
+    createCodexSessionHistoryImporter: vi.fn(() => codexImporter),
+    createHermesSessionHistoryImporter: vi.fn(() => hermesImporter)
   };
 });
 
 vi.mock('../../src/services/memory-service.js', () => ({
   getDefaultMemoryService: mocks.getDefaultMemoryService,
   getMemoryServiceForProject: mocks.getMemoryServiceForProject
+}));
+
+vi.mock('../../src/services/session-history-importer.js', () => ({
+  createSessionHistoryImporter: mocks.createSessionHistoryImporter
+}));
+
+vi.mock('../../src/services/codex-session-history-importer.js', () => ({
+  createCodexSessionHistoryImporter: mocks.createCodexSessionHistoryImporter
+}));
+
+vi.mock('../../src/services/hermes-session-history-importer.js', () => ({
+  createHermesSessionHistoryImporter: mocks.createHermesSessionHistoryImporter
 }));
 
 const { handleToolCall } = await import('../../src/extensions/mcp/handlers.js');
@@ -37,6 +59,18 @@ function resetService(service: typeof mocks.defaultService) {
   service.retrieveMemories.mockReset().mockResolvedValue({ memories: [] });
   service.getRecentEvents.mockReset().mockResolvedValue([]);
   service.getStats.mockReset().mockResolvedValue({ totalEvents: 0, vectorCount: 0, levelStats: [] });
+  service.processPendingEmbeddings.mockReset().mockResolvedValue(0);
+}
+
+function resetImporter(importer: typeof mocks.claudeImporter) {
+  importer.importProject.mockReset().mockResolvedValue({
+    totalSessions: 0,
+    totalMessages: 0,
+    importedPrompts: 0,
+    importedResponses: 0,
+    skippedDuplicates: 0,
+    errors: []
+  });
 }
 
 function event(overrides: Partial<MemoryEvent>): MemoryEvent {
@@ -61,14 +95,20 @@ describe('MCP project context tools', () => {
   beforeEach(() => {
     resetService(mocks.defaultService);
     resetService(mocks.projectService);
+    resetImporter(mocks.claudeImporter);
+    resetImporter(mocks.codexImporter);
+    resetImporter(mocks.hermesImporter);
     mocks.getDefaultMemoryService.mockClear();
     mocks.getMemoryServiceForProject.mockClear();
+    mocks.createSessionHistoryImporter.mockClear();
+    mocks.createCodexSessionHistoryImporter.mockClear();
+    mocks.createHermesSessionHistoryImporter.mockClear();
   });
 
-  it('advertises context-pack, project-timeline, and source-ref tools with projectPath support', () => {
+  it('advertises context-pack, import-latest, project-timeline, and source-ref tools with projectPath support', () => {
     const byName = new Map(tools.map((tool) => [tool.name, tool]));
 
-    for (const name of ['mem-context-pack', 'mem-project-timeline', 'mem-source-ref']) {
+    for (const name of ['mem-context-pack', 'mem-import-latest', 'mem-project-timeline', 'mem-source-ref']) {
       const tool = byName.get(name);
       expect(tool).toBeDefined();
       expect(tool?.inputSchema).toMatchObject({ type: 'object' });
@@ -78,6 +118,110 @@ describe('MCP project context tools', () => {
         description: expect.stringContaining('project')
       });
     }
+  });
+
+  it('imports the latest selected project sessions through a privacy-safe MCP freshness tool', async () => {
+    mocks.hermesImporter.importProject.mockResolvedValue({
+      totalSessions: 1,
+      totalMessages: 4,
+      importedPrompts: 2,
+      importedResponses: 2,
+      skippedDuplicates: 0,
+      errors: []
+    });
+    mocks.codexImporter.importProject.mockResolvedValue({
+      totalSessions: 1,
+      totalMessages: 3,
+      importedPrompts: 1,
+      importedResponses: 2,
+      skippedDuplicates: 1,
+      errors: []
+    });
+    mocks.projectService.processPendingEmbeddings.mockResolvedValue(5);
+
+    const result = await handleToolCall('mem-import-latest', {
+      projectPath: '/repo/app',
+      sources: ['hermes', 'codex'],
+      sessionLimit: 2,
+      messageLimit: 50,
+      force: true,
+      processEmbeddings: true,
+      stateDb: '/tmp/local-hermes-state.db',
+      sessionsDir: '/tmp/local-codex-sessions'
+    });
+
+    const text = textOf(result);
+    expect(result.isError).not.toBe(true);
+    expect(mocks.getMemoryServiceForProject).toHaveBeenCalledWith('/repo/app');
+    expect(mocks.createHermesSessionHistoryImporter).toHaveBeenCalledWith(mocks.projectService, { stateDbPath: '/tmp/local-hermes-state.db' });
+    expect(mocks.createCodexSessionHistoryImporter).toHaveBeenCalledWith(mocks.projectService, { sessionsDir: '/tmp/local-codex-sessions' });
+    expect(mocks.hermesImporter.importProject).toHaveBeenCalledWith('/repo/app', {
+      projectPath: '/repo/app',
+      sessionLimit: 2,
+      limit: 50,
+      force: true
+    });
+    expect(mocks.codexImporter.importProject).toHaveBeenCalledWith('/repo/app', {
+      projectPath: '/repo/app',
+      sessionLimit: 2,
+      limit: 50,
+      force: true
+    });
+    expect(mocks.projectService.processPendingEmbeddings).toHaveBeenCalledTimes(1);
+    expect(text).toContain('## Latest Session Import');
+    expect(text).toContain('- Project: supplied');
+    expect(text).not.toContain('app');
+    expect(text).toContain('- hermes: sessions=1 messages=4 prompts=2 responses=2 skipped=0 errors=0');
+    expect(text).toContain('- codex: sessions=1 messages=3 prompts=1 responses=2 skipped=1 errors=0');
+    expect(text).toContain('Embeddings: processed 5');
+    expect(text).not.toContain('/tmp/local-hermes-state.db');
+    expect(text).not.toContain('/tmp/local-codex-sessions');
+  });
+
+  it('rejects mem-import-latest without an absolute projectPath before opening project storage', async () => {
+    const result = await handleToolCall('mem-import-latest', {
+      projectPath: 'relative/app',
+      sources: ['hermes']
+    });
+
+    const text = textOf(result);
+    expect(result.isError).toBe(true);
+    expect(text).toContain('requires an explicit absolute projectPath');
+    expect(mocks.getMemoryServiceForProject).not.toHaveBeenCalled();
+    expect(mocks.createHermesSessionHistoryImporter).not.toHaveBeenCalled();
+  });
+
+  it('fails closed for invalid mem-import-latest sources before importing', async () => {
+    const result = await handleToolCall('mem-import-latest', {
+      projectPath: '/repo/app',
+      sources: ['hermes', 'unknown']
+    });
+
+    const text = textOf(result);
+    expect(result.isError).toBe(true);
+    expect(text).toContain('Invalid source');
+    expect(text).not.toContain('unknown');
+    expect(mocks.createHermesSessionHistoryImporter).not.toHaveBeenCalled();
+    expect(mocks.createCodexSessionHistoryImporter).not.toHaveBeenCalled();
+    expect(mocks.createSessionHistoryImporter).not.toHaveBeenCalled();
+  });
+
+  it('redacts local paths from mem-import-latest source failures', async () => {
+    mocks.hermesImporter.importProject.mockRejectedValue(new Error('failed to open /repo/app/private/state.db and C:\\Users\\me\\secret\\state.db'));
+
+    const result = await handleToolCall('mem-import-latest', {
+      projectPath: '/repo/app',
+      sources: ['hermes']
+    });
+
+    const text = textOf(result);
+    expect(result.isError).not.toBe(true);
+    expect(text).toContain('- Project: supplied');
+    expect(text).toContain('- hermes: failed');
+    expect(text).toContain('[path]');
+    expect(text).not.toContain('/repo/app');
+    expect(text).not.toContain('C:\\Users\\me');
+    expect(text).not.toContain('state.db');
   });
 
   it('builds a compact project context pack from relevant search results and recent timeline', async () => {


### PR DESCRIPTION
## Summary
- Add sessionLimit to Claude/Codex/Hermes session import paths while preserving existing limit semantics
- Expose --session-limit in Claude, Codex, and Hermes import CLIs
- Add explicit MCP mutation tool mem-import-latest for bounded project-scoped latest-session ingestion with privacy-safe aggregate output

## Validation
- npm test -- --run tests/extensions/mcp-context-tools.test.ts tests/core/session-history-importer-filter.test.ts tests/apps/hermes-import-runner.test.ts tests/apps/codex-import-runner.test.ts tests/core/hermes-session-history-importer-validation.test.ts tests/core/codex-session-history-importer-validation.test.ts
- npm run typecheck -- --pretty false
- git diff --check
- npm test -- --run
- npm run build
- graphify update .
- static/privacy diff scan
- independent pre-commit review passed