### PR TITLE
Refresh context pack before retrieval

### DIFF
--- a/src/extensions/mcp/handlers.ts
+++ b/src/extensions/mcp/handlers.ts
@@ -39,11 +39,12 @@ export async function handleToolCall(
   args: Record<string, unknown>
 ): Promise<ToolResult> {
   try {
-    if (name === 'mem-import-latest') {
+    if (name === 'mem-import-latest' || (name === 'mem-context-pack' && args.refreshLatest === true)) {
       const projectPath = optionalString(args.projectPath);
       if (!projectPath || !path.isAbsolute(projectPath)) {
+        const toolName = name === 'mem-context-pack' ? 'mem-context-pack refreshLatest' : 'mem-import-latest';
         return {
-          content: [{ type: 'text', text: 'Error: mem-import-latest requires an explicit absolute projectPath.' }],
+          content: [{ type: 'text', text: `Error: ${toolName} requires an explicit absolute projectPath.` }],
           isError: true
         };
       }
@@ -231,6 +232,18 @@ async function handleMemContextPack(memoryService: MemoryService, args: Record<s
   const projectPath = optionalString(args.projectPath);
   const genericContinuationQuery = isGenericContinuationQuery(query);
   const retrievalTopK = Math.min(topK * 3, 12);
+  const freshnessRun = args.refreshLatest === true
+    ? await runLatestImport(memoryService, {
+      projectPath: projectPath || '',
+      sources: sourceListArg(args.refreshSources),
+      sessionLimit: numberArg(args.refreshSessionLimit, 1, 1, 10),
+      messageLimit: numberArg(args.refreshMessageLimit, 200, 1, 1000),
+      force: args.refreshForce === true,
+      processEmbeddings: args.refreshEmbeddings === true,
+      sessionsDir: optionalString(args.sessionsDir),
+      stateDb: optionalString(args.stateDb)
+    })
+    : undefined;
 
   const [searchResult, recentEvents] = await Promise.all([
     memoryService.retrieveMemories(query, { topK: retrievalTopK, sessionId, recordTrace: false }),
@@ -260,10 +273,33 @@ async function handleMemContextPack(memoryService: MemoryService, args: Record<s
     `- Recent sessions shown: ${Math.min(sessionLimit, sessions.length)}`
   ];
 
+  if (freshnessRun) {
+    lines.push(
+      `- Freshness refresh: attempted before retrieval (${freshnessRun.sources.join(', ')})`,
+      `- Refresh limits: sessions=${freshnessRun.sessionLimit} messages=${freshnessRun.messageLimit} force=${freshnessRun.force ? 'yes' : 'no'} embeddings=${freshnessRun.processEmbeddings ? `processed ${freshnessRun.embeddingsProcessed ?? 0}` : 'skipped'}`
+    );
+  }
+
   if (genericContinuationQuery) {
     lines.push('- Generic continuation query: recent project timeline prioritized.');
   }
   lines.push('');
+
+  if (freshnessRun) {
+    lines.push('### Freshness Refresh', '');
+    for (const summary of freshnessRun.summaries) {
+      if (summary.result) {
+        lines.push(formatImportSummary(summary.source, summary.result));
+      } else {
+        lines.push(`- ${summary.source}: failed (${summary.error ?? 'details suppressed'})`);
+      }
+    }
+    const failedCount = freshnessRun.summaries.filter((summary) => summary.error).length;
+    if (failedCount > 0) {
+      lines.push('', `Warnings: ${failedCount} refresh source(s) failed; local path details were suppressed.`);
+    }
+    lines.push('');
+  }
 
   if (genericContinuationQuery) {
     appendRecentTimeline(lines, sessions);
@@ -294,6 +330,86 @@ interface LatestImportSummary {
   error?: string;
 }
 
+interface LatestImportRun {
+  sources: LatestImportSource[];
+  sessionLimit: number;
+  messageLimit: number;
+  force: boolean;
+  processEmbeddings: boolean;
+  embeddingsProcessed?: number;
+  summaries: LatestImportSummary[];
+}
+
+interface LatestImportRunOptions {
+  projectPath: string;
+  sources: LatestImportSource[];
+  sessionLimit: number;
+  messageLimit: number;
+  force: boolean;
+  processEmbeddings: boolean;
+  sessionsDir?: string;
+  stateDb?: string;
+}
+
+async function runLatestImport(memoryService: MemoryService, options: LatestImportRunOptions): Promise<LatestImportRun> {
+  const summaries: LatestImportSummary[] = [];
+
+  for (const source of options.sources) {
+    try {
+      if (source === 'claude') {
+        const importer = createSessionHistoryImporter(memoryService);
+        summaries.push({
+          source,
+          result: await importer.importProject(options.projectPath, {
+            projectPath: options.projectPath,
+            sessionLimit: options.sessionLimit,
+            limit: options.messageLimit,
+            force: options.force
+          })
+        });
+      } else if (source === 'codex') {
+        const importer = createCodexSessionHistoryImporter(memoryService, { sessionsDir: options.sessionsDir });
+        summaries.push({
+          source,
+          result: await importer.importProject(options.projectPath, {
+            projectPath: options.projectPath,
+            sessionLimit: options.sessionLimit,
+            limit: options.messageLimit,
+            force: options.force
+          })
+        });
+      } else {
+        const importer = createHermesSessionHistoryImporter(memoryService, { stateDbPath: options.stateDb });
+        summaries.push({
+          source,
+          result: await importer.importProject(options.projectPath, {
+            projectPath: options.projectPath,
+            sessionLimit: options.sessionLimit,
+            limit: options.messageLimit,
+            force: options.force
+          })
+        });
+      }
+    } catch (error) {
+      summaries.push({ source, error: safeErrorSummary(error) });
+    }
+  }
+
+  const embeddingsProcessed = options.processEmbeddings
+    ? await memoryService.processPendingEmbeddings()
+    : undefined;
+
+  return {
+    sources: options.sources,
+    sessionLimit: options.sessionLimit,
+    messageLimit: options.messageLimit,
+    force: options.force,
+    processEmbeddings: options.processEmbeddings,
+    embeddingsProcessed,
+    summaries
+  };
+}
+
 async function handleMemImportLatest(memoryService: MemoryService, args: Record<string, unknown>): Promise<ToolResult> {
   const projectPath = optionalString(args.projectPath);
   if (!projectPath) {
@@ -303,58 +419,32 @@ async function handleMemImportLatest(memoryService: MemoryService, args: Record<
     };
   }
 
-  const sources = sourceListArg(args.sources);
-  const sessionLimit = numberArg(args.sessionLimit, 1, 1, 10);
-  const messageLimit = numberArg(args.messageLimit, 200, 1, 1000);
-  const force = args.force === true;
-  const processEmbeddings = args.processEmbeddings === true;
-  const summaries: LatestImportSummary[] = [];
-
-  for (const source of sources) {
-    try {
-      if (source === 'claude') {
-        const importer = createSessionHistoryImporter(memoryService);
-        summaries.push({
-          source,
-          result: await importer.importProject(projectPath, { projectPath, sessionLimit, limit: messageLimit, force })
-        });
-      } else if (source === 'codex') {
-        const importer = createCodexSessionHistoryImporter(memoryService, { sessionsDir: optionalString(args.sessionsDir) });
-        summaries.push({
-          source,
-          result: await importer.importProject(projectPath, { projectPath, sessionLimit, limit: messageLimit, force })
-        });
-      } else {
-        const importer = createHermesSessionHistoryImporter(memoryService, { stateDbPath: optionalString(args.stateDb) });
-        summaries.push({
-          source,
-          result: await importer.importProject(projectPath, { projectPath, sessionLimit, limit: messageLimit, force })
-        });
-      }
-    } catch (error) {
-      summaries.push({ source, error: safeErrorSummary(error) });
-    }
-  }
-
-  const embeddingsProcessed = processEmbeddings
-    ? await memoryService.processPendingEmbeddings()
-    : undefined;
+  const importRun = await runLatestImport(memoryService, {
+    projectPath,
+    sources: sourceListArg(args.sources),
+    sessionLimit: numberArg(args.sessionLimit, 1, 1, 10),
+    messageLimit: numberArg(args.messageLimit, 200, 1, 1000),
+    force: args.force === true,
+    processEmbeddings: args.processEmbeddings === true,
+    sessionsDir: optionalString(args.sessionsDir),
+    stateDb: optionalString(args.stateDb)
+  });
 
   const lines: string[] = [
     '## Latest Session Import',
     '',
     '- Project: supplied',
-    `- Sources: ${sources.join(', ')}`,
-    `- Recent session limit per source: ${sessionLimit}`,
-    `- Message limit per source: ${messageLimit}`,
-    `- Force reimport: ${force ? 'yes' : 'no'}`,
-    `- Embeddings: ${processEmbeddings ? `processed ${embeddingsProcessed ?? 0}` : 'skipped'}`,
+    `- Sources: ${importRun.sources.join(', ')}`,
+    `- Recent session limit per source: ${importRun.sessionLimit}`,
+    `- Message limit per source: ${importRun.messageLimit}`,
+    `- Force reimport: ${importRun.force ? 'yes' : 'no'}`,
+    `- Embeddings: ${importRun.processEmbeddings ? `processed ${importRun.embeddingsProcessed ?? 0}` : 'skipped'}`,
     '',
     '### Source Results',
     ''
   ];
 
-  for (const summary of summaries) {
+  for (const summary of importRun.summaries) {
     if (summary.result) {
       lines.push(formatImportSummary(summary.source, summary.result));
     } else {
@@ -362,7 +452,7 @@ async function handleMemImportLatest(memoryService: MemoryService, args: Record<
     }
   }
 
-  const failedCount = summaries.filter((summary) => summary.error).length;
+  const failedCount = importRun.summaries.filter((summary) => summary.error).length;
   if (failedCount > 0) {
     lines.push('', `Warnings: ${failedCount} source(s) failed; local path details were suppressed.`);
   }

--- a/src/extensions/mcp/tools.ts
+++ b/src/extensions/mcp/tools.ts
@@ -111,7 +111,40 @@ export const tools: Tool[] = [
           type: 'string',
           description: 'Optional: filter relevant memories by specific session ID'
         },
-        projectPath: projectPathProperty
+        projectPath: projectPathProperty,
+        refreshLatest: {
+          type: 'boolean',
+          description: 'Explicit opt-in: import latest local session history before retrieval. Requires absolute projectPath and mutates project memory (default: false).'
+        },
+        refreshSources: {
+          type: 'array',
+          items: { type: 'string', enum: ['claude', 'codex', 'hermes'] },
+          description: 'Sources to refresh when refreshLatest is true (default: hermes and codex)'
+        },
+        refreshSessionLimit: {
+          type: 'number',
+          description: 'Maximum recent matching sessions per refresh source (default: 1, max: 10)'
+        },
+        refreshMessageLimit: {
+          type: 'number',
+          description: 'Maximum messages/memories per refresh source (default: 200, max: 1000)'
+        },
+        refreshForce: {
+          type: 'boolean',
+          description: 'Force reimport during refresh by deleting existing events for imported sessions first (default: false)'
+        },
+        refreshEmbeddings: {
+          type: 'boolean',
+          description: 'Process pending embeddings after refresh (default: false for fast context retrieval)'
+        },
+        sessionsDir: {
+          type: 'string',
+          description: 'Optional Codex sessions directory override for refreshLatest'
+        },
+        stateDb: {
+          type: 'string',
+          description: 'Optional Hermes state database path override for refreshLatest'
+        }
       }
     }
   },

--- a/src/services/hermes-session-history-importer.ts
+++ b/src/services/hermes-session-history-importer.ts
@@ -287,6 +287,29 @@ function listHermesMessages(db: Database, sessionId: string): HermesMessageRow[]
   `).all(sessionId) as HermesMessageRow[];
 }
 
+export const HERMES_IMPORTABLE_SESSION_SCAN_FACTOR = 50;
+
+function hasImportableHermesMessages(db: Database, sessionId: string): boolean {
+  return listHermesMessages(db, sessionId).some((message) => {
+    const normalized = normalizeHermesMessage(message);
+    return typeof normalized === 'object' && normalized.role === 'user';
+  });
+}
+
+function selectImportableHermesSessions(db: Database, sessions: HermesSessionRow[], sessionLimit: number): HermesSessionRow[] {
+  if (!Number.isFinite(sessionLimit) || sessionLimit <= 0) return sessions;
+
+  const selected: HermesSessionRow[] = [];
+  const maxSessions = Math.floor(sessionLimit);
+  const scanLimit = Math.min(sessions.length, Math.max(maxSessions, maxSessions * HERMES_IMPORTABLE_SESSION_SCAN_FACTOR));
+  for (const session of sessions.slice(0, scanLimit)) {
+    if (!hasImportableHermesMessages(db, session.id)) continue;
+    selected.push(session);
+    if (selected.length >= maxSessions) break;
+  }
+  return selected;
+}
+
 function createEmptyImportResult(): ImportResult {
   return {
     totalSessions: 0,
@@ -525,9 +548,7 @@ export class HermesSessionHistoryImporter {
     const result = createEmptyImportResult();
     const onProgress = options.onProgress;
     const sessionLimit = options.sessionLimit ?? Infinity;
-    const selectedSessions = Number.isFinite(sessionLimit) && sessionLimit > 0
-      ? sessions.slice(0, Math.floor(sessionLimit))
-      : sessions;
+    const selectedSessions = selectImportableHermesSessions(db, sessions, sessionLimit);
 
     onProgress?.({ phase: 'scan', message: `Found ${sessions.length} Hermes session(s)` });
 

--- a/tests/core/hermes-session-history-importer-validation.test.ts
+++ b/tests/core/hermes-session-history-importer-validation.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   createHermesSessionHistoryImporter,
+  HERMES_IMPORTABLE_SESSION_SCAN_FACTOR,
   validateHermesSessions
 } from '../../src/services/hermes-session-history-importer.js';
 
@@ -298,6 +299,252 @@ describe('Hermes SessionDB validation/import', () => {
     expect(memoryService.startSession).toHaveBeenCalledTimes(1);
     expect(memoryService.startSession).toHaveBeenCalledWith('hermes:session-newer-a', projectA);
     expect(memoryService.storeUserPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips newer empty Hermes sessions when selecting latest project sessions for import', async () => {
+    const dir = tempDir();
+    const stateDbPath = join(dir, 'state.db');
+    const projectA = join(dir, 'project-a');
+    const projectB = join(dir, 'project-b');
+    createHermesStateDb(stateDbPath, projectA, projectB);
+
+    const db = new Database(stateDbPath);
+    db.prepare(`
+      INSERT INTO sessions (id, source, user_id, model, system_prompt, started_at, title, message_count)
+      VALUES (@id, @source, @userId, @model, @systemPrompt, @startedAt, @title, @messageCount)
+    `).run({
+      id: 'session-empty-newest-a',
+      source: 'discord',
+      userId: 'user-empty',
+      model: 'gpt-5.5',
+      systemPrompt: `Project Context\n${projectA}`,
+      startedAt: 1_779_000_400,
+      title: 'newest empty project a routing shell',
+      messageCount: 0
+    });
+    db.prepare(`
+      INSERT INTO sessions (id, source, user_id, model, system_prompt, started_at, title, message_count)
+      VALUES (@id, @source, @userId, @model, @systemPrompt, @startedAt, @title, @messageCount)
+    `).run({
+      id: 'session-newer-nonempty-a',
+      source: 'discord',
+      userId: 'user-newer',
+      model: 'gpt-5.5',
+      systemPrompt: `Project Context\n${projectA}`,
+      startedAt: 1_779_000_300,
+      title: 'newer non-empty project a thread',
+      messageCount: 1
+    });
+    db.prepare(`
+      INSERT INTO messages (session_id, role, content, tool_name, timestamp)
+      VALUES (@sessionId, @role, @content, @toolName, @timestamp)
+    `).run({
+      sessionId: 'session-newer-nonempty-a',
+      role: 'user',
+      content: 'latest non-empty Hermes project session should be imported despite newer empty shells',
+      toolName: null,
+      timestamp: 1_779_000_301
+    });
+    db.close();
+
+    const memoryService = {
+      startSession: vi.fn(async (_sessionId: string, _projectPath?: string) => undefined),
+      endSession: vi.fn(async (_sessionId: string) => undefined),
+      deleteSessionEvents: vi.fn(async (_sessionId: string) => 0),
+      storeUserPrompt: vi.fn(async () => ({ success: true, isDuplicate: false })),
+      storeAgentResponse: vi.fn(async () => ({ success: true, isDuplicate: false }))
+    };
+
+    const importer = createHermesSessionHistoryImporter(memoryService as never, { stateDbPath });
+    const result = await importer.importProject(projectA, { sessionLimit: 1 });
+
+    expect(result.totalSessions).toBe(1);
+    expect(result.totalMessages).toBe(1);
+    expect(memoryService.startSession).toHaveBeenCalledTimes(1);
+    expect(memoryService.startSession).toHaveBeenCalledWith('hermes:session-newer-nonempty-a', projectA);
+    expect(memoryService.startSession).not.toHaveBeenCalledWith('hermes:session-empty-newest-a', projectA);
+    expect(memoryService.storeUserPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips newer Hermes sessions that cannot store any prompt or response when selecting latest imports', async () => {
+    const dir = tempDir();
+    const stateDbPath = join(dir, 'state.db');
+    const projectA = join(dir, 'project-a');
+    const projectB = join(dir, 'project-b');
+    createHermesStateDb(stateDbPath, projectA, projectB);
+
+    const db = new Database(stateDbPath);
+    const insertSession = db.prepare(`
+      INSERT INTO sessions (id, source, user_id, model, system_prompt, started_at, title, message_count)
+      VALUES (@id, @source, @userId, @model, @systemPrompt, @startedAt, @title, @messageCount)
+    `);
+    const insertMessage = db.prepare(`
+      INSERT INTO messages (session_id, role, content, tool_name, timestamp)
+      VALUES (@sessionId, @role, @content, @toolName, @timestamp)
+    `);
+
+    insertSession.run({
+      id: 'session-assistant-only-newest-a',
+      source: 'discord',
+      userId: 'user-assistant-only',
+      model: 'gpt-5.5',
+      systemPrompt: `Project Context\n${projectA}`,
+      startedAt: 1_779_000_500,
+      title: 'assistant-only shell',
+      messageCount: 1
+    });
+    insertMessage.run({
+      sessionId: 'session-assistant-only-newest-a',
+      role: 'assistant',
+      content: 'assistant-only content should not make this session consume the freshness slot',
+      toolName: null,
+      timestamp: 1_779_000_501
+    });
+
+    insertSession.run({
+      id: 'session-trivial-user-newer-a',
+      source: 'discord',
+      userId: 'user-trivial',
+      model: 'gpt-5.5',
+      systemPrompt: `Project Context\n${projectA}`,
+      startedAt: 1_779_000_400,
+      title: 'trivial user shell',
+      messageCount: 2
+    });
+    insertMessage.run({
+      sessionId: 'session-trivial-user-newer-a',
+      role: 'user',
+      content: 'ok',
+      toolName: null,
+      timestamp: 1_779_000_401
+    });
+    insertMessage.run({
+      sessionId: 'session-trivial-user-newer-a',
+      role: 'assistant',
+      content: 'assistant response after trivial prompt should not be stored without a real turn',
+      toolName: null,
+      timestamp: 1_779_000_402
+    });
+
+    insertSession.run({
+      id: 'session-meaningful-older-a',
+      source: 'discord',
+      userId: 'user-meaningful',
+      model: 'gpt-5.5',
+      systemPrompt: `Project Context\n${projectA}`,
+      startedAt: 1_779_000_300,
+      title: 'meaningful project a thread',
+      messageCount: 2
+    });
+    insertMessage.run({
+      sessionId: 'session-meaningful-older-a',
+      role: 'user',
+      content: 'meaningful Hermes prompt should be selected after newer non-storable shells',
+      toolName: null,
+      timestamp: 1_779_000_301
+    });
+    insertMessage.run({
+      sessionId: 'session-meaningful-older-a',
+      role: 'assistant',
+      content: 'meaningful Hermes response should be imported after the selected prompt',
+      toolName: null,
+      timestamp: 1_779_000_302
+    });
+    db.close();
+
+    const memoryService = {
+      startSession: vi.fn(async (_sessionId: string, _projectPath?: string) => undefined),
+      endSession: vi.fn(async (_sessionId: string) => undefined),
+      deleteSessionEvents: vi.fn(async (_sessionId: string) => 0),
+      storeUserPrompt: vi.fn(async () => ({ success: true, isDuplicate: false })),
+      storeAgentResponse: vi.fn(async () => ({ success: true, isDuplicate: false }))
+    };
+
+    const importer = createHermesSessionHistoryImporter(memoryService as never, { stateDbPath });
+    const result = await importer.importProject(projectA, { sessionLimit: 1 });
+
+    expect(result.totalSessions).toBe(1);
+    expect(result.totalMessages).toBe(2);
+    expect(result.importedPrompts).toBe(1);
+    expect(result.importedResponses).toBe(1);
+    expect(memoryService.startSession).toHaveBeenCalledTimes(1);
+    expect(memoryService.startSession).toHaveBeenCalledWith('hermes:session-meaningful-older-a', projectA);
+    expect(memoryService.startSession).not.toHaveBeenCalledWith('hermes:session-assistant-only-newest-a', projectA);
+    expect(memoryService.startSession).not.toHaveBeenCalledWith('hermes:session-trivial-user-newer-a', projectA);
+  });
+
+  it('bounds finite sessionLimit freshness selection to the newest candidate window', async () => {
+    const dir = tempDir();
+    const stateDbPath = join(dir, 'state.db');
+    const projectA = join(dir, 'project-a');
+    const projectB = join(dir, 'project-b');
+    createHermesStateDb(stateDbPath, projectA, projectB);
+
+    const db = new Database(stateDbPath);
+    const insertSession = db.prepare(`
+      INSERT INTO sessions (id, source, user_id, model, system_prompt, started_at, title, message_count)
+      VALUES (@id, @source, @userId, @model, @systemPrompt, @startedAt, @title, @messageCount)
+    `);
+    const insertMessage = db.prepare(`
+      INSERT INTO messages (session_id, role, content, tool_name, timestamp)
+      VALUES (@sessionId, @role, @content, @toolName, @timestamp)
+    `);
+
+    const freshnessScanWindow = HERMES_IMPORTABLE_SESSION_SCAN_FACTOR;
+    for (let index = 0; index < freshnessScanWindow + 1; index++) {
+      const sessionId = `session-assistant-shell-${index}`;
+      insertSession.run({
+        id: sessionId,
+        source: 'discord',
+        userId: `user-shell-${index}`,
+        model: 'gpt-5.5',
+        systemPrompt: `Project Context\n${projectA}`,
+        startedAt: 1_779_001_000 - index,
+        title: `assistant-only shell ${index}`,
+        messageCount: 1
+      });
+      insertMessage.run({
+        sessionId,
+        role: 'assistant',
+        content: 'assistant-only shell content should not trigger deep freshness scans',
+        toolName: null,
+        timestamp: 1_779_001_000 - index + 0.1
+      });
+    }
+
+    insertSession.run({
+      id: 'session-meaningful-beyond-window-a',
+      source: 'discord',
+      userId: 'user-meaningful',
+      model: 'gpt-5.5',
+      systemPrompt: `Project Context\n${projectA}`,
+      startedAt: 1_779_000_100,
+      title: 'meaningful but outside freshness window',
+      messageCount: 1
+    });
+    insertMessage.run({
+      sessionId: 'session-meaningful-beyond-window-a',
+      role: 'user',
+      content: 'meaningful Hermes prompt should not be reached beyond the bounded freshness scan window',
+      toolName: null,
+      timestamp: 1_779_000_101
+    });
+    db.close();
+
+    const memoryService = {
+      startSession: vi.fn(async (_sessionId: string, _projectPath?: string) => undefined),
+      endSession: vi.fn(async (_sessionId: string) => undefined),
+      deleteSessionEvents: vi.fn(async (_sessionId: string) => 0),
+      storeUserPrompt: vi.fn(async () => ({ success: true, isDuplicate: false })),
+      storeAgentResponse: vi.fn(async () => ({ success: true, isDuplicate: false }))
+    };
+
+    const importer = createHermesSessionHistoryImporter(memoryService as never, { stateDbPath });
+    const result = await importer.importProject(projectA, { sessionLimit: 1 });
+
+    expect(result.totalSessions).toBe(0);
+    expect(memoryService.startSession).not.toHaveBeenCalled();
+    expect(memoryService.storeUserPrompt).not.toHaveBeenCalled();
   });
 
   it('applies Hermes import limit per selected matching session', async () => {

--- a/tests/extensions/mcp-context-tools.test.ts
+++ b/tests/extensions/mcp-context-tools.test.ts
@@ -118,6 +118,15 @@ describe('MCP project context tools', () => {
         description: expect.stringContaining('project')
       });
     }
+
+    const contextPackProperties = byName.get('mem-context-pack')?.inputSchema.properties as Record<string, unknown>;
+    expect(contextPackProperties.refreshLatest).toMatchObject({
+      type: 'boolean',
+      description: expect.stringContaining('Explicit opt-in')
+    });
+    expect(contextPackProperties.refreshSources).toMatchObject({
+      type: 'array'
+    });
   });
 
   it('imports the latest selected project sessions through a privacy-safe MCP freshness tool', async () => {
@@ -222,6 +231,77 @@ describe('MCP project context tools', () => {
     expect(text).not.toContain('/repo/app');
     expect(text).not.toContain('C:\\Users\\me');
     expect(text).not.toContain('state.db');
+  });
+
+  it('refreshes latest sessions before building a context pack when explicitly requested', async () => {
+    mocks.hermesImporter.importProject.mockResolvedValue({
+      totalSessions: 1,
+      totalMessages: 2,
+      importedPrompts: 1,
+      importedResponses: 1,
+      skippedDuplicates: 0,
+      errors: []
+    });
+    mocks.projectService.processPendingEmbeddings.mockResolvedValue(3);
+    mocks.projectService.getRecentEvents.mockResolvedValue([
+      event({
+        id: '33333333-3333-4333-8333-333333333333',
+        sessionId: 'hermes:fresh-session',
+        eventType: 'agent_response',
+        timestamp: new Date('2026-05-05T03:00:00.000Z'),
+        content: 'Freshly imported context-pack auto-refresh implementation checkpoint.'
+      })
+    ]);
+
+    const result = await handleToolCall('mem-context-pack', {
+      projectPath: '/repo/app',
+      query: 'continue',
+      refreshLatest: true,
+      refreshSources: ['hermes'],
+      refreshSessionLimit: 2,
+      refreshMessageLimit: 50,
+      refreshForce: true,
+      refreshEmbeddings: true,
+      stateDb: '/tmp/local-hermes-state.db'
+    });
+
+    const text = textOf(result);
+    expect(result.isError).not.toBe(true);
+    expect(mocks.createHermesSessionHistoryImporter).toHaveBeenCalledWith(mocks.projectService, { stateDbPath: '/tmp/local-hermes-state.db' });
+    expect(mocks.hermesImporter.importProject).toHaveBeenCalledWith('/repo/app', {
+      projectPath: '/repo/app',
+      sessionLimit: 2,
+      limit: 50,
+      force: true
+    });
+    expect(mocks.projectService.processPendingEmbeddings).toHaveBeenCalledTimes(1);
+    expect(mocks.hermesImporter.importProject.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.projectService.retrieveMemories.mock.invocationCallOrder[0]
+    );
+    expect(mocks.hermesImporter.importProject.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.projectService.getRecentEvents.mock.invocationCallOrder[0]
+    );
+    expect(text).toContain('- Freshness refresh: attempted before retrieval (hermes)');
+    expect(text).toContain('- Refresh limits: sessions=2 messages=50 force=yes embeddings=processed 3');
+    expect(text).toContain('- hermes: sessions=1 messages=2 prompts=1 responses=1 skipped=0 errors=0');
+    expect(text).toContain('Freshly imported context-pack auto-refresh implementation checkpoint.');
+    expect(text).not.toContain('/repo/app');
+    expect(text).not.toContain('/tmp/local-hermes-state.db');
+  });
+
+  it('rejects mem-context-pack refreshLatest without opening project storage when projectPath is not absolute', async () => {
+    const result = await handleToolCall('mem-context-pack', {
+      projectPath: 'relative/app',
+      query: 'continue',
+      refreshLatest: true
+    });
+
+    const text = textOf(result);
+    expect(result.isError).toBe(true);
+    expect(text).toContain('mem-context-pack refreshLatest requires an explicit absolute projectPath');
+    expect(mocks.getMemoryServiceForProject).not.toHaveBeenCalled();
+    expect(mocks.createHermesSessionHistoryImporter).not.toHaveBeenCalled();
+    expect(mocks.projectService.retrieveMemories).not.toHaveBeenCalled();
   });
 
   it('builds a compact project context pack from relevant search results and recent timeline', async () => {


### PR DESCRIPTION
## Summary
- add explicit opt-in mem-context-pack refreshLatest to import latest local sessions before retrieval
- keep refresh/import output aggregate and path-safe
- skip non-storable Hermes shells and bound latest-session candidate scanning

## Verification
- npm run typecheck -- --pretty false
- git diff --check
- npm test -- --run tests/extensions/mcp-context-tools.test.ts tests/core/hermes-session-history-importer-validation.test.ts tests/core/codex-session-history-importer-validation.test.ts tests/apps/hermes-import-runner.test.ts tests/apps/codex-import-runner.test.ts tests/core/session-history-importer-filter.test.ts
- npm test -- --run
- npm run build
- graphify update .
- static/privacy diff scan: no findings
- independent pre-commit review: passed