### PR TITLE
[verified] feat: add Packet A architecture guard

### DIFF
--- a/docs/TARGET_ARCHITECTURE_AND_FOLDER_STRUCTURE.md
+++ b/docs/TARGET_ARCHITECTURE_AND_FOLDER_STRUCTURE.md
@@ -25,6 +25,10 @@
 
 ## 2. 목표 구조 개요
 
+메모리 계층과 source-of-truth 계약은 별도 manifest에서 관리한다:
+[`docs/architecture/memory-layer-manifest.md`](architecture/memory-layer-manifest.md).
+이 문서의 폴더 구조 제안은 그 계약을 따른다. 특히 SQLite event store가 raw events와 governance records의 authoritative store이고, markdown/vector/shared/endless/Mongo-style layer는 projection, acceleration, extension, replication 역할이다.
+
 ```text
 src/
   core/

--- a/docs/architecture/comparison-index.md
+++ b/docs/architecture/comparison-index.md
@@ -20,6 +20,7 @@ This index gathers the comparison/architecture notes used to guide the claude-me
 - [Architecture Comparison And Recommendations](../../docs/ARCHITECTURE_COMPARISON_AND_RECOMMENDATIONS.md)
 - [Mcp Memory Service Comparative Review](../../docs/MCP_MEMORY_SERVICE_COMPARATIVE_REVIEW.md)
 - [MemPalace Targeted Improvement Plan](mempalace-targeted-improvement-plan.md)
+- [Memory Layer Manifest](memory-layer-manifest.md)
 - [Memsearch Project Structure Analysis](../../docs/MEMSEARCH_PROJECT_STRUCTURE_ANALYSIS.md)
 - [Memu Adoption](../../docs/MEMU_ADOPTION.md)
 - [Project Structure Analysis](../../docs/PROJECT_STRUCTURE_ANALYSIS.md)

--- a/docs/architecture/memory-layer-manifest.md
+++ b/docs/architecture/memory-layer-manifest.md
@@ -1,0 +1,151 @@
+# CML Memory Layer Manifest
+
+This manifest is the source-of-truth contract for how `claude-memory-layer` talks about its memory layers during the thin-core refactor. It makes the current stack legible without requiring premature table or API renames.
+
+## Source-of-truth contract
+
+1. SQLite event store is authoritative for raw events and governance records.
+   - Raw conversation/tool/import events live in `events` and related session metadata.
+   - Governance/audit state for memory operations lives in SQLite tables such as `memory_governance_audit`, `memory_actions`, `memory_checkpoints`, and related operation projections.
+   - If a derived layer disagrees with SQLite, SQLite wins.
+2. Markdown mirror is a human-readable projection, not independent truth.
+   - Journal/export files may help humans inspect continuity, but they are rendered from stored state and should not be treated as a second canonical database.
+3. LanceDB/vector rows are derived and rebuildable.
+   - Vector indexes accelerate retrieval. They should be rebuildable from SQLite-backed events, entries, summaries, and outbox jobs.
+   - `embedding_outbox` and `vector_outbox` are durable coordination queues for rebuilding or retrying derived vectors; they are not the semantic source of the underlying memory.
+4. Shared/endless/Mongo-style stores are extension and replication layers.
+   - Shared memory, endless/continuity working sets, consolidated memories, and Mongo sync may replicate, cache, or promote memory for product workflows.
+   - They must not silently become canonical sources for raw private events or governance decisions.
+5. MCP tools must disclose which layer they query or mutate.
+   - Read tools should name whether they are reading raw events, derived projections, retrieval traces, vector-backed search results, or extension replicas.
+   - State-changing tools should name the SQLite projection/audit records they mutate and should retain bounded evidence references rather than raw private content.
+
+## Layer map
+
+| Layer | Role | Canonical? | Rebuildable? | Current implementation anchors |
+| --- | --- | --- | --- | --- |
+| L0 raw event store | Append-only event/session substrate and source references. | Yes for raw events. | No; preserve, do not regenerate from projections. | `events`, `sessions`, `event_dedup`; `src/core/sqlite-event-store.ts`; `src/core/engine/memory-ingest-service.ts` |
+| L1 extracted/governed units | Structured memory units and governance projections derived from or attached to L0 evidence. | Authoritative for explicit governed operations; derived for extracted facts. | Usually rebuildable from L0 plus governance audit events. | `entries`, `entities`, `entity_aliases`, `edges`, `insights`, `memory_facets`, `memory_lessons`, `memory_actions`, `memory_action_edges`, `memory_checkpoints`, `memory_retention_scores`, `memory_governance_audit`; `src/core/operations/*` |
+| L2 continuity and perspective | Human/agent continuity views: summaries, actor cards, perspective observations, working sets, consolidated memories/rules. | Authoritative only for explicit governed perspective/card writes; otherwise derived. | Partly; actor cards and manual observations preserve governed writes, summaries/working sets can be recomputed. | `sessions.summary`, `actor_cards`, `perspective_observations`, `memory_actors`, `session_actors`, `working_set`, `consolidated_memories`, `continuity_log`, `consolidated_rules` |
+| L3 retrieval and disclosure | Query-time search, context-pack assembly, source drill-down, helpfulness, and trace telemetry. | No; it explains retrieval behavior over lower layers. | Yes, except feedback/audit observations that are explicit governance records. | `retrieval_traces`, `memory_helpfulness`; `src/core/retriever.ts`; `src/core/engine/retrieval-orchestrator.ts`; `src/core/engine/retrieval-disclosure-service.ts`; `src/extensions/mcp/handlers.ts` |
+| L4 acceleration and outbox | Embedding/vector acceleration and rebuild coordination. | No for vectors; outboxes are durable operational queues. | Yes for vector rows; outbox state is replay/retry coordination. | `embedding_outbox`, `vector_outbox`; `src/core/vector-store.ts`; `src/core/vector-outbox.ts`; `src/core/vector-worker.ts`; `src/extensions/vector/*` |
+| L5 extension/replication surfaces | Shared memory, endless/continuity modes, Mongo sync, app/API/MCP surfaces. | No unless a tool explicitly writes governed SQLite records. | Extension-dependent; replicas must be recoverable or resyncable from canonical SQLite plus declared external contracts. | `src/extensions/shared-memory/*`; `src/extensions/endless-memory/*`; `src/core/shared-event-store.ts`; `src/core/shared-vector-store.ts`; `src/core/mongo-sync-worker.ts`; `src/apps/cli/mongo-sync-command.ts`; `src/extensions/mcp/*` |
+
+## Exposed memory families
+
+### Events
+
+- Tables/records: `events`, `sessions`, `event_dedup`.
+- Layer: L0.
+- Contract: raw user/assistant/tool/import/session-summary events are canonical in SQLite. Source refs should point back to event ids or bounded source-reference handles instead of exposing raw transcript paths or private content.
+- MCP/API disclosure: `mem-search`, `mem-timeline`, `mem-details`, `mem-stats`, `mem-project-timeline`, and `mem-source-ref` should be clear when they are reading event rows or event-derived previews.
+
+### Entries, entities, and edges
+
+- Tables/records: `entries`, `entities`, `entity_aliases`, `edges`, `insights`.
+- Layer: L1.
+- Contract: structured units and graph relationships are extracted or governed projections over L0 evidence. Their ids may be used as stable handles, but raw evidence remains in L0.
+- Rebuild rule: extraction logic may rebuild or supersede these records; never treat vector hits or markdown output as the canonical entity graph.
+- MCP/API disclosure: `mem-graph-query` should disclose that it queries bounded entity/edge projections and returns sanitized graph paths.
+
+### Facets
+
+- Tables/records: `memory_facets`.
+- Layer: L1.
+- Contract: facets are scoped tags on events, entities, edges, consolidated memories, lessons, or actions. Manual/governed facet writes are authoritative as governance records; automated facets are rebuildable projections with confidence and evidence pointers.
+- MCP/API disclosure: `mem-facet-query` reads facet projections. `mem-facet-tag` mutates `memory_facets` and should audit actor, target, dimension, value, confidence, and bounded source event ids.
+
+### Lessons
+
+- Tables/records: `memory_lessons`.
+- Layer: L1.
+- Contract: lessons are procedural/runbook candidates derived from successful workflows or explicitly curated. They are not raw transcript content.
+- Rebuild rule: automated lesson mining can be rerun, but manual skill-candidate decisions should remain governed writes.
+- MCP/API disclosure: `mem-lesson-list` reads compact lesson projections and should avoid returning raw private sources.
+
+### Actions
+
+- Tables/records: `memory_actions`, `memory_action_edges`, `memory_leases`.
+- Layer: L1.
+- Contract: actions are project-scoped execution-frontier records. Status changes are governed operational writes, not inferred truth from chat snippets.
+- MCP/API disclosure: `mem-action-list`, `mem-action-update`, and `mem-frontier` should state that they query or mutate action/frontier projections in SQLite and include audit metadata for state changes.
+
+### Checkpoints
+
+- Tables/records: `memory_checkpoints`.
+- Layer: L1.
+- Contract: checkpoints are resumable operation snapshots linked to actions or sessions. They may include bounded state, but should avoid secrets, raw transcript payloads, and private local paths in user-facing output.
+- MCP/API disclosure: `mem-checkpoint-create` mutates checkpoint projections with audit context. `mem-checkpoint-list` reads compact checkpoint metadata.
+
+### Actor cards
+
+- Tables/records: `memory_actors`, `session_actors`, `actor_cards`.
+- Layer: L2.
+- Contract: actor cards are compact observer-to-observed perspective summaries. They are governed perspective records, not raw conversation mirrors.
+- Rebuild rule: an automatic maintenance job may suggest updates, but replacing card entries is a state-changing write that should be audited and evidence-bounded.
+- MCP/API disclosure: `mem-actor-list`, `mem-actor-card-get`, and `mem-actor-card-upsert` should distinguish actor identity metadata from actor-card content and should identify card upsert as a SQLite/governance mutation.
+
+### Perspective observations
+
+- Tables/records: `perspective_observations`, `perspective_observations_fts`.
+- Layer: L2.
+- Contract: observations are observer-to-observed claims with level, confidence, and evidence references. Soft deletion is the exposed deletion model; hard deletion is not part of normal MCP operation tooling.
+- Rebuild rule: derived observations can be regenerated from evidence and policy, but explicit/manual observations remain governed writes.
+- MCP/API disclosure: `mem-perspective-query`, `mem-perspective-context`, `mem-perspective-observation-create`, and `mem-perspective-observation-delete` should disclose that they query/mutate perspective SQLite projections and FTS search indexes, not raw transcript stores.
+
+### Summaries and context packs
+
+- Tables/records: `sessions.summary`, `insights`, `consolidated_memories`, `consolidated_rules`, plus rendered context-pack output.
+- Layer: L2 for stored continuity summaries; L3 for assembled context-pack output.
+- Contract: summaries and context packs are compressed projections over L0/L1/L2 data. They improve continuity and token efficiency, but are not independent truth.
+- Rebuild rule: summaries/context packs can be refreshed when source events or compression policy changes. If a summary conflicts with source refs, source refs and L0 evidence win.
+- MCP/API disclosure: `mem-context-pack` and `mem-project-timeline` should disclose relevant source lanes, compression/trimming, refresh behavior, and whether they imported/processed fresh local history before retrieval.
+
+### Retrieval traces and source refs
+
+- Tables/records: `retrieval_traces`, `memory_helpfulness`, source-ref/citation handles.
+- Layer: L3.
+- Contract: retrieval traces explain query planning, candidate generation, selected events, fallback behavior, and confidence. Source refs resolve ids into bounded, privacy-filtered previews; they are evidence pointers, not unbounded transcript disclosure.
+- Rebuild rule: traces are operational telemetry and should not be replayed as memory content. They may be retained or audited separately from canonical event storage.
+- MCP/API disclosure: `mem-source-ref` should prefer redacted previews and safe metadata. `mem-details` should be used only when full content is intentionally requested and privacy policy permits it.
+
+### Vectors and vector outbox
+
+- Tables/records: LanceDB/vector rows, `embedding_outbox`, `vector_outbox`.
+- Layer: L4.
+- Contract: vector rows are derived accelerators. The durable source for what should be embedded is SQLite-backed event/entry/summary state plus outbox coordination.
+- Rebuild rule: vector stores can be dropped and rebuilt from canonical rows and outbox jobs. Failed/stuck vector jobs should be recovered by outbox maintenance, not by treating stale vectors as truth.
+- MCP/API disclosure: search tools using semantic/vector lanes should disclose that vector candidates are derived and selected against lower-layer source refs.
+
+### Shared, endless, and Mongo-style extension layers
+
+- Tables/records: shared stores/vector stores, `working_set`, `consolidated_memories`, `continuity_log`, `consolidated_rules`, Mongo sync positions/replicas.
+- Layer: L5, with some continuity tables also surfaced as L2 projections.
+- Contract: these layers are extension or replication surfaces. They may promote memories, maintain active working sets, provide cross-project/shared retrieval, or replicate SQLite events into another backend; they do not replace SQLite as the authoritative event/governance store.
+- Rebuild/resync rule: extension layers should define whether they are rebuildable, resyncable, or manually governed. Packet B/C/D/E work should turn those implicit rules into explicit ports, conformance tests, and recovery jobs.
+- MCP/API disclosure: any MCP tool or CLI command that reads shared/endless/Mongo-style data should label that lane separately from project-local canonical SQLite data.
+
+## MCP disclosure checklist
+
+Every new or refactored MCP tool should answer these questions in its schema, result envelope, or docs:
+
+1. Which memory family does the tool query or mutate?
+2. Which layer is involved: L0 raw events, L1 projections/governance, L2 continuity/perspective, L3 retrieval/disclosure, L4 vector acceleration, or L5 extension/replication?
+3. Is the returned content canonical, derived, rebuilt on demand, or a replica?
+4. For mutations, which SQLite table/projection is changed and what audit/evidence fields are recorded?
+5. For reads, are source refs bounded and privacy-filtered? If compression/trimming happened, is that disclosed?
+6. If a vector/shared/endless/Mongo lane contributed results, is that lane labeled separately from canonical SQLite evidence?
+
+## Packet work implications
+
+- Packet B source adapter work should make source identity, privacy class, transformations, incremental ingest, and evidence handles explicit before adding more import sources.
+- Packet C retrieval work should keep context-pack/retrieval output anchored to source refs and trace records, not to markdown mirrors or vector rows.
+- Packet D vector/outbox work should preserve the rule that vectors are rebuildable accelerators and outboxes are operational coordination.
+- Packet E MCP/API work should enforce the disclosure checklist above and prevent new tools from hiding which layer they touch.
+
+## Non-goals
+
+- Do not rename existing SQLite tables just to match this manifest.
+- Do not make canonical storage pluggable before the thin-core boundary is enforceable.
+- Do not expose transcript database paths, credentials, raw private content, or hidden local storage details in architecture docs or MCP result envelopes.
+- Do not treat markdown mirrors, vector indexes, shared memory replicas, endless working sets, or Mongo replicas as independent truth.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:coverage": "vitest --coverage",
     "lint": "eslint src/**/*.ts",
     "typecheck": "tsc --noEmit",
