### PR TITLE
fix: auto-repair CUDA 11 npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,37 +16,80 @@ Claude Memory Layer는 Claude Code에서 사용자와 AI 간의 모든 대화를
 
 ### 0) 최초 1회(머신 전체) 설치
 
+권장 설치 방식은 npm에 배포된 패키지를 **전역 설치**하는 것입니다. `install`은 Claude Code hook 파일 경로를 `~/.claude/settings.json`에 저장하므로, 일회성 `npx claude-memory-layer install`보다 전역 설치 또는 고정된 로컬 checkout을 쓰는 것이 안전합니다.
+
 ```bash
-cd ~/workspace/claude-memory-layer
+npm install -g claude-memory-layer@latest
+claude-memory-layer install
+claude-memory-layer status
+```
+
+로컬 개발 checkout에서 설치할 때:
+
+```bash
+git clone https://github.com/buzzni/claude-memory-layer.git
+cd claude-memory-layer
 npm install
 npm run build
 npx claude-memory-layer install
+npx claude-memory-layer status
 ```
 
 - `install`은 **한 번만** 하면 됩니다(Claude Code hooks 등록).
+- Linux x64 + CUDA 11 환경에서는 설치 중 optional embedding backend를 CPU-only ONNX Runtime으로 자동 복구합니다.
 - 이후 프로젝트별로 메모리 저장소가 자동 분리됩니다.
+- `install` / `uninstall`은 `~/.claude/settings.json`을 수정합니다.
+
+#### CUDA 11 / `onnxruntime-node` 설치 에러
+
+Linux x64 서버에 CUDA 11이 설치되어 있으면 `@huggingface/transformers`의 하위 의존성인 `onnxruntime-node`가 `nvcc --version`을 감지한 뒤 CUDA 11용 GPU 바이너리를 자동 설치하려고 합니다. 현재 해당 install script는 CUDA 11 자동 설치를 지원하지 않아 다음 오류로 `npm install`이 실패할 수 있습니다.
+
+```text
+Error: CUDA 11 binaries are not supported by this script yet.
+```
+
+Claude Memory Layer는 설치 시 Linux x64 + CUDA 11 환경을 감지하면 `@huggingface/transformers`를 optional dependency로 처리한 뒤 CPU-only ONNX Runtime 설정으로 자동 복구합니다. 그래서 일반적으로 사용자가 환경변수를 직접 지정할 필요는 없습니다.
+
+만약 구버전 패키지를 설치 중이거나 postinstall 복구가 실패하면 아래처럼 수동으로 CUDA 바이너리 다운로드만 건너뛰어 재설치할 수 있습니다.
+
+```bash
+# 실패한 전역 설치가 일부 남아 있으면 먼저 제거
+npm uninstall -g claude-memory-layer || true
+
+# 수동 fallback: CPU-only ONNX Runtime으로 재설치
+ONNXRUNTIME_NODE_INSTALL_CUDA=skip npm install -g claude-memory-layer@latest
+claude-memory-layer --version
+```
+
+로컬 checkout 개발 환경에서 구버전 의존성 설치가 같은 오류를 내면 아래처럼 수동 fallback을 사용할 수 있습니다.
+
+```bash
+ONNXRUNTIME_NODE_INSTALL_CUDA=skip npm install
+```
+
+`npm warn deprecated ...` 경고는 하위 의존성 경고이며 설치 실패 원인이 아닙니다.
 
 ### 1) 새 프로젝트에서 초기 메모리 생성
 
 ```bash
 cd /path/to/your-project
-npx claude-memory-layer import
+claude-memory-layer import
 ```
 
-- 현재 프로젝트의 기존 Claude 세션(`~/.claude/projects/...`)을 읽어와 메모리로 적재합니다.
+- 현재 프로젝트의 기존 Claude Code 세션(`~/.claude/projects/...`)을 읽어와 메모리로 적재합니다.
 - 벡터 임베딩까지 한 번에 처리됩니다.
 
 ### 2) 사용 중 확인
 
 ```bash
 # 프로젝트 메모리 검색
-npx claude-memory-layer search "인증 구조"
+claude-memory-layer search "인증 구조"
 
 # 통계 확인
-npx claude-memory-layer stats
+claude-memory-layer stats
 
 # 대시보드 실행
-npx claude-memory-layer dashboard
+claude-memory-layer dashboard --no-open
 ```
 
 ### 3) 다른 프로젝트에도 동일하게 적용?
