### PR TITLE
feat: add source neighbor expansion for MCP refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ MCP client가 환경에 따라 PATH를 못 찾으면 `command -v claude-memory-l
 ### Advanced Features
 
 - **Citations System**: 검색 결과를 `[mem:abc123]` 형태로 추적하고 `source`/`mem-source-ref`로 근거 확인
+- **Source Neighbor Expansion**: `mem-source-ref(includeNeighbors=true, neighborWindow=1..5)`로 MemPalace식 hit 주변 세션 이벤트를 privacy-safe preview로 함께 확인
 - **Progressive Disclosure**: index → timeline → details 순서로 필요한 만큼만 확장해 토큰 비용 절감
 - **Codex/Hermes Importers**: read-only validate/replay 후 explicit import로만 mutation 수행
 - **Perspective Query Agent**: 관점별 observation + raw memory를 읽기 전용으로 조합하고 source refs를 유지
@@ -681,7 +682,7 @@ node dist/mcp/index.js
 | Context | `mem-context-pack` | 작업 시작용 relevant memory + recent timeline + follow-up refs |
 | Context | `mem-import-latest` | 최신 Claude/Codex/Hermes 세션을 bounded import 후 context-pack freshness 확보 |
 | Context | `mem-project-timeline` | 최근 프로젝트 메모리를 session/source/count/safe-preview로 요약 |
-| Context | `mem-source-ref` | `mem:`/`event:` ref를 redacted preview와 safe metadata로 해석 |
+| Context | `mem-source-ref` | `mem:`/`event:` ref를 redacted preview와 safe metadata로 해석; `includeNeighbors` + `neighborWindow`로 같은 세션의 전후 이벤트를 bounded/privacy-safe preview로 확장 |
 | Operations | `mem-facet-query` / `mem-facet-tag` | project-scoped facet 조회/태깅 |
 | Operations | `mem-action-list` / `mem-action-update` | 다음 작업/action 상태 조회·갱신 |
 | Operations | `mem-frontier` | blocked/next action frontier와 safe resume hints |
@@ -703,7 +704,7 @@ node dist/mcp/index.js
 ```text
 1. 새 작업 시작: mem-context-pack(projectPath, query)
 2. 최근 흐름 확인: mem-project-timeline(projectPath)
