### PR TITLE
fix: harden CPU embedding backend fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npx claude-memory-layer status
 ```
 
 - `install`은 **한 번만** 하면 됩니다(Claude Code hooks 등록).
-- Linux x64 + CUDA 11 환경에서는 설치 중 optional embedding backend를 CPU-only ONNX Runtime으로 자동 복구합니다.
+- Linux x64에서 optional embedding backend가 빠져 있으면 설치 중 CPU-only ONNX Runtime으로 자동 복구합니다(CUDA 불필요).
 - 이후 프로젝트별로 메모리 저장소가 자동 분리됩니다.
 - `install` / `uninstall`은 `~/.claude/settings.json`을 수정합니다.
 
@@ -48,7 +48,7 @@ Linux x64 서버에 CUDA 11이 설치되어 있으면 `@huggingface/transformers
 Error: CUDA 11 binaries are not supported by this script yet.
 ```
 
-Claude Memory Layer는 설치 시 Linux x64 + CUDA 11 환경을 감지하면 `@huggingface/transformers`를 optional dependency로 처리한 뒤 CPU-only ONNX Runtime 설정으로 자동 복구합니다. 그래서 일반적으로 사용자가 환경변수를 직접 지정할 필요는 없습니다.
+Claude Memory Layer는 `@huggingface/transformers`를 optional dependency로 두고, 설치 후 Linux x64에서 embedding backend가 빠져 있으면 CPU-only ONNX Runtime 설정으로 자동 복구합니다. CUDA가 없어도 로컬 임베딩을 사용할 수 있고, CUDA 11을 감지하지 못하는 서버에서도 복구를 한 번 더 시도합니다. 그래서 일반적으로 사용자가 환경변수를 직접 지정할 필요는 없습니다.
 
 만약 구버전 패키지를 설치 중이거나 postinstall 복구가 실패하면 아래처럼 수동으로 CUDA 바이너리 다운로드만 건너뛰어 재설치할 수 있습니다.
 
@@ -68,6 +68,20 @@ ONNXRUNTIME_NODE_INSTALL_CUDA=skip npm install
 ```
 
 `npm warn deprecated ...` 경고는 하위 의존성 경고이며 설치 실패 원인이 아닙니다.
+
+#### Embedding model
+
+기본 로컬 embedding 모델은 `Xenova/multilingual-e5-small`입니다.
+
+- `@huggingface/transformers`/ONNX Runtime CPU에서 동작하므로 CUDA가 필요 없습니다.
+- 원본 `intfloat/multilingual-e5-small`은 multilingual + Korean(`ko`) 지원 모델이고, Xenova variant는 Transformers.js용 ONNX 파일을 제공합니다.
+- 384차원이라 대규모 세션 import에서도 CPU/메모리 부담이 작습니다.
+- 더 높은 품질이 필요하면 `--embedding-model <hf-model>` 또는 `CLAUDE_MEMORY_EMBEDDING_MODEL`로 `onnx-community/Qwen3-Embedding-0.6B-ONNX`, `onnx-community/embeddinggemma-300m-ONNX` 같은 Transformers.js/ONNX 모델을 실험할 수 있습니다. 다만 이들은 다운로드/CPU 비용이 더 크거나 모델/라이선스 성숙도를 별도 검토해야 합니다.
+
+```bash
+claude-memory-layer import --project "$PWD" --embedding-model Xenova/multilingual-e5-small
+CLAUDE_MEMORY_EMBEDDING_MODEL=onnx-community/Qwen3-Embedding-0.6B-ONNX claude-memory-layer process --project "$PWD"
+```
 
 ### 1) 새 프로젝트에서 초기 메모리 생성
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-memory-layer",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-memory-layer",
-      "version": "1.0.29",
+      "version": "1.0.30",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-memory-layer",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "description": "Claude Code plugin that learns from conversations to provide personalized assistance",
   "main": "dist/index.js",
   "bin": {

--- a/scripts/postinstall-embedding-backend.cjs
+++ b/scripts/postinstall-embedding-backend.cjs
@@ -60,10 +60,9 @@ function isEmbeddingBackendAvailable(rootDir = process.cwd()) {
   }
 }
 