@@ -55,8 +98,8 @@ npx claude-memory-layer dashboard
 
 ```bash
 cd /path/to/another-project
-npx claude-memory-layer import
-npx claude-memory-layer search "배포 이슈"
+claude-memory-layer import
+claude-memory-layer search "배포 이슈"
 ```
 
 프로젝트마다 내부적으로 별도 저장소(`~/.claude-code/memory/projects/<hash>`)를 사용하므로,
@@ -66,6 +109,7 @@ npx claude-memory-layer search "배포 이슈"
 
 - 특정 프로젝트를 명시하고 싶으면 대부분 명령에 `--project <path>` 사용 가능
 - 대규모 리임포트가 필요하면 `import --force` 사용
+- 최근 일부만 가져오고 싶으면 `--session-limit <n>` 또는 `--limit <n>` 사용
 - 백그라운드 worker가 못 처리한 임베딩은 `process`로 수동 처리
 - 상태 점검:
   - `GET /health` (서버 헬스)
@@ -76,6 +120,144 @@ npx claude-memory-layer search "배포 이슈"
   - `CLAUDE_MEMORY_SEMANTIC_DAEMON_IDLE_MS` (기본 `600000`, semantic daemon 유휴 종료 시간)
   - `CLAUDE_MEMORY_MIN_SCORE` (기본 0.4)
   - `CLAUDE_MEMORY_FALLBACK_MIN_SCORE` (기본 0.3, 결과 0건일 때 재시도)