-3. 근거가 더 필요할 때: mem-source-ref(projectPath, ids=["mem:abc123"])
+3. 근거가 더 필요할 때: mem-source-ref(projectPath, ids=["mem:abc123"], includeNeighbors=true, neighborWindow=1)
 ```
 
 이 workflow는 Hermes/Codex/Claude Code가 같은 project-scoped memory backend를 공유할 때 특히 유용합니다. `mem-source-ref`는 raw transcript를 그대로 덤프하지 않고 allowlisted metadata와 privacy-filtered preview만 반환합니다.

--- a/docs/architecture/comparison-index.md
+++ b/docs/architecture/comparison-index.md
@@ -19,6 +19,7 @@ This index gathers the comparison/architecture notes used to guide the claude-me
 - [Memory Stats](../../dist/.claude-plugin/commands/memory-stats.md)
 - [Architecture Comparison And Recommendations](../../docs/ARCHITECTURE_COMPARISON_AND_RECOMMENDATIONS.md)
 - [Mcp Memory Service Comparative Review](../../docs/MCP_MEMORY_SERVICE_COMPARATIVE_REVIEW.md)
+- [MemPalace Targeted Improvement Plan](mempalace-targeted-improvement-plan.md)
 - [Memsearch Project Structure Analysis](../../docs/MEMSEARCH_PROJECT_STRUCTURE_ANALYSIS.md)
 - [Memu Adoption](../../docs/MEMU_ADOPTION.md)
 - [Project Structure Analysis](../../docs/PROJECT_STRUCTURE_ANALYSIS.md)

--- a/docs/architecture/mempalace-targeted-improvement-plan.md
+++ b/docs/architecture/mempalace-targeted-improvement-plan.md
@@ -1,0 +1,613 @@
+# MemPalace-informed targeted improvement plan for claude-memory-layer
+
+> Date: 2026-06-07
+> Scope: architectural comparison and concrete next-step plan for `claude-memory-layer`, using the local MemPalace reference checkout as the comparison architecture.
+> Non-secret policy: no credentials, connection strings, API keys, or private source content are included here.
+
+## Executive summary
+
+`claude-memory-layer` is already ahead of MemPalace in several product-critical areas: project-scoped memory operations, retrieval traces, action/frontier/checkpoint tooling, perspective memory, vector outbox recovery, and Claude/Hermes/Codex import surfaces. Its main architectural risk is not missing functionality; it is that feature growth has left several boundaries implicit.
+
+MemPalace is most useful as a reference for boundary discipline:
+
+1. storage and source integration are expressed as explicit contracts (`backends/base.py`, `sources/base.py`, RFC 002),
+2. user-facing memory is presented as a small layered stack (`layers.py`),
+3. search is a standalone orchestrator (`searcher.py`) rather than a side-effect of a broad service facade,
+4. MCP exposes many capabilities, but its current monolithic shape is a cautionary example rather than something to copy directly.
+
+The recommended direction is not to port MemPalace wholesale. Keep CML's SQLite-authoritative event store, project-scoped MCP operation model, and thin-core refactor trajectory. Add MemPalace-style contracts where CML currently has implicit adapters/importers and implicit derived layers.
+
+## Evidence reviewed
+
+### claude-memory-layer baseline
+
+Reviewed files:
+
+- `AGENTS.md`
+- `package.json`
+- `README.md`
+- `docs/PROJECT_STRUCTURE_ANALYSIS.md`
+- `docs/ARCHITECTURE_COMPARISON_AND_RECOMMENDATIONS.md`
+- `docs/REFACTORING_MILESTONES_AND_ISSUES.md`
+- `docs/TARGET_ARCHITECTURE_AND_FOLDER_STRUCTURE.md`
+- `docs/REFACTORING_PLAN_THIN_CORE.md`
+- `docs/architecture/comparison-index.md`
+- `specs/thin-core-refactor/spec.md`
+- `specs/thin-core-refactor/context.md`
+- `specs/thin-core-refactor/plan.md`
+- `src/services/memory-service.ts`
+- `src/core/engine/memory-service-composition.ts`
+- `src/core/engine/memory-engine-services.ts`
+- `src/core/engine/memory-ingest-service.ts`
+- `src/core/engine/memory-query-service.ts`
+- `src/core/engine/retrieval-orchestrator.ts`
+- `src/core/retriever.ts`
+- `src/core/event-store.ts`
+- `src/core/sqlite-event-store.ts`
+- `src/core/vector-store.ts`
+- `src/core/vector-outbox.ts`
+- `src/core/operations/index.ts`
+- `src/core/operations/graph-path-service.ts`
+- `src/core/operations/frontier-service.ts`
+- `src/extensions/mcp/handlers.ts`
+
+Observed current state:
+
+- `MemoryService` has become more of a compatibility facade, but it still imports and exposes many subsystem concepts.
+- `createMemoryServiceComposition` and `createMemoryEngineServices` are good seams, but still construct concrete extension concerns from the core engine path.
+- `MemoryIngestService` provides a useful ingest-side boundary and interceptor hooks.
+- `RetrievalOrchestrator` and `Retriever` are powerful but still combine candidate generation, quality guards, fallback policy, ranking, graph hop, source context, shared memory, and output formatting in a relatively wide surface.
+- `src/extensions/mcp/handlers.ts` centralizes a very large MCP handler surface, mixing tool routing, argument validation, memory operation dispatch, import refresh, market context, compression, and rendering.
+- A quick import-boundary scan found these notable cross-layer couplings:
+  - `core -> extensions`: `core/embedder.ts`, `core/engine/endless-memory-services.ts`, `core/engine/shared-memory-services.ts`
+  - `services -> extensions`: `services/memory-service.ts` imports shared-memory and endless-memory extension indexes
+  - `extensions -> services`: MCP handlers import `MemoryService` plus session-history importers
+  - `adapters -> services`: Claude hooks call `MemoryService` directly
+
+### MemPalace reference
+
+Reviewed files:
+
+- `README.md`
+- `CLAUDE.md`
+- `pyproject.toml`
+- `mempalace/backends/base.py`
+- `mempalace/sources/base.py`
+- `docs/rfcs/002-source-adapter-plugin-spec.md`
+- `mempalace/layers.py`
+- `mempalace/searcher.py`
+- `mempalace/dialect.py`
+- `mempalace/palace.py`
+- `mempalace/mcp_server.py`
+- `mempalace/knowledge_graph.py`
+- `mempalace/convo_miner.py`
+- `mempalace/sweeper.py`
+- `mempalace/diary_ingest.py`
+
+Reference patterns worth borrowing:
+
+- `BaseBackend` and `BaseCollection` make backend capabilities explicit with clear result types and exceptions.
+- `BaseSourceAdapter` makes source ingest explicit through `SourceRef`, `SourceItemMetadata`, `DrawerRecord`, `AdapterSchema`, capabilities, privacy class, lifecycle, and close semantics.
+- RFC 002 requires adapters to declare transformations, schemas, capabilities, incremental ingest behavior, privacy class, and conformance tests. This is the strongest MemPalace lesson for CML.
+- `Layer0` to `Layer3` and `MemoryStack` make user-facing memory modes legible: identity, compressed index, recall, and search.
+- `searcher.py` separates search orchestration from the storage/backend contract, including hybrid ranking, neighbor expansion, fallback modes, and result rendering.
+- `knowledge_graph.py` records temporal graph triples with provenance-oriented fields; useful as a reference for CML graph operation maturity.
+
+Reference patterns not worth copying directly:
+
+- Full pluggable canonical storage backend. CML should keep SQLite as authoritative storage for now; making canonical storage pluggable would add risk without solving the current boundary problem.
+- Monolithic MCP server shape. MemPalace's `mcp_server.py` exposes a broad surface in one file; CML should avoid letting `extensions/mcp/handlers.ts` keep growing in the same style.
+- Chroma/AAAK-specific concepts as product goals. Their lesson is layered disclosure and compact indexes, not the exact storage/index format.
+
+## Architectural comparison
+
+### 1. Canonical storage and backend contracts
+
+CML currently has a clear operational answer: SQLite is authoritative, LanceDB is derived acceleration, markdown is a human-readable projection, and shared/Mongo-style stores are optional replication/extension layers. The docs already describe this target. The remaining issue is that source-of-truth rules are more obvious in docs than in contracts.
+
+MemPalace uses explicit backend interfaces with capability errors and typed result objects. CML does not need the same pluggable storage backend abstraction for canonical SQLite. It does need smaller ports around derived stores and extension-owned capabilities:
+
+- `VectorIndexPort` for LanceDB/vector acceleration,
+- `DerivedLayerPort` for rebuildable facts/summaries/graph/indexes,
+- `MemoryExtensionPort` for shared/endless/MCP/analytics capabilities,
+- a single core-facing composition interface that receives these ports instead of importing concrete extension indexes.
+
+Target rule: core can define ports; extensions implement them. Core must not import extension modules.
+
+### 2. Source ingest and importers
+
+CML currently has several source/import paths: Claude hooks, Claude/Codex/Hermes session importers, MCP `mem-import-latest`, and tool-observation capture. These paths mostly converge on `MemoryIngestService`, which is good. But the source-side contract is implicit.
+
+MemPalace's strongest contribution is RFC 002: each source adapter declares identity, version, schema, transformations, privacy class, capabilities, and test requirements. CML should adopt this pattern for import/capture sources.
+
+Recommended CML concept:
+
+```ts
+interface MemorySourceAdapter {
+  readonly name: string;
+  readonly adapterVersion: string;
+  readonly capabilities: readonly string[];
+  readonly defaultPrivacyClass: PrivacyClass;
+  describeSchema(): SourceAdapterSchema;
+  ingest(source: SourceRef, context: SourceIngestContext): AsyncIterable<SourceRecord>;
+  isCurrent?(item: SourceItemMetadata, existing?: ExistingSourceRecord): Promise<boolean>;
+  close?(): Promise<void>;
+}
+```
+
+This does not replace `MemoryIngestService`. It feeds it. `MemoryIngestService` remains the normalizer/appender/outbox coordinator.
+
+Priority first-party adapters:
+
+1. `claude-hook` for live hook capture,
+2. `claude-history` for Claude transcript/session import,
+3. `codex-history`,
+4. `hermes-history`,
+5. `tool-observation` if tool capture needs separate policy controls.
+
+Adapter metadata should include at least:
+
+- adapter name/version,
+- source id and source version,
+- source project hash or redacted project identifier (never raw absolute paths in exposed metadata),
+- privacy class,
+- declared transformations,
+- capture mode (`live_hook`, `history_import`, `tool_observation`, `summary_backfill`, etc.),
+- stable source references for source drill-down.
+
+### 3. Memory layers and product mental model
+
+CML already has raw events, session summaries, entries/entities/edges, lessons, actions, checkpoints, facets, actor cards, perspective observations, retrieval traces, and vector rows. The architecture is rich but not compactly explainable.
+
+MemPalace's `Layer0` to `Layer3` model makes memory easier to reason about. CML should not copy the exact names, but should introduce a documented and testable layer manifest.
+
+Recommended CML layer manifest:
+
+| Layer | CML concept | Authoritative? | Rebuildable? | Main interfaces |
+| --- | --- | --- | --- | --- |
+| L0 Raw events | session/user/assistant/tool/import events | yes | no | `MemoryIngestService`, SQLite event store |
+| L1 Extracted units | entries, entities, facets, lessons, actor observations | partly derived | yes from L0 + governance events | operation repositories, derivation services |
+| L2 Summaries and continuity | session/project summaries, actor cards, context packs | derived/governed | partly | summary/perspective/context-pack services |
+| L3 Retrieval surface | search results, expanded context, source refs, traces | no | yes | `Retriever`, `RetrievalOrchestrator`, disclosure services |
+| L4 Optional accelerators | LanceDB rows, shared memory replicas, vector/index workers | no | yes | vector outbox, extension ports |
+
+This would let docs, tests, MCP tool names, and recovery workflows all use the same language.
+
+### 4. Retrieval orchestration
+
+CML's retrieval is more advanced than MemPalace's in project scoping, graph expansion, debug lanes, fallback traces, context compression, and disclosure. But the code surface is broad.
+
+MemPalace's useful pattern is not algorithmic superiority; it is that search is a clear subsystem with distinct phases.
+
+Recommended CML split:
+
+1. `QueryPlanBuilder`: classify query, scope mode, facets, graph-hop eligibility, source lanes.
+2. `CandidateGenerator`: semantic, keyword, recent, summary, graph, perspective, shared lanes.
+3. `CandidateRanker`: semantic/lexical/recency/facet/graph scoring and quality guards.
+4. `ResultExpander`: session/turn/source expansion and progressive disclosure.
+5. `ContextAssembler`: token budgeting, compression, citation rendering.
+6. `RetrievalTraceRecorder`: trace persistence and helpfulness feedback.
+
+This preserves the current behavior while making each phase easier to test and swap.
+
+### 5. MCP surface and operation tooling
+
+CML's MCP operation model is a differentiator: project-scoped memory actions, checkpoints, frontiers, facets, actor cards, perspective observations, graph query, retention audit, import refresh, and context packs are more governance-oriented than MemPalace's surface.
+
+The risk is file-level concentration: `src/extensions/mcp/handlers.ts` is already a multi-thousand-line dispatcher. MemPalace's `mcp_server.py` shows what happens when MCP routing grows without bounded modules.
+
+Recommended CML MCP refactor:
+
+```text
+src/extensions/mcp/
+  index.ts
+  router.ts
+  schemas/
+    common.ts
+    context-pack.ts
+    operations.ts
+    import.ts
+    market-context.ts
+  handlers/
+    context-pack-handler.ts
+    import-handler.ts
+    operation-handlers/
+      facet.ts
+      action.ts
+      frontier.ts
+      graph.ts
+      perspective.ts
+      actor.ts
+      retention.ts
+    external-market-context-handler.ts
+  presenters/
+    json-result.ts
+    source-ref-presenter.ts
+    context-pack-presenter.ts
+```
+
+Acceptance rule: no new MCP tool should be added directly to the root dispatcher after the split.
+
+### 6. Maintenance and recovery workflows
+
+CML already has stronger outbox machinery than MemPalace. `VectorOutbox` provides idempotent enqueue, claim, retries, stuck recovery, and metrics. The gap is that maintenance concepts are distributed across event store, query service, runtime service, importers, and extension handlers.
+
+Borrow MemPalace's explicit workflow separation from `sweeper.py`, `convo_miner.py`, and `diary_ingest.py`, but implement it as typed CML jobs rather than scripts.
+
+Recommended CML maintenance jobs:
+
+- `ProcessEmbeddingOutboxJob`
+- `ProcessVectorOutboxJob`
+- `BackfillSessionSummariesJob`
+- `ImportLatestSourceJob` using source adapters
+- `RepairProjectScopeJob`
+- `RebuildDerivedLayerJob`
+- `VerifySourceAdapterConformanceJob`
+
+Each job should expose:
+
+- input schema,
+- dry-run support where relevant,
+- idempotency key,
+- progress metrics,
+- failure/retry policy,
+- audit event / operation log linkage.
+
+## Targeted implementation plan
+
+### P0 — make boundaries enforceable before adding more capability
+
+#### P0.1 Add an import-boundary guard
+
+Goal: convert the current thin-core intent into an automated check.
+
+Files to add or modify:
+
+- Add `scripts/check-import-boundaries.mjs`
+- Add a package script such as `check:architecture`
+- Add CI invocation if CI config exists
+
+Rules:
+
+- `src/core/**` may not import `src/extensions/**`, `src/adapters/**`, `src/apps/**`, or `src/services/**`.
+- `src/extensions/**` may import core ports/types, but should not import `src/services/memory-service.ts` after the MCP split.
+- `src/adapters/**` may use a public app/service facade, but Claude hooks should progressively depend on adapter-facing ports rather than the full `MemoryService` class.
+- legacy compatibility wrappers (`src/hooks`, `src/mcp`) may re-export but not grow new logic.
+
+Current known violations to drive the first fix:
+
+- `src/core/embedder.ts -> src/extensions/vector/index.ts`
+- `src/core/engine/endless-memory-services.ts -> src/extensions/endless-memory/index.ts`
+- `src/core/engine/shared-memory-services.ts -> src/extensions/shared-memory/index.ts`
+- `src/extensions/mcp/handlers.ts -> src/services/memory-service.ts`
+
+Verification:
+
+- `npm run check:architecture`
+- `npm test -- --run`
+
+#### P0.2 Define CML source adapter contracts
+
+Goal: standardize Claude/Codex/Hermes import and hook capture before more source types are added.
+
+Files to add:
+
+- `src/core/source/source-ref.ts`
+- `src/core/source/source-adapter.ts`
+- `src/core/source/source-schema.ts`
+- `src/core/source/source-transformations.ts`
+- `src/core/source/source-adapter-contract-suite.ts` or test helpers under `tests/`
+- `docs/architecture/source-adapter-contract.md`
+
+Initial adapters to wrap existing code:
+
+- `src/adapters/claude/source/claude-hook-adapter.ts`
+- `src/adapters/claude/source/claude-history-adapter.ts`
+- `src/adapters/codex/source/codex-history-adapter.ts`
+- `src/adapters/hermes/source/hermes-history-adapter.ts`
+
+Contract requirements borrowed from MemPalace, adapted for CML:
+
+- stable source id and source version,
+- declared transformations,
+- privacy class,
+- schema declaration,
+- incremental ingest/currentness check,
+- close semantics,
+- source-ref options must not contain secrets,
+- conformance tests for stable identity, schema conformance, and declared transformations.
+
+Verification:
+
+- New contract tests for one adapter first, likely `claude-history` or `hermes-history` because they are import-like and easier to fixture.
+- Existing import tests must still pass.
+
+#### P0.3 Document the layer manifest and source-of-truth contract
+
+Goal: make CML's memory layers as legible as MemPalace's stack without renaming existing tables prematurely.
+
+Files to add or update:
+
+- Add `docs/architecture/memory-layer-manifest.md`
+- Update `docs/TARGET_ARCHITECTURE_AND_FOLDER_STRUCTURE.md`
+- Update `specs/thin-core-refactor/context.md`
+
+Must state:
+
+- SQLite event store is authoritative for raw events and governance records.
+- Markdown mirror is human-readable projection, not independent truth.
+- LanceDB/vector rows are derived and rebuildable.
+- Shared/endless/Mongo-style stores are extension/replication layers.
+- MCP tools should disclose which layer they query or mutate.
+
+Verification:
+
+- Docs mention every currently exposed memory family: events, entries/entities/edges, facets, lessons, actions, checkpoints, actor cards, perspective observations, summaries, retrieval traces, vectors, shared memory.
+
+### P1 — reduce core/service coupling while preserving behavior
+
+#### P1.1 Invert extension construction
+
+Goal: `core` defines extension ports; composition wires implementations from `services` or `extensions` without core importing extension implementations.
+
+Files likely involved:
+
+- `src/core/engine/memory-engine-services.ts`
+- `src/core/engine/memory-service-composition.ts`
+- `src/core/engine/shared-memory-services.ts`
+- `src/core/engine/endless-memory-services.ts`
+- `src/extensions/shared-memory/index.ts`
+- `src/extensions/endless-memory/index.ts`
+- `src/extensions/vector/index.ts`
+
+Plan:
+
+1. Introduce `src/core/ports/vector-index-port.ts`.
+2. Introduce `src/core/ports/extension-runtime-port.ts` or narrow named ports.
+3. Move extension factory calls to `src/services/memory-service-composition.ts` or `src/extensions/*/factory.ts` invoked by service layer.
+4. Keep existing public `MemoryService` API stable.
+
+Verification:
+
+- Architecture guard passes.
+- Existing public imports continue to compile.
+- Tests around shared/endless/vector behavior pass.
+
+#### P1.2 Split retrieval into phase modules
+
+Goal: preserve current retrieval output while making each decision independently testable.
+
+Files likely involved:
+
+- `src/core/retriever.ts`
+- `src/core/engine/retrieval-orchestrator.ts`
+- `src/core/engine/retrieval-services.ts`
+- new `src/core/retrieval/*`
+
+Suggested sequence:
+
+1. Extract pure `QueryPlanBuilder` from option normalization, quality query, command-artifact guard, scope mode, and graph-hop policy.
+2. Extract `CandidateRanker` from semantic/lexical/recency/facet/graph weighting.
+3. Extract `ResultExpander` from session/source/context expansion.
+4. Move formatting/token budgeting into `ContextAssembler`.
+5. Keep `Retriever.retrieve()` as the compatibility entry point.
+
+Verification:
+
+- Golden retrieval tests for representative queries before extraction.
+- Candidate debug and selected debug traces remain stable enough for dashboard consumers.
+
+#### P1.3 MCP handler modularization
+
+Goal: prevent CML's MCP server from becoming MemPalace-style monolithic routing.
+
+Files likely involved:
+
+- `src/extensions/mcp/handlers.ts`
+- new `src/extensions/mcp/handlers/*`
+- new `src/extensions/mcp/schemas/*`
+- new `src/extensions/mcp/presenters/*`
+
+Plan:
+
+1. Extract common argument helpers and JSON result helpers.
+2. Move memory operation tools into bounded handlers.
+3. Move import refresh/context pack handling into dedicated handlers.
+4. Add a registry table mapping tool name to schema and handler.
+5. Keep `handleToolCall(name, args)` as compatibility entry point.
+
+Verification:
+
+- MCP handler tests cover every tool name in the registry.
+- Typecheck catches missing handlers.
+
+### P2 — improve source-aware retrieval and graph quality
+
+#### P2.1 Add source-aware retrieval lanes
+
+Goal: let context packs and search output distinguish live hooks, history imports, summaries, tool observations, and governed facts.
+
+Files likely involved:
+
+- source adapter metadata from P0.2
+- `src/core/retriever.ts`
+- `src/core/engine/retrieval-orchestrator.ts`
+- `src/core/context-compressor.ts`
+- source-ref presenter in MCP
+
+Capabilities:
+
+- Filter by source adapter/source type.
+- Prefer governed facts/summaries for broad continuation queries.
+- Prefer raw/tool/source refs for debugging and provenance queries.
+- Surface declared transformations in source refs when output is not raw/verbatim.
+
+Verification:
+
+- Tests for source-filtered retrieval.
+- Context pack output includes source lane labels without leaking raw private data.
+
+Implemented first slice (2026-06-07):
+
+- `mem-source-ref` now accepts `includeNeighbors` and `neighborWindow` so an agent can expand a cited hit to bounded before/after events from the same session.
+- Neighbor previews use the existing MCP privacy filter and content budget clamps; they expose citation/source-ref metadata rather than raw transcript dumps.
+- Covered by `tests/extensions/mcp-context-tools.test.ts` for schema exposure, neighbor-window bounds, and secret redaction.
+
+#### P2.2 Introduce rebuildable derived-layer jobs
+
+Goal: make facts, summaries, vectors, graph edges, actor cards, and retrieval indexes visibly rebuildable when their derivation logic changes.
+
+Files likely involved:
+
+- `src/core/engine/*maintenance*`
+- `src/core/operations/*`
+- `src/core/vector-outbox.ts`
+- new `src/core/layers/*`
+
+Plan:
+
+1. Define `DerivedLayerDescriptor` with `name`, `version`, `inputs`, `outputs`, `rebuild`, `verify`.
+2. Register descriptors for vectors, summaries, lessons, perspective observations, graph paths/edges where appropriate.
+3. Add dry-run layer audit: what is stale, missing, or failed.
+4. Expose through CLI and MCP only after internal tests exist.
+
+Verification:
+
+- Rebuild jobs are idempotent.
+- Dry-run reports no mutation.
+- Vector outbox and derived-layer rebuild do not fight over the same rows.
+
+#### P2.3 Upgrade graph provenance and temporal semantics
+
+Goal: borrow MemPalace KG's temporal/provenance discipline without replacing CML's current entity-edge model.
+
+Files likely involved:
+
+- `src/core/operations/graph-path-service.ts`
+- entity/edge repositories and schema migrations
+- MCP graph query handler
+
+Plan:
+
+- Add optional `valid_from`, `valid_to`, `source_event_ids`, `source_adapter`, `source_record_id`, and `confidence` fields to graph edges or edge metadata.
+- Teach graph query/presentation to show provenance and active/inactive status.
+- Keep `maxHops <= 2` safety clamp unless a separate performance review approves more.
+
+Verification:
+
+- Existing graph path tests pass.
+- New tests cover expired/invalidated edges and provenance rendering.
+
+## Work packet sequencing
+
+### Packet A: Architecture guard + layer manifest
+
+Why first: lowest risk, immediately prevents future boundary drift.
+
+Deliverables:
+
+- import-boundary checker,
+- `memory-layer-manifest.md`,
+- docs update linking this plan into the architecture index.
+
+Expected verification:
+
+- `npm run check:architecture`
+- `npm run typecheck`
+
+### Packet B: Source adapter contract + one pilot adapter
+
+Why second: highest MemPalace-derived leverage.
+
+Deliverables:
+
+- source adapter types,
+- source contract doc,
+- one pilot adapter wrapping an existing importer,
+- contract tests.
+
+Expected verification:
+
+- adapter contract tests,
+- existing import tests,
+- no public MCP behavior change.
+
+### Packet C: Extension port inversion
+
+Why third: core boundary cleanup after contracts are explicit.
+
+Deliverables:
+
+- ports under `src/core/ports` or equivalent,
+- no `core -> extensions` imports,
+- service-layer composition still constructs extension implementations.
+
+Expected verification:
+
+- architecture guard passes with stricter rules,
+- typecheck and existing unit tests.
+
+### Packet D: MCP modularization
+
+Why fourth: reduces future maintenance cost and enables safer tool additions.
+
+Deliverables:
+
+- handler registry,
+- bounded handler modules,
+- schema/presenter split,
+- compatibility wrapper.
+
+Expected verification:
+
+- MCP tool registry tests,
+- no missing tool names,
+- manual smoke for `mem-context-pack`, `mem-import-latest`, `mem-frontier`, and `mem-graph-query`.
+
+### Packet E: Retrieval phase split
+
+Why fifth: high-value but riskier; do after boundary and test scaffolding.
+
+Deliverables:
+
+- query plan, candidate generation, ranker, expander, assembler modules,
+- golden retrieval tests,
+- trace compatibility review.
+
+Expected verification:
+
+- retrieval tests,
+- dashboard smoke for trace/debug data,
+- real project `mem-context-pack` smoke.
+
+## Non-goals
+
+- Do not replace SQLite as CML's canonical store.
+- Do not port MemPalace's Chroma backend, AAAK dialect, or palace terminology wholesale.
+- Do not make canonical storage pluggable until CML has a concrete user/business reason and a full migration story.
+- Do not add new source types before the source adapter contract exists.
+- Do not grow `src/extensions/mcp/handlers.ts` with more direct tool branches after modularization starts.
+
+## Success criteria
+
+The MemPalace comparison should be considered acted on when CML has:
+
+1. an enforced import-boundary check,
+2. a documented memory-layer manifest,
+3. a source adapter contract with conformance tests,
+4. at least one existing importer migrated behind that contract,
+5. no direct `core -> extensions` imports,
+6. MCP tools routed through bounded handler modules,
+7. retrieval behavior preserved while the retrieval implementation is split into phase-level modules.
+
+## Recommended immediate next task
+
+Start with Packet A. It is small, reversible, and creates guardrails for every later packet:
+
+1. add `scripts/check-import-boundaries.mjs`,
+2. add `npm run check:architecture`,
+3. write `docs/architecture/memory-layer-manifest.md`,
+4. link this plan and the manifest from `docs/architecture/comparison-index.md`,
+5. run typecheck/tests.
+
+This sequence keeps CML's current thin-core momentum and uses MemPalace where it is strongest: contracts, layer clarity, and adapter conformance.

--- a/src/extensions/mcp/handlers.ts
+++ b/src/extensions/mcp/handlers.ts
@@ -1571,7 +1571,10 @@ async function handleMemSourceRef(memoryService: MemoryService, args: Record<str
     : [];
   const maxContentChars = numberArg(args.maxContentChars, 500, 80, 2000);
   const lookupLimit = numberArg(args.lookupLimit, 10000, 1, 50000);
+  const includeNeighbors = args.includeNeighbors === true;
+  const neighborWindow = includeNeighbors ? numberArg(args.neighborWindow, 1, 0, 5) : 0;
   const recentEvents = await memoryService.getRecentEvents(lookupLimit);
+  const sessionEventCache = new Map<string, Promise<MemoryEvent[]>>();
 
   const lines: string[] = ['## Source References', ''];
 
@@ -1605,6 +1608,19 @@ async function handleMemSourceRef(memoryService: MemoryService, args: Record<str
 
     lines.push('- Redacted Preview:');
     lines.push(`  > ${safeInline(event.content, maxContentChars)}`);
+    if (neighborWindow > 0) {
+      try {
+        let sessionEventsPromise = sessionEventCache.get(event.sessionId);
+        if (!sessionEventsPromise) {
+          sessionEventsPromise = memoryService.getSessionHistory(event.sessionId);
+          sessionEventCache.set(event.sessionId, sessionEventsPromise);
+        }
+        const sessionEvents = await sessionEventsPromise;
+        appendSourceRefNeighborContext(lines, event, sessionEvents, neighborWindow, maxContentChars);
+      } catch {
+        lines.push('- Neighbor Context: unavailable (details suppressed)');
+      }
+    }
     lines.push('');
   }
 
@@ -1956,6 +1972,46 @@ function sourceTypeForEvent(event: MemoryEvent): string {
   if (typeof event.metadata?.importedFrom === 'string') return 'imported_history';
   if (typeof event.metadata?.transcriptPath === 'string') return 'transcript';
   return 'raw_event';
+}
+
+function appendSourceRefNeighborContext(
+  lines: string[],
+  event: MemoryEvent,
+  sessionEvents: MemoryEvent[],
+  neighborWindow: number,
+  maxContentChars: number
+): void {
+  const sorted = sessionEvents
+    .slice()
+    .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime() || a.id.localeCompare(b.id));
+  const targetIndex = sorted.findIndex((candidate) => candidate.id === event.id);
+
+  lines.push('- Neighbor Context:');
+  if (targetIndex < 0) {
+    lines.push('  - unavailable (source event not found in session history)');
+    return;
+  }
+
+  const start = Math.max(0, targetIndex - neighborWindow);
+  const end = Math.min(sorted.length, targetIndex + neighborWindow + 1);
+  const neighbors = sorted
+    .map((candidate, index) => ({ event: candidate, index }))
+    .slice(start, end)
+    .filter((candidate) => candidate.event.id !== event.id);
+  if (neighbors.length === 0) {
+    lines.push('  - none within requested window');
+    return;
+  }
+
+  const previewChars = Math.max(80, Math.min(maxContentChars, 300));
+  for (const neighbor of neighbors) {
+    const direction = neighbor.index < targetIndex ? 'before' : 'after';
+    const citationId = generateCitationId(neighbor.event.id);
+    lines.push(
+      `  - ${direction} [mem:${citationId}] sourceRef=event:${neighbor.event.id} type=${neighbor.event.eventType} timestamp=${neighbor.event.timestamp.toISOString()}`
+    );
+    lines.push(`    > ${safeInline(neighbor.event.content, previewChars)}`);
+  }
 }
 
 function formatRelevantMemoryLine(

--- a/src/extensions/mcp/tools.ts
+++ b/src/extensions/mcp/tools.ts
@@ -323,6 +323,16 @@ export const tools: Tool[] = [
           type: 'number',
           description: 'Maximum recent events to scan for ID resolution (default: 10000, max: 50000)'
         },
+        includeNeighbors: {
+          type: 'boolean',
+          description: 'When true, include privacy-safe neighbor events from the same session around each resolved source reference.'
+        },
+        neighborWindow: {
+          type: 'number',
+          minimum: 0,
+          maximum: 5,
+          description: 'Number of before/after session neighbor events to include when includeNeighbors is true (default: 1, max: 5).'
+        },
         projectPath: projectPathProperty
       },
       required: ['ids']

--- a/tests/extensions/mcp-context-tools.test.ts
+++ b/tests/extensions/mcp-context-tools.test.ts
@@ -161,6 +161,16 @@ describe('MCP project context tools', () => {
     expect(maxTokensDescription).toContain('selected compression mode');
     expect(maxTokensDescription).toContain('final assembly');
     expect(maxTokensDescription).not.toContain('after safe compression');
+    const sourceRefProperties = byName.get('mem-source-ref')?.inputSchema.properties as Record<string, unknown>;
+    expect(sourceRefProperties.includeNeighbors).toMatchObject({
+      type: 'boolean',
+      description: expect.stringContaining('neighbor')
+    });
+    expect(sourceRefProperties.neighborWindow).toMatchObject({
+      type: 'number',
+      minimum: 0,
+      maximum: 5
+    });
     const marketContextProperties = byName.get('external-market-context')?.inputSchema.properties as Record<string, unknown>;
     expect(marketContextProperties.projectPath).toMatchObject({ type: 'string' });
     expect(marketContextProperties.includeSnapshot).toMatchObject({ type: 'boolean' });
@@ -1684,5 +1694,197 @@ describe('MCP project context tools', () => {
 
     expect(result.isError).not.toBe(true);
     expect(textOf(result)).toContain('Citation lookup target');
+  });
+
+  it('does not expand source reference neighbors unless explicitly enabled', async () => {
+    const target = event({
+      id: '66666666-6666-4666-8666-666666666660',
+      sessionId: 'session-neighbor-disabled',
+      eventType: 'agent_response',
+      timestamp: new Date('2026-05-05T02:01:00.000Z'),
+      content: 'Target source reference content.'
+    });
+    mocks.projectService.getRecentEvents.mockResolvedValue([target]);
+    mocks.projectService.getSessionHistory.mockResolvedValue([
+      target,
+      event({
+        id: '66666666-6666-4666-8666-66666666665f',
+        sessionId: 'session-neighbor-disabled',
+        eventType: 'user_prompt',
+        timestamp: new Date('2026-05-05T02:00:00.000Z'),
+        content: 'This neighboring turn should not be expanded.'
+      })
+    ]);
+
+    const result = await handleToolCall('mem-source-ref', {
+      projectPath: '/repo/app',
+      ids: [target.id],
+      neighborWindow: 1,
+      maxContentChars: 240
+    });
+
+    const text = textOf(result);
+    expect(result.isError).not.toBe(true);
+    expect(mocks.projectService.getSessionHistory).not.toHaveBeenCalled();
+    expect(text).not.toContain('- Neighbor Context:');
+    expect(text).not.toContain('This neighboring turn should not be expanded');
+  });
+
+  it('defaults, disables, and clamps source reference neighbor windows', async () => {
+    const sessionEvents = Array.from({ length: 13 }, (_, index) => {
+      const offset = index - 6;
+      return event({
+        id: `77777777-7777-4777-8777-7777777777${String(index).padStart(2, '0')}`,
+        sessionId: 'session-neighbor-bounds',
+        eventType: offset === 0 ? 'agent_response' : 'user_prompt',
+        timestamp: new Date(Date.UTC(2026, 4, 5, 4, index, 0, 0)),
+        content: `Neighbor offset ${offset}`
+      });
+    });
+    const target = sessionEvents[6];
+    mocks.projectService.getRecentEvents.mockResolvedValue([target]);
+    mocks.projectService.getSessionHistory.mockResolvedValue(sessionEvents);
+
+    const defaultResult = await handleToolCall('mem-source-ref', {
+      projectPath: '/repo/app',
+      ids: [target.id],
+      includeNeighbors: true,
+      maxContentChars: 240
+    });
+    const defaultText = textOf(defaultResult);
+    expect(defaultResult.isError).not.toBe(true);
+    expect(defaultText).toContain('Neighbor offset -1');
+    expect(defaultText).toContain('Neighbor offset 1');
+    expect(defaultText).not.toContain('Neighbor offset -2');
+    expect(defaultText).not.toContain('Neighbor offset 2');
+
+    mocks.projectService.getSessionHistory.mockClear();
+    const disabledResult = await handleToolCall('mem-source-ref', {
+      projectPath: '/repo/app',
+      ids: [target.id],
+      includeNeighbors: true,
+      neighborWindow: 0,
+      maxContentChars: 240
+    });
+    const disabledText = textOf(disabledResult);
+    expect(disabledResult.isError).not.toBe(true);
+    expect(mocks.projectService.getSessionHistory).not.toHaveBeenCalled();
+    expect(disabledText).not.toContain('- Neighbor Context:');
+
+    const clampedResult = await handleToolCall('mem-source-ref', {
+      projectPath: '/repo/app',
+      ids: [target.id],
+      includeNeighbors: true,
+      neighborWindow: 99,
+      maxContentChars: 240
+    });
+    const clampedText = textOf(clampedResult);
+    expect(clampedResult.isError).not.toBe(true);
+    expect(clampedText).toContain('Neighbor offset -5');
+    expect(clampedText).toContain('Neighbor offset 5');
+    expect(clampedText).not.toContain('Neighbor offset -6');
+    expect(clampedText).not.toContain('Neighbor offset 6');
+  });
+
+  it('caches same-session neighbor history and labels same-timestamp neighbors by sorted position', async () => {
+    const timestamp = new Date('2026-05-05T04:00:00.000Z');
+    const previous = event({
+      id: '88888888-8888-4888-8888-888888888881',
+      sessionId: 'session-neighbor-cache',
+      eventType: 'user_prompt',
+      timestamp,
+      content: 'Same timestamp previous event.'
+    });
+    const firstTarget = event({
+      id: '88888888-8888-4888-8888-888888888882',
+      sessionId: 'session-neighbor-cache',
+      eventType: 'agent_response',
+      timestamp,
+      content: 'First target source reference content.'
+    });
+    const secondTarget = event({
+      id: '88888888-8888-4888-8888-888888888883',
+      sessionId: 'session-neighbor-cache',
+      eventType: 'agent_response',
+      timestamp,
+      content: 'Second target source reference content.'
+    });
+    const next = event({
+      id: '88888888-8888-4888-8888-888888888884',
+      sessionId: 'session-neighbor-cache',
+      eventType: 'tool_observation',
+      timestamp,
+      content: 'Same timestamp next event.'
+    });
+    mocks.projectService.getRecentEvents.mockResolvedValue([firstTarget, secondTarget]);
+    mocks.projectService.getSessionHistory.mockResolvedValue([previous, firstTarget, secondTarget, next]);
+
+    const result = await handleToolCall('mem-source-ref', {
+      projectPath: '/repo/app',
+      ids: [firstTarget.id, secondTarget.id],
+      includeNeighbors: true,
+      neighborWindow: 1,
+      maxContentChars: 240
+    });
+
+    const text = textOf(result);
+    expect(result.isError).not.toBe(true);
+    expect(mocks.projectService.getSessionHistory).toHaveBeenCalledTimes(1);
+    expect(text).toContain(`before [mem:${generateCitationId(previous.id)}]`);
+    expect(text).toContain(`after [mem:${generateCitationId(secondTarget.id)}]`);
+    expect(text).toContain(`after [mem:${generateCitationId(next.id)}]`);
+  });
+
+  it('optionally expands source references with privacy-safe neighboring session events', async () => {
+    const previous = event({
+      id: '66666666-6666-4666-8666-666666666661',
+      sessionId: 'session-neighbor',
+      eventType: 'user_prompt',
+      timestamp: new Date('2026-05-05T03:00:00.000Z'),
+      content: 'Previous turn explains why retrieval source context matters.'
+    });
+    const target = event({
+      id: '66666666-6666-4666-8666-666666666662',
+      sessionId: 'session-neighbor',
+      eventType: 'agent_response',
+      timestamp: new Date('2026-05-05T03:01:00.000Z'),
+      content: 'Target source reference content.'
+    });
+    const next = event({
+      id: '66666666-6666-4666-8666-666666666663',
+      sessionId: 'session-neighbor',
+      eventType: 'tool_observation',
+      timestamp: new Date('2026-05-05T03:02:00.000Z'),
+      content: `Next turn contains ${'api' + '_key'}=neighbor-secret but also a useful smoke-test result.`
+    });
+    const far = event({
+      id: '66666666-6666-4666-8666-666666666664',
+      sessionId: 'session-neighbor',
+      eventType: 'agent_response',
+      timestamp: new Date('2026-05-05T03:03:00.000Z'),
+      content: 'Far turn outside the requested neighbor window.'
+    });
+    mocks.projectService.getRecentEvents.mockResolvedValue([target]);
+    mocks.projectService.getSessionHistory.mockResolvedValue([previous, target, next, far]);
+
+    const result = await handleToolCall('mem-source-ref', {
+      projectPath: '/repo/app',
+      ids: [target.id],
+      includeNeighbors: true,
+      neighborWindow: 1,
+      maxContentChars: 240
+    });
+
+    const text = textOf(result);
+    expect(result.isError).not.toBe(true);
+    expect(mocks.projectService.getSessionHistory).toHaveBeenCalledWith('session-neighbor');
+    expect(text).toContain('- Neighbor Context:');
+    expect(text).toContain(`[mem:${generateCitationId(previous.id)}]`);
+    expect(text).toContain('Previous turn explains why retrieval source context matters');
+    expect(text).toContain(`[mem:${generateCitationId(next.id)}]`);
+    expect(text).toContain('useful smoke-test result');
+    expect(text).not.toContain('neighbor-secret');
+    expect(text).not.toContain('api_key=');
+    expect(text).not.toContain('Far turn outside the requested neighbor window');
   });
 });


### PR DESCRIPTION
## Summary
- Adds a detailed MemPalace architecture/adoption analysis for CML, linked from the architecture comparison index.
- Implements an opt-in MemPalace-inspired source-neighbor expansion for `mem-source-ref`.
- Documents the new MCP parameters in README and tool schema.

## MemPalace takeaways applied
- MemPalace keeps raw/conversation memories separate from structured palace abstractions and lets agents expand from a hit to nearby context.
- CML already has progressive disclosure, project-scoped retrieval, graph/facet/perspective lanes, and safe source references.
- This PR ports the lowest-risk high-value pattern: bounded neighbor expansion around a cited source event, without changing default privacy behavior.

## Implementation
- `includeNeighbors: true` enables source-local neighbor context.
- `neighborWindow` is bounded to `0..5` and defaults to `1` only when neighbor expansion is explicitly enabled.
- Same-session history is cached per tool call for multiple IDs.
- Neighbor previews are bounded and pass through the existing redaction path.
- Tests cover opt-in behavior, window defaults/disable/clamp, same-timestamp direction labels, caching, and secret redaction.

## Validation
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npx vitest run tests/extensions/mcp-context-tools.test.ts` (40 tests)
- [x] `npx vitest run` (125 files / 687 tests)
- [x] `git diff --check`
- [x] staged and branch diff credential-value scans: 0 findings
- [x] independent review: PASS

## Note
- `npm run lint` is not currently executable in this checkout because `eslint` is not installed/declared for the repo; no lint result is available from that script.