-function shouldAttemptAutoInstall({ platform, arch, cudaMajor, transformersAvailable, skipRequested }) {
+function shouldAttemptAutoInstall({ platform, arch, transformersAvailable, skipRequested }) {
   return platform === 'linux' &&
     arch === 'x64' &&
-    cudaMajor === 11 &&
     !transformersAvailable &&
     !skipRequested;
 }
@@ -104,7 +103,7 @@ function runPostinstall({
     return { attempted: false, cudaMajor, transformersAvailable, skipRequested };
   }
 
-  log('[claude-memory-layer] CUDA 11 detected and optional embedding backend is missing. Installing CPU-only embedding backend...');
+  log('[claude-memory-layer] Optional embedding backend is missing on Linux x64. Installing CPU-only embedding backend...');
 
   const npmCommand = platform === 'win32' ? 'npm.cmd' : 'npm';
   const result = spawnSyncImpl(npmCommand, createNpmInstallArgs(), {

--- a/src/apps/cli/index.ts
+++ b/src/apps/cli/index.ts
@@ -59,6 +59,10 @@ import {
   renderExternalMarketContextReport,
   type ExternalMarketProvider
 } from '../../core/external-market-context.js';
+import {
+  DEFAULT_EMBEDDING_FALLBACK_MODEL,
+  DEFAULT_EMBEDDING_MODEL
+} from '../../extensions/vector/embedder.js';
 
 // ============================================================
 // Hook Installation Utilities
@@ -1025,7 +1029,7 @@ program
   .option('-l, --limit <number>', 'Limit messages per session')
   .option('--session-limit <number>', 'Limit recent matching sessions to import')
   .option('-f, --force', 'Force reimport: delete existing events and reimport with turn_id grouping')
-  .option('--embedding-model <name>', 'Embedding model override (default: jinaai/jina-embeddings-v5-text-nano-text-matching, or env CLAUDE_MEMORY_EMBEDDING_MODEL; fallback env: CLAUDE_MEMORY_EMBEDDING_FALLBACK_MODEL)')
+  .option('--embedding-model <name>', `Embedding model override (default: ${DEFAULT_EMBEDDING_MODEL}, or env CLAUDE_MEMORY_EMBEDDING_MODEL; fallback: ${DEFAULT_EMBEDDING_FALLBACK_MODEL} or env CLAUDE_MEMORY_EMBEDDING_FALLBACK_MODEL)`)
   .option('-v, --verbose', 'Show detailed progress')
   .action(async (options) => {
     const startTime = Date.now();

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -152,8 +152,8 @@ export const ConfigSchema = z.object({
   }).default({}),
   embedding: z.object({
     provider: z.enum(['local', 'openai']).default('local'),
-    model: z.string().default('jinaai/jina-embeddings-v5-text-nano-text-matching'),
-    openaiModel: z.string().default('jinaai/jina-embeddings-v5-text-nano-text-matching'),
+    model: z.string().default('Xenova/multilingual-e5-small'),
+    openaiModel: z.string().default('Xenova/multilingual-e5-small'),
     batchSize: z.number().default(32)
   }).default({}),
   retrieval: z.object({

--- a/src/extensions/vector/embedder.ts
+++ b/src/extensions/vector/embedder.ts
@@ -14,13 +14,16 @@ type FeatureExtractionPipelineFactory = (
   model: string
 ) => Promise<NonNullable<Embedder['pipeline']>>;
 
+export const DEFAULT_EMBEDDING_MODEL = 'Xenova/multilingual-e5-small';
+export const DEFAULT_EMBEDDING_FALLBACK_MODEL = 'intfloat/multilingual-e5-small';
+
 export class Embedder {
   private pipeline: ((input: string, options?: Record<string, unknown>) => Promise<{ data: Float32Array }>) | null = null;
   private readonly modelName: string;
   private activeModelName: string;
   private initialized = false;
 
-  constructor(modelName: string = 'jinaai/jina-embeddings-v5-text-nano-text-matching') {
+  constructor(modelName: string = DEFAULT_EMBEDDING_MODEL) {
     this.modelName = modelName;
     this.activeModelName = modelName;
   }
@@ -31,7 +34,16 @@ export class Embedder {
   async initialize(): Promise<void> {
     if (this.initialized) return;
 
-    const pipeline = await withSuppressedKnownTransformersWarnings(() => loadTransformersPipeline());
+    const pipeline = await withSuppressedKnownTransformersWarnings(async () => {
+      try {
+        return await loadTransformersPipeline();
+      } catch (error) {
+        if (isMissingTransformersDependencyError(error)) {
+          throw createEmbeddingBackendUnavailableError(error);
+        }
+        throw error;
+      }
+    });
 
     try {
       this.pipeline = await withSuppressedKnownTransformersWarnings(() => pipeline('feature-extraction', this.modelName));
@@ -39,7 +51,7 @@ export class Embedder {
       this.initialized = true;
       return;
     } catch (primaryError) {
-      const fallbackModel = process.env.CLAUDE_MEMORY_EMBEDDING_FALLBACK_MODEL || 'onnx-community/embeddinggemma-300m-ONNX';
+      const fallbackModel = process.env.CLAUDE_MEMORY_EMBEDDING_FALLBACK_MODEL || DEFAULT_EMBEDDING_FALLBACK_MODEL;
       if (fallbackModel === this.modelName) {
         throw primaryError;
       }
@@ -184,6 +196,30 @@ export async function withSuppressedKnownTransformersWarnings<T>(fn: () => Promi
 export function isKnownBenignTransformersWarning(message: string): boolean {
   return message.includes('Unknown model class "eurobert"') ||
     message.includes('dtype not specified for "model"');
+}
+
+export function isMissingTransformersDependencyError(error: unknown): boolean {
+  const maybeError = error as { code?: unknown; message?: unknown } | null;
+  const message = typeof maybeError?.message === 'string' ? maybeError.message : '';
+  return maybeError?.code === 'ERR_MODULE_NOT_FOUND' &&
+    message.includes("@huggingface/transformers");
+}
+
+export function createEmbeddingBackendUnavailableError(cause: unknown): Error & { cause?: unknown } {
+  const error = new Error(
+    [
+      'Optional embedding backend is not installed.',
+      '',
+      'Claude Memory Layer can run embeddings on CPU-only ONNX Runtime; CUDA is not required.',
+      'Reinstall globally with:',
+      '  ONNXRUNTIME_NODE_INSTALL_CUDA=skip npm install -g claude-memory-layer@latest',
+      '',
+      'If you are inside a local checkout or package directory, repair only the backend with:',
+      '  ONNXRUNTIME_NODE_INSTALL_CUDA=skip npm install --no-save --no-package-lock --omit=dev @huggingface/transformers@3.8.1'
+    ].join('\n')
+  ) as Error & { cause?: unknown };
+  error.cause = cause;
+  return error;
 }
 
 async function loadTransformersPipeline(): Promise<FeatureExtractionPipelineFactory> {

--- a/tests/apps/postinstall-embedding-backend.test.ts
+++ b/tests/apps/postinstall-embedding-backend.test.ts
@@ -64,7 +64,7 @@ describe('embedding backend postinstall repair', () => {
     expect(postinstall.parseCudaMajor('nvcc: NVIDIA (R) Cuda compiler driver')).toBeNull();
   });
 
-  it('only auto-installs the embedding backend for Linux x64 CUDA 11 when it is missing', () => {
+  it('auto-installs a missing embedding backend for Linux x64 even when CUDA cannot be detected', () => {
     const postinstall = loadPostinstallModule();
 
     expect(postinstall.shouldAttemptAutoInstall({
@@ -78,26 +78,10 @@ describe('embedding backend postinstall repair', () => {
     expect(postinstall.shouldAttemptAutoInstall({
       platform: 'linux',
       arch: 'x64',
-      cudaMajor: 11,
-      transformersAvailable: true,
-      skipRequested: false
-    })).toBe(false);
-
-    expect(postinstall.shouldAttemptAutoInstall({
-      platform: 'linux',
-      arch: 'arm64',
-      cudaMajor: 11,
+      cudaMajor: null,
       transformersAvailable: false,
       skipRequested: false
-    })).toBe(false);
-
-    expect(postinstall.shouldAttemptAutoInstall({
-      platform: 'darwin',
-      arch: 'x64',
-      cudaMajor: 11,
-      transformersAvailable: false,
-      skipRequested: false
-    })).toBe(false);
+    })).toBe(true);
 
     expect(postinstall.shouldAttemptAutoInstall({
       platform: 'linux',
@@ -105,12 +89,36 @@ describe('embedding backend postinstall repair', () => {
       cudaMajor: 12,
       transformersAvailable: false,
       skipRequested: false
+    })).toBe(true);
+
+    expect(postinstall.shouldAttemptAutoInstall({
+      platform: 'linux',
+      arch: 'x64',
+      cudaMajor: null,
+      transformersAvailable: true,
+      skipRequested: false
+    })).toBe(false);
+
+    expect(postinstall.shouldAttemptAutoInstall({
+      platform: 'linux',
+      arch: 'arm64',
+      cudaMajor: null,
+      transformersAvailable: false,
+      skipRequested: false
+    })).toBe(false);
+
+    expect(postinstall.shouldAttemptAutoInstall({
+      platform: 'darwin',
+      arch: 'x64',
+      cudaMajor: null,
+      transformersAvailable: false,
+      skipRequested: false
     })).toBe(false);
 
     expect(postinstall.shouldAttemptAutoInstall({
       platform: 'linux',
       arch: 'x64',
-      cudaMajor: 11,
+      cudaMajor: null,
       transformersAvailable: false,
       skipRequested: true
     })).toBe(false);
@@ -132,7 +140,7 @@ describe('embedding backend postinstall repair', () => {
     ]);
   });
 
-  it('runs the automatic repair command when Linux x64 CUDA 11 skipped the optional backend', () => {
+  it('runs the automatic repair command when Linux x64 skipped the optional backend without detectable CUDA', () => {
     const postinstall = loadPostinstallModule();
     const rootDir = mkdtempSync(join(tmpdir(), 'cml-postinstall-test-'));
     const calls: SpawnCall[] = [];
@@ -145,7 +153,7 @@ describe('embedding backend postinstall repair', () => {
         env: {},
         platform: 'linux',
         arch: 'x64',
-        execFileSyncImpl: () => 'Cuda compilation tools, release 11.8, V11.8.89',
+        execFileSyncImpl: () => '',
         spawnSyncImpl: (cmd, args, options) => {
           calls.push({ cmd, args, env: options.env });
           return { status: 0 };
@@ -154,7 +162,7 @@ describe('embedding backend postinstall repair', () => {
         warn: () => undefined
       });
 
-      expect(result).toMatchObject({ attempted: true, success: true, cudaMajor: 11, transformersAvailable: false });
+      expect(result).toMatchObject({ attempted: true, success: true, cudaMajor: null, transformersAvailable: false });
       expect(calls).toHaveLength(1);
       expect(calls[0]?.cmd).toBe('npm');
       expect(calls[0]?.args).toEqual(postinstall.createNpmInstallArgs());

--- a/tests/extensions/embedder-warning-suppression.test.ts
+++ b/tests/extensions/embedder-warning-suppression.test.ts
@@ -1,11 +1,41 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  DEFAULT_EMBEDDING_MODEL,
+  Embedder,
+  createEmbeddingBackendUnavailableError,
   isKnownBenignTransformersWarning,
+  isMissingTransformersDependencyError,
   withSuppressedKnownTransformersWarnings
 } from '../../src/extensions/vector/embedder.js';
+import { ConfigSchema } from '../../src/core/types.js';
 
 describe('Embedder warning suppression', () => {
+  it('uses a CPU-friendly multilingual Korean-capable default embedding model', () => {
+    expect(DEFAULT_EMBEDDING_MODEL).toBe('Xenova/multilingual-e5-small');
+    expect(new Embedder().getModelName()).toBe(DEFAULT_EMBEDDING_MODEL);
+
+    const parsedConfig = ConfigSchema.parse({});
+    expect(parsedConfig.embedding.model).toBe(DEFAULT_EMBEDDING_MODEL);
+    expect(parsedConfig.embedding.openaiModel).toBe(DEFAULT_EMBEDDING_MODEL);
+  });
+
+  it('turns missing optional @huggingface/transformers errors into actionable install guidance', () => {
+    const missingBackendError = Object.assign(
+      new Error("Cannot find package '@huggingface/transformers' imported from /tmp/dist/cli/index.js"),
+      { code: 'ERR_MODULE_NOT_FOUND' }
+    );
+
+    expect(isMissingTransformersDependencyError(missingBackendError)).toBe(true);
+    expect(isMissingTransformersDependencyError(new Error('network failure'))).toBe(false);
+
+    const friendly = createEmbeddingBackendUnavailableError(missingBackendError);
+    expect(friendly.message).toContain('Optional embedding backend is not installed');
+    expect(friendly.message).toContain('ONNXRUNTIME_NODE_INSTALL_CUDA=skip npm install -g claude-memory-layer@latest');
+    expect(friendly.message).toContain('ONNXRUNTIME_NODE_INSTALL_CUDA=skip npm install --no-save --no-package-lock --omit=dev @huggingface/transformers@3.8.1');
+    expect(friendly.cause).toBe(missingBackendError);
+  });
+
   it('recognizes known benign transformer warnings', () => {
     expect(isKnownBenignTransformersWarning('Unknown model class "eurobert", attempting to construct from base class.')).toBe(true);
     expect(isKnownBenignTransformersWarning('dtype not specified for "model". Using the default dtype (fp32).')).toBe(true);


### PR DESCRIPTION
## Summary
- Broaden Linux x64 postinstall repair so a missing optional `@huggingface/transformers` backend is repaired with CPU-only ONNX Runtime even when CUDA cannot be detected.
- Convert runtime `ERR_MODULE_NOT_FOUND` for the optional embedding backend into actionable reinstall/repair guidance.
- Switch the default local embedding model to CPU/ONNX-friendly `Xenova/multilingual-e5-small` for multilingual/Korean retrieval; keep larger newer ONNX candidates documented as opt-in experiments.
- Bump package version to `1.0.30`.

## Embedding review
- Default selected: `Xenova/multilingual-e5-small` (`intfloat/multilingual-e5-small` ONNX variant), because it runs on `@huggingface/transformers` CPU, supports Korean/multilingual use, and is small enough for server imports.
- Considered opt-in candidates: `onnx-community/Qwen3-Embedding-0.6B-ONNX`, `onnx-community/embeddinggemma-300m-ONNX`; both loaded locally on CPU but were materially heavier.
- Rejected as default for now: BGE-M3/GTE/Jina-class larger models until Transformers.js ONNX packaging, CPU latency, and license/quality trade-offs are validated on CML retrieval benchmarks.

## Test Plan
- `npm test -- --run tests/apps/postinstall-embedding-backend.test.ts tests/extensions/embedder-warning-suppression.test.ts`
- `npm run typecheck`
- `npm test -- --run`
- `npm run build`
- `git diff --check`
- added-line secret scan: 0 findings
- `npm list claude-memory-layer --depth=0` => `(empty)`
- independent reviewer subagent: passed, no security concerns or logic errors