+
+---
+
+## 다른 서버 초기 세팅 & 이전 대화 ingest
+
+새 서버에서 Claude Memory Layer를 설치하고 기존 Claude Code/Codex/Hermes 대화 기록을 처음 적재할 때는 아래 체크리스트를 따르세요.
+
+### 1) 새 서버 준비
+
+```bash
+node --version   # Node.js >= 18 필수
+npm --version
+npm install -g claude-memory-layer@latest
+claude-memory-layer install
+claude-memory-layer status
+```
+
+> `claude-memory-layer install`은 Claude Code hooks를 등록합니다. 이미 Claude Code가 실행 중이면 재시작해야 hook이 반영됩니다.
+
+### 2) 이전 서버의 원본 대화 기록 가져오기
+
+가장 안전한 방식은 **원본 대화 기록을 새 서버로 복사한 뒤 새 서버에서 다시 import**하는 것입니다. 필요한 것만 선택해서 복사하세요. 이 디렉토리/DB에는 민감한 대화와 경로가 포함될 수 있으므로 공개 저장소에 커밋하거나 공유하지 말고, SSH/사설망 등 신뢰할 수 있는 경로로만 복사하세요.
+
+```bash
+# Claude Code 원본 세션(JSONL)
+mkdir -p ~/.claude/projects
+rsync -a OLD_HOST:~/.claude/projects/ ~/.claude/projects/
+
+# Codex CLI 원본 세션(JSONL) - Codex 기록도 가져올 때만
+mkdir -p ~/.codex/sessions
+rsync -a OLD_HOST:~/.codex/sessions/ ~/.codex/sessions/
+
+# Hermes Agent SessionDB - Hermes 기록도 가져올 때만
+# 권장: OLD_HOST에서 Hermes/gateway/agent 프로세스를 먼저 멈춘 뒤 SQLite sidecar까지 함께 복사
+mkdir -p ~/.hermes
+rsync -a OLD_HOST:'~/.hermes/state.db*' ~/.hermes/
+```
+
+Hermes를 멈출 수 없는 운영 서버라면, `state.db` 파일을 직접 복사하는 대신 OLD_HOST에서 SQLite `.backup`으로 일관된 스냅샷을 만든 뒤 가져오세요.
+
+```bash
+ssh OLD_HOST 'sqlite3 ~/.hermes/state.db ".backup /tmp/hermes-state.db.backup"'
+mkdir -p ~/.hermes
+rsync -a OLD_HOST:/tmp/hermes-state.db.backup ~/.hermes/state.db
+```
+
+이미 처리된 CML 저장소를 그대로 옮기고 싶다면, 이전/새 서버의 관련 agent, dashboard, semantic daemon/worker 등 모든 CML writer를 멈춘 뒤 아래처럼 복사할 수도 있습니다. 단, 재현성과 모델/버전 migration을 위해서는 위의 원본 기록 re-ingest 방식을 우선 권장합니다.
+
+```bash
+mkdir -p ~/.claude-code
+rsync -a OLD_HOST:~/.claude-code/memory/ ~/.claude-code/memory/
+```
+
+### 3) 프로젝트별로 read-only 검증 후 import
+
+프로젝트 메모리는 프로젝트 경로 기준으로 분리됩니다. 새 서버의 실제 repo 경로를 `PROJECT`에 넣고, 필요한 importer만 실행하세요.
+
+중요: Codex/Hermes/Claude Code 원본 세션의 project filter는 **대화가 생성될 당시의 절대 경로**를 기준으로 매칭합니다. 새 서버에서도 repo 절대 경로가 이전 서버와 같으면 아래 project import를 그대로 쓰면 됩니다.
+
+```bash
+export PROJECT=/path/to/your-project
+cd "$PROJECT"
+
+# Claude Code 기록: import 가능한 세션 확인 후 프로젝트 메모리로 적재
+claude-memory-layer list --project "$PROJECT"
+claude-memory-layer import --project "$PROJECT" --verbose
+
+# Codex 기록: 먼저 읽기 전용 리포트로 확인한 뒤 명시적으로 import
+claude-memory-layer codex validate --project "$PROJECT" --format markdown
+claude-memory-layer codex import --project "$PROJECT" --verbose
+
+# Hermes 기록: 먼저 읽기 전용 리포트로 확인한 뒤 명시적으로 import
+claude-memory-layer hermes validate --project "$PROJECT" --format markdown
+claude-memory-layer hermes import --project "$PROJECT" --verbose
+
+# pending embedding이 남아 있으면 수동 처리
+claude-memory-layer process --project "$PROJECT"
+```
+
+이전 서버와 새 서버의 repo 절대 경로가 다르면, `OLD_PROJECT`로 원본 세션을 찾고 특정 session 파일/id를 새 프로젝트 저장소(`NEW_PROJECT`)로 가져오세요.
+
+```bash
+export OLD_PROJECT=/old/server/path/to/your-project
+export NEW_PROJECT=/path/to/your-project
+cd "$NEW_PROJECT"
+
+# Claude Code: list 출력의 JSONL session file path를 확인해서 사용
+claude-memory-layer list --project "$OLD_PROJECT"
+claude-memory-layer import --project "$NEW_PROJECT" --session /path/to/claude-session.jsonl --verbose
+
+# Codex: validate 결과에서 session JSONL 파일을 확인한 뒤 import
+claude-memory-layer codex validate --project "$OLD_PROJECT" --format markdown
+claude-memory-layer codex import --project "$NEW_PROJECT" --session /path/to/codex-session.jsonl --verbose
+
+# Hermes: validate 결과에서 Hermes session id를 확인한 뒤 import
+claude-memory-layer hermes validate --project "$OLD_PROJECT" --format markdown
+claude-memory-layer hermes import --project "$NEW_PROJECT" --session 20260505_010203_abcd1234 --verbose
+
+claude-memory-layer process --project "$NEW_PROJECT"
+```
+
+주의:
+
+- `claude-memory-layer import --all`은 모든 Claude Code 세션을 전역 저장소로 가져옵니다. 프로젝트별 컨텍스트 품질이 중요하면 각 repo에서 `--project <path>` 방식으로 반복하는 것을 권장합니다.
+- `codex import --all`, `hermes import --all`도 의도적으로 전역 메모리를 만들 때만 사용하세요.
+- import/validate/list 결과에는 대화 내용 일부나 로컬 경로가 포함될 수 있습니다. 외부 공유 전에는 민감정보와 경로를 제거하고, Codex validate 리포트는 필요하면 `--anonymize-projects`를 함께 사용하세요.
+- import는 콘텐츠 해시 기반으로 중복을 건너뛰므로 여러 번 실행해도 같은 내용이 중복 저장되지 않습니다. 단, `--force`는 기존 import 이벤트를 지우고 재적재하므로 신중히 사용하세요.
+
+### 4) 검증
+
+```bash
+export VERIFY_PROJECT=/path/to/your-project  # 위에서 쓴 PROJECT 또는 NEW_PROJECT
+claude-memory-layer stats --project "$VERIFY_PROJECT"
+claude-memory-layer search "최근에 하던 작업" --project "$VERIFY_PROJECT" --top-k 5
+claude-memory-layer dashboard --no-open --port 37777
+# 다른 터미널에서: curl http://localhost:37777/api/health
+```
+
+### 5) MCP/다른 agent에 연결
+
+Claude Desktop은 CLI로 자동 등록할 수 있습니다. GUI 앱에서 shell `PATH`가 다를 수 있으면 stdio binary의 절대 경로를 command로 넣는 방식이 더 견고합니다.
+
+```bash
+claude-memory-layer mcp install --command "$(command -v claude-memory-layer-mcp)"
+# Claude Desktop 재시작
+```
+
+Codex/Hermes 등 MCP client에도 전역 설치된 stdio binary를 등록하면 됩니다.
+
+```bash
+# Codex 예시
+codex mcp add claude-memory-layer -- claude-memory-layer-mcp
+
+# Hermes 예시
+hermes mcp add claude-memory-layer --command claude-memory-layer-mcp
+```
+
+MCP client가 환경에 따라 PATH를 못 찾으면 `command -v claude-memory-layer-mcp`로 절대 경로를 확인해서 command에 넣으세요.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "claude-memory-layer",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-memory-layer",
-      "version": "1.0.28",
+      "version": "1.0.29",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.13.0",
-        "@huggingface/transformers": "^3.8.1",
         "@lancedb/lancedb": "^0.5.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "better-sqlite3": "^12.6.2",
