### PR TITLE
Bump package version to 1.0.28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-memory-layer",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-memory-layer",
-      "version": "1.0.27",
+      "version": "1.0.28",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-memory-layer",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "description": "Claude Code plugin that learns from conversations to provide personalized assistance",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump claude-memory-layer package and lockfile version from 1.0.27 to 1.0.28 for the external market context release.

## Verification
- npm run typecheck
- npm test -- --run
- npm run build
- npm list claude-memory-layer --depth=0
- npm publish --dry-run --json
- added-line secret scan

## Publish note
- npm registry latest is currently 1.0.27.
- Local npm auth is currently invalid, so actual npm publish requires a refreshed npm login/token after merge.