+    "check:architecture": "node scripts/check-import-boundaries.mjs",
     "ops:sync-gap:report": "node scripts/report-sync-gap.js",
     "ops:sync-gap:fix": "node scripts/fix-sync-gap.js",
     "ops:sync-gap:heal": "bash scripts/sync-gap-auto-heal.sh",

--- a/scripts/check-import-boundaries.mjs
+++ b/scripts/check-import-boundaries.mjs
@@ -1,0 +1,332 @@
+#!/usr/bin/env node
+import { constants as fsConstants } from 'node:fs';
+import { access, readdir, readFile } from 'node:fs/promises';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+const DEFAULT_BASELINE = path.join('scripts', 'import-boundary-baseline.json');
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
+const CORE_FORBIDDEN_LAYERS = [
+  'src/extensions',
+  'src/adapters',
+  'src/apps',
+  'src/services'
+];
+
+class CliError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'CliError';
+  }
+}
+
+export async function scanImportBoundaries(options = {}) {
+  const rootDir = path.resolve(options.rootDir ?? process.cwd());
+  const baselinePath = path.resolve(rootDir, options.baselinePath ?? DEFAULT_BASELINE);
+  const baseline = await loadBaseline(baselinePath, { required: options.baselinePath !== undefined, rootDir });
+  const files = await collectSourceFiles(path.join(rootDir, 'src'), rootDir);
+  const baselineByKey = new Map(baseline.entries.map((entry) => [baselineKey(entry), entry]));
+  const usedBaselineKeys = new Set();
+  const violations = [];
+
+  for (const fileRel of files) {
+    const fileAbs = path.join(rootDir, fileRel);
+    const source = await readFile(fileAbs, 'utf8');
+    const imports = extractStaticImports(source, fileRel);
+    for (const importRef of imports) {
+      const targetRel = resolveSourceSpecifier(rootDir, fileRel, importRef.specifier);
+      if (!targetRel) continue;
+      const rule = classifyBoundaryRule(fileRel, targetRel);
+      if (!rule) continue;
+
+      const violation = {
+        rule,
+        from: fileRel,
+        to: targetRel,
+        line: lineNumberForIndex(source, importRef.index),
+        specifier: importRef.specifier,
+        kind: importRef.kind
+      };
+      const key = baselineKey(violation);
+      if (baselineByKey.has(key)) {
+        usedBaselineKeys.add(key);
+      } else {
+        violations.push(violation);
+      }
+    }
+  }
+
+  const staleBaselineEntries = baseline.entries.filter((entry) => !usedBaselineKeys.has(baselineKey(entry)));
+  return {
+    ok: violations.length === 0 && staleBaselineEntries.length === 0,
+    rootDir,
+    scannedFiles: files.length,
+    violations,
+    baselineEntries: baseline.entries,
+    activeBaselineEntries: baseline.entries.filter((entry) => usedBaselineKeys.has(baselineKey(entry))),
+    staleBaselineEntries
+  };
+}
+
+export async function loadBaseline(baselinePath, { required = false, rootDir = process.cwd() } = {}) {
+  const exists = await fileExists(baselinePath);
+  if (!exists) {
+    if (required) throw new CliError(`Baseline file not found: ${toRepoRelative(rootDir, baselinePath)}`);
+    return { version: 1, entries: [] };
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(await readFile(baselinePath, 'utf8'));
+  } catch (error) {
+    throw new CliError(`Unable to parse baseline JSON: ${toRepoRelative(rootDir, baselinePath)}`);
+  }
+
+  if (!parsed || parsed.version !== 1 || !Array.isArray(parsed.entries)) {
+    throw new CliError('Baseline must be a JSON object with version: 1 and entries: []');
+  }
+
+  const entries = parsed.entries.map((entry, index) => normalizeBaselineEntry(entry, index));
+  return { version: 1, entries };
+}
+
+function normalizeBaselineEntry(entry, index) {
+  if (!entry || typeof entry !== 'object') {
+    throw new CliError(`Baseline entry ${index} must be an object`);
+  }
+  const rule = normalizeRel(entry.rule ?? '');
+  const from = normalizeRel(entry.from ?? '');
+  const to = normalizeRel(entry.to ?? '');
+  const reason = typeof entry.reason === 'string' ? entry.reason.trim() : '';
+  if (!rule || !from || !to) {
+    throw new CliError(`Baseline entry ${index} must include rule, from, and to`);
+  }
+  if (reason.length < 20) {
+    throw new CliError(`Baseline entry ${index} must include a documented removal reason`);
+  }
+  return { rule, from, to, reason };
+}
+
+async function collectSourceFiles(startDir, rootDir) {
+  if (!(await fileExists(startDir))) return [];
+  const results = [];
+  async function visit(dirAbs) {
+    const entries = await readdir(dirAbs, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name.startsWith('.')) continue;
+      const abs = path.join(dirAbs, entry.name);
+      if (entry.isDirectory()) {
+        await visit(abs);
+      } else if (entry.isFile() && isSourceFile(entry.name)) {
+        results.push(toRepoRelative(rootDir, abs));
+      }
+    }
+  }
+  await visit(startDir);
+  return results.sort();
+}
+
+function isSourceFile(fileName) {
+  if (fileName.endsWith('.d.ts')) return false;
+  return SOURCE_EXTENSIONS.has(path.extname(fileName));
+}
+
+export function extractStaticImports(source, fileName = 'source.ts') {
+  const refs = [];
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    source,
+    ts.ScriptTarget.Latest,
+    false,
+    scriptKindForFile(fileName)
+  );
+
+  function visit(node) {
+    if (ts.isImportDeclaration(node) && hasStringModuleSpecifier(node)) {
+      refs.push({
+        kind: 'import',
+        specifier: node.moduleSpecifier.text,
+        index: node.getStart(sourceFile)
+      });
+    } else if (ts.isExportDeclaration(node) && hasStringModuleSpecifier(node)) {
+      refs.push({
+        kind: 'export',
+        specifier: node.moduleSpecifier.text,
+        index: node.getStart(sourceFile)
+      });
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return refs.sort((a, b) => a.index - b.index || a.specifier.localeCompare(b.specifier));
+}
+
+function hasStringModuleSpecifier(node) {
+  return node.moduleSpecifier && typeof node.moduleSpecifier.text === 'string';
+}
+
+function scriptKindForFile(fileName) {
+  const ext = path.extname(fileName).toLowerCase();
+  if (ext === '.tsx') return ts.ScriptKind.TSX;
+  if (ext === '.jsx') return ts.ScriptKind.JSX;
+  if (ext === '.js' || ext === '.mjs' || ext === '.cjs') return ts.ScriptKind.JS;
+  return ts.ScriptKind.TS;
+}
+
+function resolveSourceSpecifier(rootDir, importerRel, specifier) {
+  if (!specifier || specifier.startsWith('node:')) return null;
+  let resolvedAbs;
+  if (specifier.startsWith('.')) {
+    resolvedAbs = path.resolve(rootDir, path.dirname(importerRel), specifier);
+  } else if (specifier.startsWith('/')) {
+    resolvedAbs = path.resolve(rootDir, `.${specifier}`);
+  } else if (specifier === 'src' || specifier.startsWith('src/')) {
+    resolvedAbs = path.resolve(rootDir, specifier);
+  } else {
+    return null;
+  }
+  const rel = toRepoRelative(rootDir, resolvedAbs);
+  if (rel.startsWith('../') || rel === '..') return null;
+  return rel;
+}
+
+function classifyBoundaryRule(fromRel, toRel) {
+  if (fromRel.startsWith('src/core/') && CORE_FORBIDDEN_LAYERS.some((root) => isWithinRel(toRel, root))) {
+    return 'core-no-forbidden-imports';
+  }
+  if (fromRel.startsWith('src/extensions/') && isMemoryServiceFacade(toRel)) {
+    return 'extensions-no-memory-service';
+  }
+  return null;
+}
+
+function isWithinRel(value, root) {
+  return value === root || value.startsWith(`${root}/`);
+}
+
+function isMemoryServiceFacade(toRel) {
+  return toRel === 'src/services/memory-service'
+    || toRel === 'src/services/memory-service.js'
+    || toRel === 'src/services/memory-service.ts';
+}
+
+function baselineKey(entry) {
+  return `${entry.rule}\u0000${normalizeRel(entry.from)}\u0000${normalizeRel(entry.to)}`;
+}
+
+function lineNumberForIndex(source, index) {
+  return source.slice(0, index).split('\n').length;
+}
+
+function formatReport(result) {
+  if (result.ok) {
+    return [
+      'Import boundary check passed.',
+      `Scanned files: ${result.scannedFiles}`,
+      `Baseline entries still active: ${result.activeBaselineEntries.length}`,
+      ''
+    ].join('\n');
+  }
+
+  const lines = ['Import boundary check failed.'];
+  if (result.violations.length > 0) {
+    lines.push('', 'New or unlisted violations:');
+    for (const violation of result.violations) {
+      lines.push(`- [${violation.rule}] ${violation.from} -> ${violation.to} (line ${violation.line}; ${violation.kind} '${violation.specifier}')`);
+    }
+  }
+  if (result.staleBaselineEntries.length > 0) {
+    lines.push('', 'Stale baseline entries no longer observed; remove them from scripts/import-boundary-baseline.json:');
+    for (const entry of result.staleBaselineEntries) {
+      lines.push(`- [${entry.rule}] ${entry.from} -> ${entry.to}`);
+    }
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+function parseArgs(argv) {
+  const options = { rootDir: process.cwd(), baselinePath: undefined };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--root') {
+      options.rootDir = readOptionValue(argv, ++index, arg);
+    } else if (arg === '--baseline') {
+      options.baselinePath = readOptionValue(argv, ++index, arg);
+    } else if (arg === '--help' || arg === '-h') {
+      options.help = true;
+    } else {
+      throw new CliError(`Unknown option: ${arg}`);
+    }
+  }
+  return options;
+}
+
+function readOptionValue(argv, index, optionName) {
+  const value = argv[index];
+  if (value === undefined || value.startsWith('--')) {
+    throw new CliError(`Missing value for ${optionName}`);
+  }
+  return value;
+}
+
+function usage() {
+  return [
+    'Usage: node scripts/check-import-boundaries.mjs [--root <repo>] [--baseline <json>]',
+    '',
+    'Checks Packet A architecture boundaries:',
+    '- src/core/** must not import src/extensions/**, src/adapters/**, src/apps/**, or src/services/**.',
+    '- src/extensions/** must not import the legacy src/services/memory-service facade.',
+    '',
+    'Known legacy debt must be documented narrowly in scripts/import-boundary-baseline.json.'
+  ].join('\n');
+}
+
+async function fileExists(filePath) {
+  try {
+    await access(filePath, fsConstants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function toRepoRelative(rootDir, absPath) {
+  return normalizeRel(path.relative(rootDir, absPath));
+}
+
+function normalizeRel(value) {
+  return String(value).replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
+async function main(argv) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    process.stdout.write(`${usage()}\n`);
+    return;
+  }
+  const result = await scanImportBoundaries(options);
+  const report = formatReport(result);
+  if (result.ok) {
+    process.stdout.write(report);
+  } else {
+    process.stderr.write(report);
+    process.exitCode = 1;
+  }
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  main(process.argv.slice(2)).catch((error) => {
+    if (error instanceof CliError) {
+      process.stderr.write(`${error.message}\n`);
+    } else if (error instanceof Error) {
+      process.stderr.write(`${error.stack ?? error.message}\n`);
+    } else {
+      process.stderr.write(`${String(error)}\n`);
+    }
+    process.exitCode = 1;
+  });
+}

--- a/scripts/import-boundary-baseline.json
+++ b/scripts/import-boundary-baseline.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "entries": [
+    {
+      "rule": "core-no-forbidden-imports",
+      "from": "src/core/embedder.ts",
+      "to": "src/extensions/vector/index.js",
+      "reason": "Existing P0.1 Packet A import debt documented in docs/architecture/mempalace-targeted-improvement-plan.md; remove during Packet C boundary inversion."
+    },
+    {
+      "rule": "core-no-forbidden-imports",
+      "from": "src/core/engine/endless-memory-services.ts",
+      "to": "src/extensions/endless-memory/index.js",
+      "reason": "Existing P0.1 Packet A import debt documented in docs/architecture/mempalace-targeted-improvement-plan.md; remove during Packet C boundary inversion."
+    },
+    {
+      "rule": "core-no-forbidden-imports",
+      "from": "src/core/engine/shared-memory-services.ts",
+      "to": "src/extensions/shared-memory/index.js",
+      "reason": "Existing P0.1 Packet A import debt documented in docs/architecture/mempalace-targeted-improvement-plan.md; remove during Packet C boundary inversion."
+    },
+    {
+      "rule": "extensions-no-memory-service",
+      "from": "src/extensions/mcp/handlers.ts",
+      "to": "src/services/memory-service.js",
+      "reason": "Existing P0.1 MCP split import debt documented in docs/architecture/mempalace-targeted-improvement-plan.md; remove during Packet C/P1 MCP handler modularization."
+    }
+  ]
+}

--- a/specs/thin-core-refactor/context.md
+++ b/specs/thin-core-refactor/context.md
@@ -203,6 +203,9 @@ session/project continuity는 중요하지만 raw event와 같은 층에 두면 
 - **LanceDB** = disposable acceleration layer
 - **shared/Mongo** = replication/extension
 
+이 source-of-truth 계약과 현재 노출된 memory family 목록은
+[`docs/architecture/memory-layer-manifest.md`](../../docs/architecture/memory-layer-manifest.md)에 정리한다. Thin-core 작업은 이 manifest를 기준으로 MCP tool이 어떤 layer를 query/mutate하는지 드러내야 한다.
+
 이 정리가 있으면:
 - 운영 판단이 쉬워지고
 - 장애 복구가 쉬워지고

--- a/tests/scripts/check-import-boundaries.test.ts
+++ b/tests/scripts/check-import-boundaries.test.ts
@@ -1,0 +1,174 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = process.cwd();
+const checkerPath = path.join(repoRoot, 'scripts', 'check-import-boundaries.mjs');
+
+function makeFixtureRepo(name: string): string {
+  const root = mkdtempSync(path.join(tmpdir(), `cml-import-boundary-${name}-`));
+  mkdirSync(path.join(root, 'src', 'core'), { recursive: true });
+  mkdirSync(path.join(root, 'src', 'extensions', 'vector'), { recursive: true });
+  mkdirSync(path.join(root, 'src', 'adapters', 'claude'), { recursive: true });
+  mkdirSync(path.join(root, 'src', 'apps', 'cli'), { recursive: true });
+  mkdirSync(path.join(root, 'src', 'services'), { recursive: true });
+  mkdirSync(path.join(root, 'src', 'extensions', 'mcp'), { recursive: true });
+  writeFileSync(path.join(root, 'src', 'extensions', 'vector', 'index.ts'), 'export const vector = 1;\n', 'utf8');
+  writeFileSync(path.join(root, 'src', 'adapters', 'claude', 'index.ts'), 'export const adapter = 1;\n', 'utf8');
+  writeFileSync(path.join(root, 'src', 'apps', 'cli', 'index.ts'), 'export const app = 1;\n', 'utf8');
+  writeFileSync(path.join(root, 'src', 'services', 'memory-service.ts'), 'export const memoryService = 1;\n', 'utf8');
+  return root;
+}
+
+function runChecker(root: string, extraArgs: string[] = []) {
+  return spawnSync('node', [checkerPath, '--root', root, ...extraArgs], {
+    cwd: repoRoot,
+    encoding: 'utf8'
+  });
+}
+
+describe('check-import-boundaries architecture guard', () => {
+  it('fails on new core imports and re-exports from extension, adapter, app, or service layers', () => {
+    const root = makeFixtureRepo('core-forbidden');
+    writeFileSync(path.join(root, 'src', 'core', 'violates-extension.ts'), "import { vector } from '../extensions/vector/index.js';\nvoid vector;\n", 'utf8');
+    writeFileSync(path.join(root, 'src', 'core', 'violates-adapter.ts'), "export { adapter } from '../adapters/claude/index.js';\n", 'utf8');
+    writeFileSync(path.join(root, 'src', 'core', 'violates-app.ts'), "export { app } from '../apps/cli/index.js';\n", 'utf8');
+    writeFileSync(path.join(root, 'src', 'core', 'violates-service.ts'), "import { memoryService } from '../services/memory-service.js';\nvoid memoryService;\n", 'utf8');
+
+    const result = runChecker(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Import boundary check failed');
+    expect(result.stderr).toContain('src/core/violates-extension.ts -> src/extensions/vector/index.js');
+    expect(result.stderr).toContain('src/core/violates-adapter.ts -> src/adapters/claude/index.js');
+    expect(result.stderr).toContain('src/core/violates-app.ts -> src/apps/cli/index.js');
+    expect(result.stderr).toContain('src/core/violates-service.ts -> src/services/memory-service.js');
+    expect(result.stderr).not.toContain(root);
+  });
+
+  it('allows only exact documented baseline entries and still fails on unlisted new violations', () => {
+    const root = makeFixtureRepo('baseline');
+    const baselinePath = path.join(root, 'import-boundary-baseline.json');
+    writeFileSync(path.join(root, 'src', 'core', 'existing-debt.ts'), "export { vector } from '../extensions/vector/index.js';\n", 'utf8');
+    writeFileSync(path.join(root, 'src', 'core', 'new-debt.ts'), "export { adapter } from '../adapters/claude/index.js';\n", 'utf8');
+    writeFileSync(baselinePath, `${JSON.stringify({
+      version: 1,
+      entries: [
+        {
+          rule: 'core-no-forbidden-imports',
+          from: 'src/core/existing-debt.ts',
+          to: 'src/extensions/vector/index.js',
+          reason: 'Existing Packet A fixture debt; remove during Packet C boundary inversion.'
+        }
+      ]
+    }, null, 2)}\n`, 'utf8');
+
+    const result = runChecker(root, ['--baseline', baselinePath]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('src/core/new-debt.ts -> src/adapters/claude/index.js');
+    expect(result.stderr).not.toContain('src/core/existing-debt.ts -> src/extensions/vector/index.js');
+  });
+
+  it('fails on forbidden layer barrel-root imports from core modules', () => {
+    const root = makeFixtureRepo('core-layer-roots');
+    writeFileSync(path.join(root, 'src', 'core', 'violates-extension-root.ts'), "import * as extensions from '../extensions';\nvoid extensions;\n", 'utf8');
+    writeFileSync(path.join(root, 'src', 'core', 'violates-app-root.ts'), "export * as apps from '../apps';\n", 'utf8');
+    writeFileSync(path.join(root, 'src', 'core', 'violates-service-root.ts'), "import * as services from '../services';\nvoid services;\n", 'utf8');
+
+    const result = runChecker(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('src/core/violates-extension-root.ts -> src/extensions');
+    expect(result.stderr).toContain('src/core/violates-app-root.ts -> src/apps');
+    expect(result.stderr).toContain('src/core/violates-service-root.ts -> src/services');
+    expect(result.stderr).not.toContain(root);
+  });
+
+  it('fails on namespace re-exports from forbidden layers', () => {
+    const root = makeFixtureRepo('namespace-export');
+    writeFileSync(path.join(root, 'src', 'core', 'violates-namespace-export.ts'), "export * as vector from '../extensions/vector/index.js';\n", 'utf8');
+
+    const result = runChecker(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('src/core/violates-namespace-export.ts -> src/extensions/vector/index.js');
+    expect(result.stderr).not.toContain(root);
+  });
+
+  it('fails on forbidden layer root and barrel imports from core', () => {
+    const root = makeFixtureRepo('layer-roots');
+    writeFileSync(path.join(root, 'src', 'core', 'violates-extension-root.ts'), "import { vector } from '../extensions';\nvoid vector;\n", 'utf8');
+    writeFileSync(path.join(root, 'src', 'core', 'violates-adapter-root.ts'), "export * from '../adapters';\n", 'utf8');
+    writeFileSync(path.join(root, 'src', 'core', 'violates-app-root.ts'), "import { app } from 'src/apps';\nvoid app;\n", 'utf8');
+    writeFileSync(path.join(root, 'src', 'core', 'violates-service-root.ts'), "export { memoryService } from '../services';\n", 'utf8');
+
+    const result = runChecker(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('src/core/violates-extension-root.ts -> src/extensions');
+    expect(result.stderr).toContain('src/core/violates-adapter-root.ts -> src/adapters');
+    expect(result.stderr).toContain('src/core/violates-app-root.ts -> src/apps');
+    expect(result.stderr).toContain('src/core/violates-service-root.ts -> src/services');
+    expect(result.stderr).not.toContain(root);
+  });
+
+  it('ignores import-looking text inside comments and string literals', () => {
+    const root = makeFixtureRepo('comments-and-strings');
+    writeFileSync(path.join(root, 'src', 'core', 'safe-comments.ts'), [
+      "// import { vector } from '../extensions/vector/index.js';",
+      "const example = \"export { adapter } from '../adapters/claude/index.js';\";",
+      "void example;",
+      ""
+    ].join('\n'), 'utf8');
+
+    const result = runChecker(root);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Import boundary check passed');
+    expect(result.stdout).not.toContain(root);
+    expect(result.stderr).toBe('');
+  });
+
+  it('fails when an extensions module imports the legacy MemoryService facade', () => {
+    const root = makeFixtureRepo('extensions-service');
+    writeFileSync(path.join(root, 'src', 'extensions', 'mcp', 'handlers.ts'), "import { MemoryService } from '../../services/memory-service.js';\nvoid MemoryService;\n", 'utf8');
+
+    const result = runChecker(root);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('[extensions-no-memory-service]');
+    expect(result.stderr).toContain('src/extensions/mcp/handlers.ts -> src/services/memory-service.js');
+    expect(result.stderr).not.toContain(root);
+  });
+
+  it('passes for allowed imports and reports active baseline counts without absolute paths', () => {
+    const root = makeFixtureRepo('passing');
+    const baselinePath = path.join(root, 'import-boundary-baseline.json');
+    writeFileSync(path.join(root, 'src', 'core', 'safe.ts'), "import { sibling } from './sibling.js';\nvoid sibling;\n", 'utf8');
+    writeFileSync(path.join(root, 'src', 'core', 'sibling.ts'), 'export const sibling = 1;\n', 'utf8');
+    writeFileSync(path.join(root, 'src', 'core', 'existing-debt.ts'), "export { vector } from '../extensions/vector/index.js';\n", 'utf8');
+    writeFileSync(baselinePath, `${JSON.stringify({
+      version: 1,
+      entries: [
+        {
+          rule: 'core-no-forbidden-imports',
+          from: 'src/core/existing-debt.ts',
+          to: 'src/extensions/vector/index.js',
+          reason: 'Existing Packet A fixture debt; remove during Packet C boundary inversion.'
+        }
+      ]
+    }, null, 2)}\n`, 'utf8');
+
+    const result = runChecker(root, ['--baseline', baselinePath]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Import boundary check passed');
+    expect(result.stdout).toContain('Baseline entries still active: 1');
+    expect(result.stdout).not.toContain(root);
+    expect(result.stderr).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `npm run check:architecture` with a TypeScript-AST import-boundary guard.
- Baseline current architectural debt explicitly so known Packet C cleanup items are documented while new violations fail closed.
- Add Packet A memory layer manifest documenting source-of-truth, projections, vector/retrieval layers, extension families, and MCP disclosure expectations.
- Link the manifest from architecture docs and thin-core context.

## Packet A scope
This PR focuses on enforceability before broader refactors:
- `src/core/**` must not import/re-export extension, adapter, app, or service layers.
- `src/extensions/**` must not import the legacy `src/services/memory-service` facade.
- Known active debt is allowed only when exactly listed in `scripts/import-boundary-baseline.json`.

## Validation
- [x] `npm run check:architecture`
- [x] `npx vitest run tests/scripts/check-import-boundaries.test.ts` (8 tests)
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test -- --run` (126 files / 695 tests)
- [x] `git diff --check`
- [x] staged/pre-push credential-value scans: 0 findings
- [x] independent final pre-commit review: passed

## Kanban
Board: `cml-mempalace-packet-a`
- T1 guard implementation recovered from stale worker and verified by operator.
- T2 manifest docs completed by worker.
- T3 integration validation recovered from stale worker, independent review blocker fixed, final review passed.