@@ -33,6 +33,9 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@huggingface/transformers": "^3.8.1"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -504,6 +507,7 @@
       "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-3.8.1.tgz",
       "integrity": "sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@huggingface/jinja": "^0.5.3",
         "onnxruntime-node": "1.21.0",
@@ -516,6 +520,7 @@
       "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.5.tgz",
       "integrity": "sha512-xRlzazC+QZwr6z4ixEqYHo9fgwhTZ3xNSdljlKfUFGZSdlvt166DljRELFUfFytlYOYvo3vTisA/AFOuOAzFQQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -525,6 +530,7 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
       "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -533,19 +539,22 @@
       "version": "25.9.23",
       "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
       "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/@huggingface/transformers/node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/@huggingface/transformers/node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -555,6 +564,7 @@
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
       "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.1.2"
       },
@@ -566,7 +576,8 @@
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.0.tgz",
       "integrity": "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@huggingface/transformers/node_modules/onnxruntime-node": {
       "version": "1.21.0",
@@ -574,6 +585,7 @@
       "integrity": "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "win32",
         "darwin",
@@ -590,6 +602,7 @@
       "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.22.0-dev.20250409-89f8206ba4.tgz",
       "integrity": "sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "flatbuffers": "^25.1.24",
         "guid-typescript": "^1.0.9",
@@ -603,7 +616,8 @@
       "version": "1.22.0-dev.20250409-89f8206ba4",
       "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.22.0-dev.20250409-89f8206ba4.tgz",
       "integrity": "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@huggingface/transformers/node_modules/protobufjs": {
       "version": "7.5.4",
@@ -611,6 +625,7 @@
       "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -635,6 +650,7 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -678,6 +694,7 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
       "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -694,6 +711,7 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
       "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -703,6 +721,7 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -1168,6 +1187,7 @@
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
       "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.0.4"
       },
@@ -1180,6 +1200,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -1367,31 +1388,36 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
       "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
       "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "license": "BSD-3-Clause",
+      "optional": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -1401,31 +1427,36 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
       "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.57.1",
@@ -2219,7 +2250,8 @@
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/bson": {
       "version": "6.10.4",
@@ -2589,6 +2621,7 @@
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -2606,6 +2639,7 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -2649,7 +2683,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -2759,7 +2794,8 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/esbuild": {
       "version": "0.20.2",
@@ -2811,6 +2847,7 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -3233,6 +3270,7 @@
       "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
       "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
       "license": "BSD-3-Clause",
+      "optional": true,
       "dependencies": {
         "boolean": "^3.0.1",
         "es6-error": "^4.1.1",
@@ -3250,6 +3288,7 @@
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "define-properties": "^1.2.1",
         "gopd": "^1.0.1"
@@ -3277,7 +3316,8 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
       "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -3293,6 +3333,7 @@
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -3516,7 +3557,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/local-pkg": {
       "version": "0.5.1",
@@ -3566,6 +3608,7 @@
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
       "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "escape-string-regexp": "^4.0.0"
       },
@@ -3925,6 +3968,7 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -4111,7 +4155,8 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/postcss": {
       "version": "8.5.6",
@@ -4383,6 +4428,7 @@
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
       "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
       "license": "BSD-3-Clause",
+      "optional": true,
       "dependencies": {
         "boolean": "^3.0.1",
         "detect-node": "^2.0.4",
@@ -4498,7 +4544,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -4556,6 +4603,7 @@
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
       "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "type-fest": "^0.13.1"
       },
@@ -4787,7 +4835,8 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -5418,6 +5467,7 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
       "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
       "license": "(MIT OR CC0-1.0)",
+      "optional": true,
       "engines": {
         "node": ">=10"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-memory-layer",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "Claude Code plugin that learns from conversations to provide personalized assistance",
   "main": "dist/index.js",
   "bin": {
@@ -23,7 +23,8 @@
     "ops:health": "npm run ops:sync-gap:report && npm run ops:sync-gap:heal && npm run ops:review:resolve",
     "ops:projects:clean-unknown": "node scripts/delete-unknown-projects.js",
     "benchmark:replay": "tsx scripts/replay-retrieval-benchmark.ts",
-    "benchmark:qrels": "tsx scripts/generate-session-qrels.ts"
+    "benchmark:qrels": "tsx scripts/generate-session-qrels.ts",
+    "postinstall": "node scripts/postinstall-embedding-backend.cjs"
   },
   "keywords": [
     "claude-code",
@@ -40,7 +41,6 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.13.0",
-    "@huggingface/transformers": "^3.8.1",
     "@lancedb/lancedb": "^0.5.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "better-sqlite3": "^12.6.2",
@@ -48,6 +48,9 @@
     "hono": "^4.0.0",
     "mongodb": "^6.14.0",
     "zod": "^3.22.0"
+  },
+  "optionalDependencies": {
+    "@huggingface/transformers": "^3.8.1"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/scripts/postinstall-embedding-backend.cjs
+++ b/scripts/postinstall-embedding-backend.cjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+'use strict';
+
+const { execFileSync, spawnSync } = require('node:child_process');
+const path = require('node:path');
+const { createRequire } = require('node:module');
+
+const EMBEDDING_BACKEND_PACKAGE_NAME = '@huggingface/transformers';
+const EMBEDDING_BACKEND_VERSION = '3.8.1';
+const EMBEDDING_BACKEND_PACKAGE = `${EMBEDDING_BACKEND_PACKAGE_NAME}@${EMBEDDING_BACKEND_VERSION}`;
+const REPAIR_GUARD_ENV = 'CLAUDE_MEMORY_LAYER_EMBEDDING_POSTINSTALL_REPAIR';
+const SKIP_ENV = 'CLAUDE_MEMORY_LAYER_SKIP_EMBEDDING_POSTINSTALL';
+
+function parseCudaMajor(output) {
+  const releaseMatch = String(output).match(/release\s+(\d+)(?:\.\d+)?/i);
+  if (releaseMatch) return Number(releaseMatch[1]);
+
+  const versionMatch = String(output).match(/\bV(\d+)\.\d+/i);
+  if (versionMatch) return Number(versionMatch[1]);
+
+  return null;
+}
+
+function parseCudaMajorFromEnv(env = process.env) {
+  const value = env.ONNXRUNTIME_NODE_INSTALL_CUDA || env.npm_config_onnxruntime_node_install_cuda;
+  if (!value) return null;
+  if (value === 'v11' || value === '11') return 11;
+  if (value === 'v12' || value === '12') return 12;
+  return null;
+}
+
+function detectCudaMajor({ env = process.env, execFileSyncImpl = execFileSync } = {}) {
+  const envMajor = parseCudaMajorFromEnv(env);
+  if (envMajor) return envMajor;
+
+  try {
+    return parseCudaMajor(execFileSyncImpl('nvcc', ['--version'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    }));
+  } catch {
+    return null;
+  }
+}
+
+function isSkipRequested(env = process.env) {
+  if (env[SKIP_ENV] === '1' || env[REPAIR_GUARD_ENV] === '1') return true;
+  if (env.npm_config_optional === 'false') return true;
+  if (String(env.npm_config_omit || '').split(',').map((item) => item.trim()).includes('optional')) return true;
+  return false;
+}
+
+function isEmbeddingBackendAvailable(rootDir = process.cwd()) {
+  try {
+    const requireFromRoot = createRequire(path.join(rootDir, 'package.json'));
+    requireFromRoot.resolve(EMBEDDING_BACKEND_PACKAGE_NAME);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function shouldAttemptAutoInstall({ platform, arch, cudaMajor, transformersAvailable, skipRequested }) {
+  return platform === 'linux' &&
+    arch === 'x64' &&
+    cudaMajor === 11 &&
+    !transformersAvailable &&
+    !skipRequested;
+}
+
+function createRepairEnv(env = process.env) {
+  return {
+    ...env,
+    ONNXRUNTIME_NODE_INSTALL_CUDA: 'skip',
+    [REPAIR_GUARD_ENV]: '1'
+  };
+}
+
+function createNpmInstallArgs() {
+  return [
+    'install',
+    '--no-save',
+    '--no-package-lock',
+    '--omit=dev',
+    EMBEDDING_BACKEND_PACKAGE
+  ];
+}
+
+function runPostinstall({
+  rootDir = process.cwd(),
+  env = process.env,
+  platform = process.platform,
+  arch = process.arch,
+  execFileSyncImpl = execFileSync,
+  spawnSyncImpl = spawnSync,
+  log = console.log,
+  warn = console.warn
+} = {}) {
+  const transformersAvailable = isEmbeddingBackendAvailable(rootDir);
+  const skipRequested = isSkipRequested(env);
+  const cudaMajor = detectCudaMajor({ env, execFileSyncImpl });
+
+  if (!shouldAttemptAutoInstall({ platform, arch, cudaMajor, transformersAvailable, skipRequested })) {
+    return { attempted: false, cudaMajor, transformersAvailable, skipRequested };
+  }
+
+  log('[claude-memory-layer] CUDA 11 detected and optional embedding backend is missing. Installing CPU-only embedding backend...');
+
+  const npmCommand = platform === 'win32' ? 'npm.cmd' : 'npm';
+  const result = spawnSyncImpl(npmCommand, createNpmInstallArgs(), {
+    cwd: rootDir,
+    env: createRepairEnv(env),
+    stdio: 'inherit'
+  });
+
+  if (result.error || result.status !== 0) {
+    warn('[claude-memory-layer] Optional embedding backend repair failed. Claude Memory Layer is installed, but semantic/vector embeddings may be unavailable until you run:');
+    warn(`  ONNXRUNTIME_NODE_INSTALL_CUDA=skip npm install -g claude-memory-layer@latest`);
+    if (result.error) warn(`  ${result.error.message}`);
+    return { attempted: true, success: false, cudaMajor, transformersAvailable, skipRequested };
+  }
+
+  log('[claude-memory-layer] Optional embedding backend installed with CPU-only ONNX Runtime.');
+  return { attempted: true, success: true, cudaMajor, transformersAvailable, skipRequested };
+}
+
+if (require.main === module) {
+  runPostinstall();
+}
+
+module.exports = {
+  EMBEDDING_BACKEND_PACKAGE,
+  parseCudaMajor,
+  parseCudaMajorFromEnv,
+  detectCudaMajor,
+  isSkipRequested,
+  isEmbeddingBackendAvailable,
+  shouldAttemptAutoInstall,
+  createRepairEnv,
+  createNpmInstallArgs,
+  runPostinstall
+};

--- a/tests/apps/postinstall-embedding-backend.test.ts
+++ b/tests/apps/postinstall-embedding-backend.test.ts
@@ -1,0 +1,167 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+
+type SpawnCall = {
+  cmd: string;
+  args: string[];
+  env: NodeJS.ProcessEnv;
+};
+
+type PostinstallEmbeddingBackend = {
+  EMBEDDING_BACKEND_PACKAGE: string;
+  parseCudaMajor(output: string): number | null;
+  shouldAttemptAutoInstall(input: {
+    platform: NodeJS.Platform;
+    arch: string;
+    cudaMajor: number | null;
+    transformersAvailable: boolean;
+    skipRequested: boolean;
+  }): boolean;
+  createRepairEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv;
+  createNpmInstallArgs(): string[];
+  runPostinstall(input?: {
+    rootDir?: string;
+    env?: NodeJS.ProcessEnv;
+    platform?: NodeJS.Platform;
+    arch?: string;
+    execFileSyncImpl?: () => string;
+    spawnSyncImpl?: (cmd: string, args: string[], options: { env: NodeJS.ProcessEnv }) => { status: number };
+    log?: () => void;
+    warn?: () => void;
+  }): { attempted: boolean; success?: boolean; cudaMajor: number | null; transformersAvailable: boolean; skipRequested: boolean };
+};
+
+function loadPostinstallModule(): PostinstallEmbeddingBackend {
+  return require('../../scripts/postinstall-embedding-backend.cjs') as PostinstallEmbeddingBackend;
+}
+
+describe('embedding backend postinstall repair', () => {
+  it('keeps the install-time embedding backend optional and registers postinstall repair', () => {
+    const pkg = JSON.parse(readFileSync('package.json', 'utf-8')) as {
+      scripts: Record<string, string>;
+      dependencies?: Record<string, string>;
+      optionalDependencies?: Record<string, string>;
+    };
+
+    expect(pkg.dependencies).not.toHaveProperty('@huggingface/transformers');
+    expect(pkg.optionalDependencies).toMatchObject({
+      '@huggingface/transformers': '^3.8.1'
+    });
+    expect(pkg.scripts.postinstall).toBe('node scripts/postinstall-embedding-backend.cjs');
+  });
+
+  it('detects CUDA major version from nvcc output', () => {
+    const postinstall = loadPostinstallModule();
+
+    expect(postinstall.parseCudaMajor('Cuda compilation tools, release 11.8, V11.8.89')).toBe(11);
+    expect(postinstall.parseCudaMajor('Cuda compilation tools, release 12.4, V12.4.131')).toBe(12);
+    expect(postinstall.parseCudaMajor('nvcc: NVIDIA (R) Cuda compiler driver')).toBeNull();
+  });
+
+  it('only auto-installs the embedding backend for Linux x64 CUDA 11 when it is missing', () => {
+    const postinstall = loadPostinstallModule();
+
+    expect(postinstall.shouldAttemptAutoInstall({
+      platform: 'linux',
+      arch: 'x64',
+      cudaMajor: 11,
+      transformersAvailable: false,
+      skipRequested: false
+    })).toBe(true);
+
+    expect(postinstall.shouldAttemptAutoInstall({
+      platform: 'linux',
+      arch: 'x64',
+      cudaMajor: 11,
+      transformersAvailable: true,
+      skipRequested: false
+    })).toBe(false);
+
+    expect(postinstall.shouldAttemptAutoInstall({
+      platform: 'linux',
+      arch: 'arm64',
+      cudaMajor: 11,
+      transformersAvailable: false,
+      skipRequested: false
+    })).toBe(false);
+
+    expect(postinstall.shouldAttemptAutoInstall({
+      platform: 'darwin',
+      arch: 'x64',
+      cudaMajor: 11,
+      transformersAvailable: false,
+      skipRequested: false
+    })).toBe(false);
+
+    expect(postinstall.shouldAttemptAutoInstall({
+      platform: 'linux',
+      arch: 'x64',
+      cudaMajor: 12,
+      transformersAvailable: false,
+      skipRequested: false
+    })).toBe(false);
+
+    expect(postinstall.shouldAttemptAutoInstall({
+      platform: 'linux',
+      arch: 'x64',
+      cudaMajor: 11,
+      transformersAvailable: false,
+      skipRequested: true
+    })).toBe(false);
+  });
+
+  it('repairs missing transformers with CPU-only onnxruntime install settings', () => {
+    const postinstall = loadPostinstallModule();
+
+    expect(postinstall.createRepairEnv({})).toMatchObject({
+      ONNXRUNTIME_NODE_INSTALL_CUDA: 'skip',
+      CLAUDE_MEMORY_LAYER_EMBEDDING_POSTINSTALL_REPAIR: '1'
+    });
+    expect(postinstall.createNpmInstallArgs()).toEqual([
+      'install',
+      '--no-save',
+      '--no-package-lock',
+      '--omit=dev',
+      postinstall.EMBEDDING_BACKEND_PACKAGE
+    ]);
+  });
+
+  it('runs the automatic repair command when Linux x64 CUDA 11 skipped the optional backend', () => {
+    const postinstall = loadPostinstallModule();
+    const rootDir = mkdtempSync(join(tmpdir(), 'cml-postinstall-test-'));
+    const calls: SpawnCall[] = [];
+
+    try {
+      writeFileSync(join(rootDir, 'package.json'), JSON.stringify({ name: 'claude-memory-layer-install-root' }));
+
+      const result = postinstall.runPostinstall({
+        rootDir,
+        env: {},
+        platform: 'linux',
+        arch: 'x64',
+        execFileSyncImpl: () => 'Cuda compilation tools, release 11.8, V11.8.89',
+        spawnSyncImpl: (cmd, args, options) => {
+          calls.push({ cmd, args, env: options.env });
+          return { status: 0 };
+        },
+        log: () => undefined,
+        warn: () => undefined
+      });
+
+      expect(result).toMatchObject({ attempted: true, success: true, cudaMajor: 11, transformersAvailable: false });
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.cmd).toBe('npm');
+      expect(calls[0]?.args).toEqual(postinstall.createNpmInstallArgs());
+      expect(calls[0]?.env.ONNXRUNTIME_NODE_INSTALL_CUDA).toBe('skip');
+      expect(calls[0]?.env.CLAUDE_MEMORY_LAYER_EMBEDDING_POSTINSTALL_REPAIR).toBe('1');
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Move `@huggingface/transformers` to optionalDependencies so Linux x64 CUDA 11 ONNX install failures do not block package installation.
- Add a postinstall repair script that detects Linux x64 + CUDA 11 + missing embedding backend and retries the optional backend install with `ONNXRUNTIME_NODE_INSTALL_CUDA=skip`.
- Update README with other-server install/import guidance and CUDA 11 automatic recovery docs.
- Bump package version to `1.0.29`.

## Validation
- Independent reviewer: passed; no blockers.
- `npm test -- --run tests/apps/postinstall-embedding-backend.test.ts` — 5 passed.
- `npm run typecheck` — passed.
- `npm test -- --run` — 62 files / 282 tests passed.
- `npm run build` — passed.
- `npm pack --dry-run --json` — passed; required package files included.
- `git diff --check` — passed.
- Added-line secret scan — passed.
- `npm list claude-memory-layer --depth=0` — `(empty)`.