### PR TITLE
Improve vector outbox health visibility

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,24 @@
+import tseslint from 'typescript-eslint';
+
+export default [
+  {
+    ignores: [
+      'dist/**',
+      '.claude-plugin/**',
+      'node_modules/**',
+      'coverage/**',
+      'memory/**'
+    ]
+  },
+  {
+    files: ['src/**/*.ts'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module'
+      }
+    },
+    rules: {}
+  }
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,10 @@
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20.11.0",
         "esbuild": "^0.28.0",
+        "eslint": "^9.39.4",
         "tsx": "^4.7.0",
         "typescript": "^5.4.0",
+        "typescript-eslint": "^8.62.0",
         "vitest": "^4.1.8"
       },
       "engines": {
@@ -513,6 +515,249 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
@@ -591,6 +836,72 @@
         "@img/sharp-win32-arm64": "0.34.5",
         "@img/sharp-win32-ia32": "0.34.5",
         "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@img/colour": {
@@ -1682,6 +1993,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.30",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
@@ -1714,6 +2032,236 @@
       "license": "MIT",
       "dependencies": {
         "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.0.tgz",
+      "integrity": "sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/type-utils": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.62.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.0.tgz",
+      "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
+      "integrity": "sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.62.0",
+        "@typescript-eslint/types": "^8.62.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.0.tgz",
+      "integrity": "sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
+      "integrity": "sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.0.tgz",
+      "integrity": "sha512-+g5O3j0w2ldzC86Pv6fvbO/xhAonbJFIdf/MKQ1d30gndlsVzUOE83ldfSE15Qrl9fhFjK6AovHs5Wpp6vx86w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+      "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.0.tgz",
+      "integrity": "sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.62.0",
+        "@typescript-eslint/tsconfig-utils": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
+      "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
+      "integrity": "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1888,6 +2436,29 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
@@ -1968,6 +2539,13 @@
         "arrow2csv": "bin/arrow2csv.cjs"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/array-back": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
@@ -1992,6 +2570,16 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -2095,6 +2683,19 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/bson": {
       "version": "6.10.4",
       "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
@@ -2164,6 +2765,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/chai": {
@@ -2304,6 +2915,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/content-disposition": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
@@ -2422,6 +3040,13 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -2653,13 +3278,238 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/estree-walker": {
@@ -2670,6 +3520,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/etag": {
@@ -2822,6 +3682,20 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -2854,6 +3728,19 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -2895,11 +3782,49 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/flatbuffers": {
       "version": "23.5.26",
       "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-23.5.26.tgz",
       "integrity": "sha512-vE+SI9vrJDwi1oETtTIFldC/o9GsVKRM+s6EL0nQgxXlYV1Vc4Tk30hj4xGICftInKQKj1F3up2n8UbIVobISQ==",
       "license": "SEE LICENSE IN LICENSE"
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/form-data": {
       "version": "4.0.6",
@@ -3027,6 +3952,19 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/global-agent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
@@ -3043,6 +3981,19 @@
       },
       "engines": {
         "node": ">=10.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globalthis": {
@@ -3214,6 +4165,43 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -3244,6 +4232,29 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -3265,6 +4276,29 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/json-bignum": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
@@ -3272,6 +4306,13 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -3285,12 +4326,43 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -3553,10 +4625,33 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/long": {
@@ -3656,6 +4751,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minimist": {
@@ -3815,6 +4926,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-abi": {
@@ -4031,6 +5149,69 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -4038,6 +5219,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-key": {
@@ -4189,6 +5380,16 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/protobufjs": {
@@ -4344,6 +5545,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/roarr": {
@@ -4901,6 +6112,19 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -4936,6 +6160,19 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/type-fest": {
@@ -5004,6 +6241,30 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typescript-eslint": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.0.tgz",
+      "integrity": "sha512-8QxXi+ZACKX0kaqO4gY8kn0RSD9gFfaHDWwjqtEN48aWCBkX4MJaufWN+c3BzlrXLOxfywDL8CaoqUwcRq4j4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.62.0",
+        "@typescript-eslint/parser": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
     "node_modules/typical": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
@@ -5026,6 +6287,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -5268,6 +6539,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wordwrapjs": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
@@ -5291,6 +6572,19 @@
       "optional": true,
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -93,8 +93,10 @@
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20.11.0",
     "esbuild": "^0.28.0",
+    "eslint": "^9.39.4",
     "tsx": "^4.7.0",
     "typescript": "^5.4.0",
+    "typescript-eslint": "^8.62.0",
     "vitest": "^4.1.8"
   }
 }

--- a/scripts/longmemeval-codex-judge.ts
+++ b/scripts/longmemeval-codex-judge.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env tsx
 import { spawn, type ChildProcess } from 'node:child_process';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { appendFile, mkdir, mkdtemp, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 
@@ -8,6 +9,9 @@ interface ParsedArgs {
   hypPath: string;
   refPath: string;
   outPath: string;
+  checkpointPath: string;
+  resume: boolean;
+  force: boolean;
 }
 
 interface HypothesisRow {
@@ -49,6 +53,7 @@ const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_TIMEOUT_MS = 600_000;
 const DEFAULT_SANDBOX = 'read-only';
 const ALLOWED_SANDBOXES = new Set(['read-only', 'workspace-write', 'danger-full-access']);
+const CHECKPOINT_VERSION = 1;
 
 void main(process.argv.slice(2)).catch((error) => {
   if (error instanceof CliHelp) {
@@ -69,50 +74,70 @@ void main(process.argv.slice(2)).catch((error) => {
 async function main(argv: string[]): Promise<void> {
   const options = parseArgs(argv);
   const timeoutMs = parsePositiveInteger(readEnv('LONGMEMEVAL_CODEX_TIMEOUT_MS'), DEFAULT_TIMEOUT_MS, 'LONGMEMEVAL_CODEX_TIMEOUT_MS', MAX_TIMEOUT_MS);
-  const hypotheses = parseHypotheses(await readFile(options.hypPath, 'utf8'), options.hypPath);
-  const references = parseReferences(await readFile(options.refPath, 'utf8'), options.refPath);
+  const hypRaw = await readFile(options.hypPath, 'utf8');
+  const refRaw = await readFile(options.refPath, 'utf8');
+  const runFingerprint = buildRunOptionsFingerprint(options, hypRaw, refRaw);
+  const hypotheses = parseHypotheses(hypRaw, options.hypPath);
+  const references = parseReferences(refRaw, options.refPath);
   assertUniqueIds(hypotheses, 'hypothesis');
   assertUniqueIds(references, 'reference');
   if (hypotheses.length === 0) {
     throw new CliError('Hypothesis file contains no rows to evaluate');
   }
   const qidToReference = new Map(references.map((reference) => [reference.question_id, reference]));
-  const categoryScores = new Map<string, number[]>();
-  for (const reference of references) {
-    categoryScores.set(reference.question_type, []);
+  for (const hypothesis of hypotheses) {
+    if (!qidToReference.has(hypothesis.question_id)) {
+      throw new CliError(`${hypothesis.question_id} is not in reference data`);
+    }
   }
 
-  const evaluated: EvaluatedRow[] = [];
+  const resumeCheckpoint = await prepareCheckpointedRun(options, hypotheses.length, runFingerprint);
+  const evaluatedById = options.resume
+    ? await readEvaluatedRowsByQuestionId(options.outPath, hypotheses)
+    : new Map<string, EvaluatedRow>();
+  if (options.resume && resumeCheckpoint) {
+    validateResumeOutputConsistency(resumeCheckpoint, hypotheses.length, evaluatedById.size);
+  }
+  await writeCheckpoint(options, 'judge_running', hypotheses.length, evaluatedById.size, runFingerprint);
+
   for (const hypothesis of hypotheses) {
+    if (evaluatedById.has(hypothesis.question_id)) continue;
     const reference = qidToReference.get(hypothesis.question_id);
     if (!reference) {
       throw new CliError(`${hypothesis.question_id} is not in reference data`);
     }
-    const prompt = getAnscheckPrompt(
-      reference.question_type,
-      reference.question,
-      reference.answer,
-      hypothesis.hypothesis,
-      hypothesis.question_id.includes('_abs')
-    );
-    const evalResponse = await runCodexPrompt(prompt, timeoutMs);
-    const label = parseJudgeLabel(evalResponse);
-    evaluated.push({
-      ...hypothesis,
-      autoeval_label: {
-        model: 'codex-cli',
-        label
-      }
-    });
-    const scores = categoryScores.get(reference.question_type) ?? [];
-    scores.push(label ? 1 : 0);
-    categoryScores.set(reference.question_type, scores);
+    try {
+      const prompt = getAnscheckPrompt(
+        reference.question_type,
+        reference.question,
+        reference.answer,
+        hypothesis.hypothesis,
+        hypothesis.question_id.includes('_abs')
+      );
+      const evalResponse = await runCodexPrompt(prompt, timeoutMs);
+      const label = parseJudgeLabel(evalResponse);
+      const evaluated: EvaluatedRow = {
+        ...hypothesis,
+        autoeval_label: {
+          model: 'codex-cli',
+          label
+        }
+      };
+      await appendJsonlRow(options.outPath, evaluated);
+      evaluatedById.set(hypothesis.question_id, evaluated);
+      await writeCheckpoint(options, 'judge_running', hypotheses.length, evaluatedById.size, runFingerprint);
+    } catch (error) {
+      await writeCheckpoint(options, 'judge_failed', hypotheses.length, evaluatedById.size, runFingerprint).catch(() => undefined);
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new CliError(`Codex judge failed for ${hypothesis.question_id}: ${detail}`);
+    }
   }
 
-  await writeTextFile(options.outPath, `${evaluated.map((entry) => JSON.stringify(entry)).join('\n')}\n`);
+  const evaluated = hypotheses.map((hypothesis) => evaluatedById.get(hypothesis.question_id)).filter((row): row is EvaluatedRow => row !== undefined);
   const allScores = evaluated.map((entry) => entry.autoeval_label.label ? 1 : 0);
+  await writeCheckpoint(options, 'completed', hypotheses.length, evaluated.length, runFingerprint);
   process.stdout.write(`Accuracy: ${round4(mean(allScores))}\n`);
-  for (const [category, scores] of [...categoryScores.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+  for (const [category, scores] of buildCategoryScores(references, evaluated).entries()) {
     if (scores.length === 0) continue;
     process.stdout.write(`\t${category}: ${round4(mean(scores))} (${scores.length})\n`);
   }
@@ -120,7 +145,7 @@ async function main(argv: string[]): Promise<void> {
 }
 
 function parseArgs(argv: string[]): ParsedArgs {
-  const parsed: ParsedArgs = { hypPath: '', refPath: '', outPath: '' };
+  const parsed: ParsedArgs = { hypPath: '', refPath: '', outPath: '', checkpointPath: '', resume: false, force: false };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === '--hyp' || arg === '--hyp-file') {
@@ -129,6 +154,12 @@ function parseArgs(argv: string[]): ParsedArgs {
       parsed.refPath = readOptionValue(argv, ++i, arg);
     } else if (arg === '--out') {
       parsed.outPath = readOptionValue(argv, ++i, arg);
+    } else if (arg === '--checkpoint') {
+      parsed.checkpointPath = readOptionValue(argv, ++i, arg);
+    } else if (arg === '--resume') {
+      parsed.resume = true;
+    } else if (arg === '--force') {
+      parsed.force = true;
     } else if (arg === '--help' || arg === '-h') {
       throw new CliHelp(usage());
     } else if (arg.startsWith('--')) {
@@ -147,7 +178,243 @@ function parseArgs(argv: string[]): ParsedArgs {
   if (!parsed.outPath) {
     parsed.outPath = `${parsed.hypPath}.eval-results-codex`;
   }
+  if (!parsed.checkpointPath) {
+    parsed.checkpointPath = `${parsed.outPath}.checkpoint.json`;
+  }
+  if (parsed.resume && parsed.force) {
+    throw new CliError('Cannot combine --resume and --force');
+  }
   return parsed;
+}
+
+type JudgeCheckpointStatus = 'judge_running' | 'judge_failed' | 'completed';
+
+interface JudgeCheckpoint {
+  version: number;
+  status?: unknown;
+  run_options?: unknown;
+  judge?: unknown;
+}
+
+async function prepareCheckpointedRun(options: ParsedArgs, total: number, runFingerprint: Record<string, unknown>): Promise<JudgeCheckpoint | undefined> {
+  assertSafeOutputPaths(options);
+  if (options.resume) {
+    return validateResumeCheckpoint(options, runFingerprint);
+  }
+  if (!options.force) {
+    if (await fileExists(options.outPath)) {
+      throw new CliError('Refusing to overwrite existing judge output; use --resume to continue or --force to restart.');
+    }
+    if (await fileExists(options.checkpointPath)) {
+      throw new CliError('Refusing to overwrite existing judge checkpoint; use --resume to continue or --force to restart.');
+    }
+  }
+  if (options.force) {
+    await Promise.all([
+      rm(options.outPath, { force: true }).catch(() => undefined),
+      rm(options.checkpointPath, { force: true }).catch(() => undefined)
+    ]);
+  }
+  await createEmptyOutputFile(options.outPath);
+  await writeCheckpoint(options, 'judge_running', total, 0, runFingerprint);
+  return undefined;
+}
+
+function assertSafeOutputPaths(options: ParsedArgs): void {
+  const inputPaths = new Set([path.resolve(options.hypPath), path.resolve(options.refPath)]);
+  const outPath = path.resolve(options.outPath);
+  const checkpointPath = path.resolve(options.checkpointPath);
+  if (inputPaths.has(outPath)) {
+    throw new CliError('Refusing to use input file as judge output');
+  }
+  if (inputPaths.has(checkpointPath)) {
+    throw new CliError('Refusing to use input file as checkpoint output');
+  }
+  if (outPath === checkpointPath) {
+    throw new CliError('Managed output path collision: --out and --checkpoint must be different');
+  }
+}
+
+async function validateResumeCheckpoint(options: ParsedArgs, runFingerprint: Record<string, unknown>): Promise<JudgeCheckpoint> {
+  if (!await fileExists(options.checkpointPath)) {
+    throw new CliError('Resume checkpoint is required; use --force to restart or choose a new --out path.');
+  }
+  const checkpoint = await readJsonFile<JudgeCheckpoint>(options.checkpointPath, 'checkpoint');
+  if (!isRecord(checkpoint)) {
+    throw new CliError('Resume checkpoint must be a JSON object');
+  }
+  if (checkpoint.version !== CHECKPOINT_VERSION) {
+    throw new CliError(`Unsupported resume checkpoint version: ${String(checkpoint.version)}`);
+  }
+  if (!isRecord(checkpoint.run_options)) {
+    throw new CliError('Resume checkpoint is missing run_options; use --force to restart');
+  }
+  const mismatches = collectObjectMismatches(checkpoint.run_options, runFingerprint, 'run_options');
+  if (mismatches.length > 0) {
+    throw new CliError(`Resume checkpoint does not match current options: ${mismatches.join(', ')}. Use matching options, a new --out path, or --force to restart.`);
+  }
+  return checkpoint;
+}
+
+function buildRunOptionsFingerprint(options: ParsedArgs, hypRaw: string, refRaw: string): Record<string, unknown> {
+  return {
+    hyp_path_hash: sha256(path.resolve(options.hypPath)),
+    ref_path_hash: sha256(path.resolve(options.refPath)),
+    out_path_hash: sha256(path.resolve(options.outPath)),
+    hyp_sha256: sha256(hypRaw),
+    ref_sha256: sha256(refRaw),
+    codex_model: readEnv('LONGMEMEVAL_CODEX_MODEL') ?? null,
+    codex_sandbox: readEnv('LONGMEMEVAL_CODEX_SANDBOX') ?? DEFAULT_SANDBOX
+  };
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function collectObjectMismatches(actual: Record<string, unknown>, expected: Record<string, unknown>, prefix: string): string[] {
+  const mismatches: string[] = [];
+  for (const key of Object.keys(expected).sort()) {
+    const left = actual[key];
+    const right = expected[key];
+    if (JSON.stringify(left) !== JSON.stringify(right)) {
+      mismatches.push(`${prefix}.${key}`);
+    }
+  }
+  return mismatches;
+}
+
+async function readEvaluatedRowsByQuestionId(filePath: string, expectedHypotheses: HypothesisRow[]): Promise<Map<string, EvaluatedRow>> {
+  const rowsById = new Map<string, EvaluatedRow>();
+  if (!await fileExists(filePath)) return rowsById;
+  const raw = await readFile(filePath, 'utf8');
+  if (!raw.trim()) return rowsById;
+  const parsed = parseJsonOrJsonl(raw, 'resume output');
+  for (const [index, entry] of parsed.entries()) {
+    if (!isRecord(entry)) {
+      throw new CliError(`Evaluated row ${index + 1} in resume output must be an object`);
+    }
+    const questionId = entry.question_id;
+    const hypothesis = entry.hypothesis;
+    const autoevalLabel = entry.autoeval_label;
+    if (typeof questionId !== 'string' || questionId.trim() === '') {
+      throw new CliError(`Evaluated row ${index + 1} requires non-empty string question_id`);
+    }
+    const expectedHypothesis = expectedHypotheses[index];
+    if (!expectedHypothesis) {
+      throw new CliError(`Unexpected extra evaluated row ${index + 1} in resumed output`);
+    }
+    if (questionId !== expectedHypothesis.question_id) {
+      throw new CliError(`Resume output row ${index + 1} does not match current hypothesis order`);
+    }
+    if (hypothesis !== expectedHypothesis.hypothesis) {
+      throw new CliError(`Resume output row ${index + 1} hypothesis does not match current hypotheses`);
+    }
+    if (rowsById.has(questionId)) {
+      throw new CliError(`Duplicate evaluated question_id in resumed output: ${questionId}`);
+    }
+    if (typeof hypothesis !== 'string') {
+      throw new CliError(`Evaluated row ${index + 1} requires string hypothesis`);
+    }
+    if (!isRecord(autoevalLabel) || typeof autoevalLabel.label !== 'boolean') {
+      throw new CliError(`Evaluated row ${index + 1} requires boolean autoeval_label.label`);
+    }
+    rowsById.set(questionId, { ...entry, question_id: questionId, hypothesis } as EvaluatedRow);
+  }
+  return rowsById;
+}
+
+function validateResumeOutputConsistency(checkpoint: JudgeCheckpoint, total: number, rowCount: number): void {
+  if (!isRecord(checkpoint.judge)) {
+    throw new CliError('Resume checkpoint is missing judge progress; use --force to restart');
+  }
+  const rawTotal = checkpoint.judge.total;
+  const rawCompleted = checkpoint.judge.completed;
+  if (!Number.isInteger(rawTotal) || !Number.isInteger(rawCompleted)) {
+    throw new CliError('Resume checkpoint has invalid judge progress; use --force to restart');
+  }
+  const checkpointTotal = rawTotal as number;
+  const checkpointCompleted = rawCompleted as number;
+  if (checkpointTotal !== total) {
+    throw new CliError('Resume checkpoint total does not match current hypothesis rows; use --force to restart');
+  }
+  if (checkpointCompleted > 0 && rowCount === 0) {
+    throw new CliError('Resume output is missing evaluated rows recorded by the checkpoint; use --force to restart');
+  }
+  if (rowCount < checkpointCompleted) {
+    throw new CliError('Resume output row count is behind checkpoint progress; use --force to restart');
+  }
+}
+
+async function createEmptyOutputFile(filePath: string): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  try {
+    await writeFile(filePath, '', { encoding: 'utf8', flag: 'wx' });
+  } catch (error) {
+    if (hasErrorCode(error, 'EEXIST')) {
+      throw new CliError('Refusing to overwrite existing judge output; use --resume to continue or --force to restart.');
+    }
+    throw error;
+  }
+}
+
+async function appendJsonlRow(filePath: string, row: EvaluatedRow): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await appendFile(filePath, `${JSON.stringify(row)}\n`, 'utf8');
+}
+
+async function writeCheckpoint(options: ParsedArgs, status: JudgeCheckpointStatus, total: number, completed: number, runFingerprint: Record<string, unknown>): Promise<void> {
+  const checkpoint = {
+    version: CHECKPOINT_VERSION,
+    status,
+    updated_at: new Date().toISOString(),
+    run_options: runFingerprint,
+    files: {
+      hyp_path_hash: runFingerprint.hyp_path_hash,
+      ref_path_hash: runFingerprint.ref_path_hash,
+      out_path_hash: runFingerprint.out_path_hash
+    },
+    judge: {
+      total,
+      completed
+    }
+  };
+  await writeTextFileAtomic(options.checkpointPath, `${JSON.stringify(checkpoint, null, 2)}\n`);
+}
+
+async function readJsonFile<T>(filePath: string, label: string): Promise<T> {
+  try {
+    return JSON.parse(await readFile(filePath, 'utf8')) as T;
+  } catch (error) {
+    const detail = error instanceof SyntaxError ? `: ${error.message}` : '';
+    throw new CliError(`Failed to read ${label}${detail}`);
+  }
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await stat(filePath);
+    return true;
+  } catch (error) {
+    if (hasErrorCode(error, 'ENOENT')) return false;
+    throw error;
+  }
+}
+
+function buildCategoryScores(references: ReferenceRow[], evaluated: EvaluatedRow[]): Map<string, number[]> {
+  const qidToReference = new Map(references.map((reference) => [reference.question_id, reference]));
+  const scores = new Map<string, number[]>();
+  for (const category of [...new Set(references.map((reference) => reference.question_type))].sort((a, b) => a.localeCompare(b))) {
+    scores.set(category, []);
+  }
+  for (const row of evaluated) {
+    const reference = qidToReference.get(row.question_id);
+    if (!reference) continue;
+    const categoryScores = scores.get(reference.question_type) ?? [];
+    categoryScores.push(row.autoeval_label.label ? 1 : 0);
+    scores.set(reference.question_type, categoryScores);
+  }
+  return scores;
 }
 
 function parseHypotheses(raw: string, filePath: string): HypothesisRow[] {
@@ -382,6 +649,19 @@ async function writeTextFile(filePath: string, content: string): Promise<void> {
   await writeFile(filePath, content, 'utf8');
 }
 
+async function writeTextFileAtomic(filePath: string, content: string): Promise<void> {
+  const dir = path.dirname(filePath);
+  await mkdir(dir, { recursive: true });
+  const tmpPath = path.join(dir, `.${path.basename(filePath)}.${process.pid}.${Date.now()}.tmp`);
+  try {
+    await writeFile(tmpPath, content, { encoding: 'utf8', flag: 'wx' });
+    await rename(tmpPath, filePath);
+  } catch (error) {
+    await rm(tmpPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
 function readOptionValue(argv: string[], index: number, option: string): string {
   const value = argv[index];
   if (value === undefined || value.startsWith('--')) {
@@ -447,6 +727,10 @@ function collectSecretEnvValues(): string[] {
   return [...values].sort((a, b) => b.length - a.length);
 }
 
+function hasErrorCode(error: unknown, code: string): boolean {
+  return isRecord(error) && error.code === code;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
@@ -455,7 +739,12 @@ function usage(): string {
   return `LongMemEval Codex-compatible judge
 
 Usage:
-  npx tsx scripts/longmemeval-codex-judge.ts --hyp hypotheses.jsonl --ref longmemeval_s_cleaned.json [--out results.jsonl]
+  npx tsx scripts/longmemeval-codex-judge.ts --hyp hypotheses.jsonl --ref longmemeval_s_cleaned.json [--out results.jsonl] [--checkpoint PATH] [--resume|--force]
+
+Options:
+  --checkpoint PATH  Checkpoint file for resumable judging. Default: <out>.checkpoint.json
+  --resume           Continue from an existing checkpoint and append only missing question_id rows.
+  --force            Remove existing output/checkpoint and restart from scratch. Cannot be combined with --resume.
 
 Runs the LongMemEval answer-check prompt through local \`codex exec\` and writes JSONL rows with autoeval_label. This is useful when only Codex subscription auth is available, but it is not the unmodified upstream official evaluator. Upstream official QA still requires running LongMemEval's evaluate_qa.py with API-compatible judge credentials. Prompt content is piped to Codex stdin instead of argv, and Codex runs from an isolated temporary working directory with a pruned environment.
 

--- a/src/apps/cli/vector-command.ts
+++ b/src/apps/cli/vector-command.ts
@@ -35,12 +35,12 @@ export function formatVectorStatusReport(input: VectorStatusReportInput): string
     `Vector count: ${input.stats.vectorCount}`,
     `Total events: ${input.stats.totalEvents}`,
     '',
-    'Queue      pending  processing  failed  stuck  total  oldest',
+    'Queue      pending  processing  failed  retryable  quarantined  stuck  total  oldest',
     formatQueueRow('Embedding', embedding),
     formatQueueRow('Vector', vector),
     formatQueueRow('Total', totals),
     '',
-    `Totals: pending=${totals.pending}, processing=${totals.processing}, failed=${totals.failed}, stuck=${totals.stuckProcessing}, total=${totals.total}`,
+    `Totals: pending=${totals.pending}, processing=${totals.processing}, failed=${totals.failed}, retryableFailed=${totals.retryableFailed ?? 0}, quarantinedFailed=${totals.quarantinedFailed ?? 0}, stuck=${totals.stuckProcessing}, total=${totals.total}`,
     `Oldest processing age: ${formatDuration(oldestProcessingAge)}`,
     `Status: ${status}`
   ];
@@ -57,6 +57,8 @@ function normalizeQueue(queue: OutboxQueueStats): OutboxQueueStats {
     pending: numberOrZero(queue.pending),
     processing: numberOrZero(queue.processing),
     failed: numberOrZero(queue.failed),
+    retryableFailed: numberOrZero(queue.retryableFailed),
+    quarantinedFailed: numberOrZero(queue.quarantinedFailed),
     total: numberOrZero(queue.total),
     stuckProcessing: numberOrZero(queue.stuckProcessing),
     oldestProcessingAgeMs: Number.isFinite(queue.oldestProcessingAgeMs ?? Number.NaN)
@@ -70,6 +72,8 @@ function sumQueues(a: OutboxQueueStats, b: OutboxQueueStats): OutboxQueueStats {
     pending: a.pending + b.pending,
     processing: a.processing + b.processing,
     failed: a.failed + b.failed,
+    retryableFailed: (a.retryableFailed ?? 0) + (b.retryableFailed ?? 0),
+    quarantinedFailed: (a.quarantinedFailed ?? 0) + (b.quarantinedFailed ?? 0),
     stuckProcessing: a.stuckProcessing + b.stuckProcessing,
     total: a.total + b.total,
     oldestProcessingAgeMs: maxNullable(a.oldestProcessingAgeMs, b.oldestProcessingAgeMs)
@@ -82,6 +86,8 @@ function formatQueueRow(label: string, queue: OutboxQueueStats): string {
     String(queue.pending).padStart(7),
     String(queue.processing).padStart(11),
     String(queue.failed).padStart(7),
+    String(queue.retryableFailed ?? 0).padStart(9),
+    String(queue.quarantinedFailed ?? 0).padStart(11),
     String(queue.stuckProcessing).padStart(6),
     String(queue.total).padStart(6),
     formatDuration(queue.oldestProcessingAgeMs).padStart(7)
@@ -94,8 +100,9 @@ function maxNullable(a: number | null, b: number | null): number | null {
   return Math.max(a, b);
 }
 
-function numberOrZero(value: number): number {
-  return Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
+function numberOrZero(value: number | null | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return 0;
+  return Math.floor(value);
 }
 
 function formatDuration(ms: number | null): string {

--- a/src/apps/dashboard/assets/js/overview.js
+++ b/src/apps/dashboard/assets/js/overview.js
@@ -108,7 +108,7 @@ function updateProjectDetailUI() {
       <div class="cfg-section">
         <div class="cfg-section-title"><i class="ri-router-line"></i>Sources & outbox</div>
         <div style="display:flex; gap:6px; flex-wrap:wrap; margin-bottom:8px;">${sourceChips}</div>
-        <div class="session-muted">${formatNumber(outbox.pending || 0)} pending · ${formatNumber(outbox.processing || 0)} processing · ${formatNumber(outbox.failed || 0)} failed · ${formatNumber(outbox.stuckProcessing || 0)} stuck</div>
+        <div class="session-muted">${formatNumber(outbox.pending || 0)} pending · ${formatNumber(outbox.processing || 0)} processing · ${formatNumber(outbox.failed || 0)} failed · ${formatNumber(outbox.retryableFailed || 0)} retryable · ${formatNumber(outbox.quarantinedFailed || 0)} quarantined · ${formatNumber(outbox.stuckProcessing || 0)} stuck</div>
       </div>
     </div>
   `;
@@ -505,6 +505,8 @@ function vectorOutboxTotals(outbox) {
     pending: vectorHealthCount(providedTotals?.pending ?? (vectorHealthCount(embedding.pending) + vectorHealthCount(vector.pending))),
     processing: vectorHealthCount(providedTotals?.processing ?? (vectorHealthCount(embedding.processing) + vectorHealthCount(vector.processing))),
     failed: vectorHealthCount(providedTotals?.failed ?? (vectorHealthCount(embedding.failed) + vectorHealthCount(vector.failed))),
+    retryableFailed: vectorHealthCount(providedTotals?.retryableFailed ?? (vectorHealthCount(embedding.retryableFailed) + vectorHealthCount(vector.retryableFailed))),
+    quarantinedFailed: vectorHealthCount(providedTotals?.quarantinedFailed ?? (vectorHealthCount(embedding.quarantinedFailed) + vectorHealthCount(vector.quarantinedFailed))),
     stuckProcessing: vectorHealthCount(providedTotals?.stuckProcessing ?? (vectorHealthCount(embedding.stuckProcessing) + vectorHealthCount(vector.stuckProcessing))),
     oldestProcessingAgeMs: providedTotals?.oldestProcessingAgeMs ?? maxNullableHealthAge(embedding.oldestProcessingAgeMs, vector.oldestProcessingAgeMs)
   };
@@ -533,15 +535,17 @@ function vectorOutboxQueueRow(label, stats) {
   const pending = vectorHealthCount(stats?.pending);
   const processing = vectorHealthCount(stats?.processing);
   const failed = vectorHealthCount(stats?.failed);
+  const retryable = vectorHealthCount(stats?.retryableFailed);
+  const quarantined = vectorHealthCount(stats?.quarantinedFailed);
   const stuck = vectorHealthCount(stats?.stuckProcessing);
   const total = vectorHealthCount(stats?.total);
   const age = formatVectorHealthAge(stats?.oldestProcessingAgeMs);
-  const statusColor = failed > 0 || stuck > 0 ? 'var(--warning)' : 'var(--success)';
+  const statusColor = quarantined > 0 || stuck > 0 || failed > 0 ? 'var(--warning)' : 'var(--success)';
   return `
     <div class="shared-item">
       <div class="shared-info" style="flex-direction:column; align-items:flex-start; gap:2px; min-width:0;">
         <span style="font-size:12px; color:var(--text-secondary);">${escapeHtml(label)}</span>
-        <span style="font-size:10px; color:var(--text-muted);">pending ${formatNumber(pending)} · processing ${formatNumber(processing)} · failed ${formatNumber(failed)} · stuck ${formatNumber(stuck)} · oldest ${age}</span>
+        <span style="font-size:10px; color:var(--text-muted);">pending ${formatNumber(pending)} · processing ${formatNumber(processing)} · failed ${formatNumber(failed)} · retryable ${formatNumber(retryable)} · quarantined ${formatNumber(quarantined)} · stuck ${formatNumber(stuck)} · oldest ${age}</span>
       </div>
       <div style="display:flex; flex-direction:column; align-items:flex-end; gap:2px; min-width:48px;">
         <span style="font-size:15px; font-weight:700; color:${statusColor};">${formatNumber(total)}</span>
@@ -612,6 +616,8 @@ function updateVectorHealthUI() {
         <span><strong>${formatNumber(totals.pending)} pending</strong></span>
         <span><strong>${formatNumber(totals.processing)} processing</strong></span>
         <span><strong>${formatNumber(totals.failed)} failed</strong></span>
+        <span><strong>${formatNumber(totals.retryableFailed)} retryable</strong></span>
+        <span><strong>${formatNumber(totals.quarantinedFailed)} quarantined</strong></span>
         <span><strong>${formatNumber(totals.stuckProcessing)} stuck</strong></span>
         <span><strong>${formatVectorHealthAge(totals.oldestProcessingAgeMs)} oldest processing</strong></span>
       </div>

--- a/src/apps/dashboard/assets/js/views.js
+++ b/src/apps/dashboard/assets/js/views.js
@@ -930,7 +930,7 @@ function renderSetupProviderHealthCard(setupHealth) {
           <div class="cfg-row"><span class="cfg-row-label">Status</span><span class="cfg-row-value">${escapeHtml(storage.status || 'unknown')}</span></div>
           <div class="cfg-row"><span class="cfg-row-label">Events</span><span class="cfg-row-value">${formatNumber(storage.totalEvents || 0)} events</span></div>
           <div class="cfg-row"><span class="cfg-row-label">Vectors</span><span class="cfg-row-value">${formatNumber(storage.vectorCount || 0)} vectors</span></div>
-          <div class="cfg-row"><span class="cfg-row-label">Outbox</span><span class="cfg-row-value">${formatNumber(outbox.pending || 0)} pending · ${formatNumber(outbox.failed || 0)} failed · ${formatNumber(outbox.stuckProcessing || 0)} stuck</span></div>
+          <div class="cfg-row"><span class="cfg-row-label">Outbox</span><span class="cfg-row-value">${formatNumber(outbox.pending || 0)} pending · ${formatNumber(outbox.failed || 0)} failed · ${formatNumber(outbox.retryableFailed || 0)} retryable · ${formatNumber(outbox.quarantinedFailed || 0)} quarantined · ${formatNumber(outbox.stuckProcessing || 0)} stuck</span></div>
         </div>
         <div class="cfg-section">
           <div class="cfg-section-title"><i class="ri-terminal-box-line"></i>Provider Readiness</div>

--- a/src/apps/server/api/health.ts
+++ b/src/apps/server/api/health.ts
@@ -52,8 +52,10 @@ function aggregateOutbox(outbox: Awaited<ReturnType<Awaited<ReturnType<typeof ge
   const pending = (outbox.embedding?.pending || 0) + (outbox.vector?.pending || 0);
   const processing = (outbox.embedding?.processing || 0) + (outbox.vector?.processing || 0);
   const failed = (outbox.embedding?.failed || 0) + (outbox.vector?.failed || 0);
+  const retryableFailed = (outbox.embedding?.retryableFailed || 0) + (outbox.vector?.retryableFailed || 0);
+  const quarantinedFailed = (outbox.embedding?.quarantinedFailed || 0) + (outbox.vector?.quarantinedFailed || 0);
   const stuckProcessing = (outbox.embedding?.stuckProcessing || 0) + (outbox.vector?.stuckProcessing || 0);
-  return { pending, processing, failed, stuckProcessing };
+  return { pending, processing, failed, retryableFailed, quarantinedFailed, stuckProcessing };
 }
 
 // GET /api/health/setup
@@ -133,6 +135,8 @@ healthRouter.get('/', async (c) => {
     const outboxPending = outbox.embedding.pending + outbox.vector.pending;
     const outboxProcessing = outbox.embedding.processing + outbox.vector.processing;
     const outboxFailed = outbox.embedding.failed + outbox.vector.failed;
+    const outboxRetryableFailed = (outbox.embedding.retryableFailed ?? 0) + (outbox.vector.retryableFailed ?? 0);
+    const outboxQuarantinedFailed = (outbox.embedding.quarantinedFailed ?? 0) + (outbox.vector.quarantinedFailed ?? 0);
     const outboxStuckProcessing = outbox.embedding.stuckProcessing + outbox.vector.stuckProcessing;
     const oldestProcessingAgeMs = Math.max(
       outbox.embedding.oldestProcessingAgeMs ?? 0,
@@ -155,6 +159,8 @@ healthRouter.get('/', async (c) => {
           pending: outboxPending,
           processing: outboxProcessing,
           failed: outboxFailed,
+          retryableFailed: outboxRetryableFailed,
+          quarantinedFailed: outboxQuarantinedFailed,
           stuckProcessing: outboxStuckProcessing,
           oldestProcessingAgeMs
         }

--- a/src/core/sqlite-event-store.ts
+++ b/src/core/sqlite-event-store.ts
@@ -1763,6 +1763,9 @@ export class SQLiteEventStore {
     const thresholdMs = Number.isFinite(options.stuckThresholdMs) && (options.stuckThresholdMs ?? 0) >= 0
       ? options.stuckThresholdMs!
       : DEFAULT_OUTBOX_STUCK_THRESHOLD_MS;
+    const maxRetries = Number.isFinite(options.maxRetries) && (options.maxRetries ?? 0) > 0
+      ? options.maxRetries!
+      : DEFAULT_OUTBOX_MAX_RETRIES;
     const now = options.now ?? new Date();
     const threshold = new Date(now.getTime() - thresholdMs).toISOString();
 
@@ -1786,9 +1789,11 @@ export class SQLiteEventStore {
     const fromRows = (
       rows: Array<{ status: string; count: number }>,
       stuckProcessing: number,
-      oldestProcessingAgeMs: number | null
+      oldestProcessingAgeMs: number | null,
+      retryableFailed: number,
+      quarantinedFailed: number
     ) => {
-      const out = { pending: 0, processing: 0, failed: 0, total: 0, stuckProcessing, oldestProcessingAgeMs };
+      const out = { pending: 0, processing: 0, failed: 0, retryableFailed, quarantinedFailed, total: 0, stuckProcessing, oldestProcessingAgeMs };
       for (const row of rows) {
         const key = row.status as 'pending' | 'processing' | 'failed' | 'done';
         if (key === 'pending' || key === 'processing' || key === 'failed') {
@@ -1813,6 +1818,22 @@ export class SQLiteEventStore {
        FROM embedding_outbox
        WHERE status = 'processing'`
     );
+    const embeddingRetryableFailed = sqliteGet<{ count: number }>(
+      this.db,
+      `SELECT COUNT(*) as count
+       FROM embedding_outbox
+       WHERE status = 'failed'
+         AND retry_count < ?`,
+      [maxRetries]
+    );
+    const embeddingQuarantinedFailed = sqliteGet<{ count: number }>(
+      this.db,
+      `SELECT COUNT(*) as count
+       FROM embedding_outbox
+       WHERE status = 'failed'
+         AND retry_count >= ?`,
+      [maxRetries]
+    );
 
     const vectorStuck = sqliteGet<{ count: number }>(
       this.db,
@@ -1828,17 +1849,37 @@ export class SQLiteEventStore {
        FROM vector_outbox
        WHERE status = 'processing'`
     );
+    const vectorRetryableFailed = sqliteGet<{ count: number }>(
+      this.db,
+      `SELECT COUNT(*) as count
+       FROM vector_outbox
+       WHERE status = 'failed'
+         AND retry_count < ?`,
+      [maxRetries]
+    );
+    const vectorQuarantinedFailed = sqliteGet<{ count: number }>(
+      this.db,
+      `SELECT COUNT(*) as count
+       FROM vector_outbox
+       WHERE status = 'failed'
+         AND retry_count >= ?`,
+      [maxRetries]
+    );
 
     return {
       embedding: fromRows(
         embeddingRows,
         Number(embeddingStuck?.count ?? 0),
-        processingAgeMs(embeddingOldest?.oldest)
+        processingAgeMs(embeddingOldest?.oldest),
+        Number(embeddingRetryableFailed?.count ?? 0),
+        Number(embeddingQuarantinedFailed?.count ?? 0)
       ),
       vector: fromRows(
         vectorRows,
         Number(vectorStuck?.count ?? 0),
-        processingAgeMs(vectorOldest?.oldest)
+        processingAgeMs(vectorOldest?.oldest),
+        Number(vectorRetryableFailed?.count ?? 0),
+        Number(vectorQuarantinedFailed?.count ?? 0)
       )
     };
   }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -723,6 +723,8 @@ export interface OutboxItem {
 export interface OutboxStatsOptions {
   /** Processing rows older than this threshold are considered abandoned/stuck. */
   stuckThresholdMs?: number;
+  /** Failed rows below this retry budget are counted as retryable; rows at/above it are counted as quarantined. */
+  maxRetries?: number;
   /** Test hook for deterministic age calculations. */
   now?: Date;
 }
@@ -731,6 +733,10 @@ export interface OutboxQueueStats {
   pending: number;
   processing: number;
   failed: number;
+  /** Failed rows that recovery can safely move back to pending without exposing payloads. */
+  retryableFailed?: number;
+  /** Failed rows at/above retry budget that need operator attention/quarantine handling. */
+  quarantinedFailed?: number;
   total: number;
   stuckProcessing: number;
   /** Age in milliseconds for the oldest processing row, or null when none are processing. */

--- a/src/core/vector-outbox.ts
+++ b/src/core/vector-outbox.ts
@@ -33,6 +33,13 @@ export interface OutboxMetrics {
   oldestPendingAge: number | null;
 }
 
+function isRetryableLanceCommitConflict(error: string): boolean {
+  const normalized = error.toLowerCase();
+  return normalized.includes('lance')
+    && normalized.includes('commit')
+    && normalized.includes('conflict');
+}
+
 export interface OutboxEnqueueInput {
   itemKind: OutboxItemKind;
   itemId: string;
@@ -177,6 +184,18 @@ export class VectorOutbox {
     if (rows.length === 0) return;
 
     const retryCount = rows[0].retry_count;
+
+    if (isRetryableLanceCommitConflict(error)) {
+      await dbRun(
+        this.db,
+        `UPDATE vector_outbox
+         SET status = 'pending', error = ?, updated_at = ?
+         WHERE job_id = ?`,
+        [error, now, jobId]
+      );
+      return;
+    }
+
     const newStatus: OutboxStatus = retryCount >= this.config.maxRetries - 1
       ? 'failed'
       : 'pending';  // Will retry

--- a/tests/apps/dashboard-project-detail-ui.test.ts
+++ b/tests/apps/dashboard-project-detail-ui.test.ts
@@ -65,7 +65,7 @@ describe('dashboard project detail card', () => {
         eventTypes: { user_prompt: 5, agent_response: 4 },
         sources: { hermes: 6, codex: 3 },
         retrieval: { totalQueries: 9, selectionRate: 0.37, rawQuery: 'PRIVATE_QUERY_SHOULD_NOT_LEAK' },
-        outbox: { pending: 3, processing: 1, failed: 0, stuckProcessing: 0, rawIds: ['PRIVATE_OUTBOX_ID_SHOULD_NOT_LEAK'] },
+        outbox: { pending: 3, processing: 1, failed: 3, retryableFailed: 2, quarantinedFailed: 1, stuckProcessing: 0, rawIds: ['PRIVATE_OUTBOX_ID_SHOULD_NOT_LEAK'] },
       }) };
     });
     hooks.state.currentProject = 'project-safe-hash';
@@ -84,6 +84,8 @@ describe('dashboard project detail card', () => {
     expect(card.innerHTML).toContain('31 vectors');
     expect(card.innerHTML).toContain('37.0% selection');
     expect(card.innerHTML).toContain('3 pending');
+    expect(card.innerHTML).toContain('2 retryable');
+    expect(card.innerHTML).toContain('1 quarantined');
     expect(card.innerHTML).toContain('user_prompt');
     expect(card.innerHTML).toContain('hermes');
 

--- a/tests/apps/dashboard-setup-health-ui.test.ts
+++ b/tests/apps/dashboard-setup-health-ui.test.ts
@@ -57,7 +57,7 @@ describe('dashboard setup/provider health UI', () => {
           setup: {
             scope: 'project',
             storage: { status: 'ok', totalEvents: 12, vectorCount: 8, rawPath: 'PRIVATE_STORAGE_PATH_SHOULD_NOT_LEAK' },
-            outbox: { pending: 1, processing: 0, failed: 0, stuckProcessing: 0, rawIds: ['PRIVATE_OUTBOX_ID_SHOULD_NOT_LEAK'] },
+            outbox: { pending: 1, processing: 0, failed: 3, retryableFailed: 2, quarantinedFailed: 1, stuckProcessing: 0, rawIds: ['PRIVATE_OUTBOX_ID_SHOULD_NOT_LEAK'] },
           },
           providers: {
             claudeCli: { status: 'missing', command: 'claude', authSignal: 'not-detected', rawError: 'PRIVATE_CLAUDE_ERROR_SHOULD_NOT_LEAK' },
@@ -90,6 +90,8 @@ describe('dashboard setup/provider health UI', () => {
     expect(cfg.innerHTML).toContain('@huggingface/transformers');
     expect(cfg.innerHTML).toContain('12 events');
     expect(cfg.innerHTML).toContain('1 pending');
+    expect(cfg.innerHTML).toContain('2 retryable');
+    expect(cfg.innerHTML).toContain('1 quarantined');
     expect(cfg.innerHTML).toContain('Install or authenticate Claude CLI');
 
     for (const privateSentinel of [

--- a/tests/apps/health-api-outbox-recovery.test.ts
+++ b/tests/apps/health-api-outbox-recovery.test.ts
@@ -42,8 +42,8 @@ describe('health API outbox recovery', () => {
       levelStats: []
     });
     mocks.service.getOutboxStats.mockReset().mockResolvedValue({
-      embedding: { pending: 1, processing: 0, failed: 0, total: 1, stuckProcessing: 0, oldestProcessingAgeMs: null },
-      vector: { pending: 0, processing: 0, failed: 0, total: 0, stuckProcessing: 0, oldestProcessingAgeMs: null }
+      embedding: { pending: 1, processing: 0, failed: 0, retryableFailed: 0, quarantinedFailed: 0, total: 1, stuckProcessing: 0, oldestProcessingAgeMs: null },
+      vector: { pending: 0, processing: 0, failed: 0, retryableFailed: 0, quarantinedFailed: 0, total: 0, stuckProcessing: 0, oldestProcessingAgeMs: null }
     });
     mocks.service.recoverStuckOutboxItems.mockReset().mockResolvedValue({
       embedding: { recoveredProcessing: 34, retriedFailed: 0 },
@@ -63,7 +63,7 @@ describe('health API outbox recovery', () => {
     const json = await res.json();
     expect(json.status).toBe('ok');
     expect(json.storage).toEqual({ totalEvents: 51, vectorCount: 0 });
-    expect(json.outbox.totals).toEqual({ pending: 1, processing: 0, failed: 0, stuckProcessing: 0, oldestProcessingAgeMs: null });
+    expect(json.outbox.totals).toEqual({ pending: 1, processing: 0, failed: 0, retryableFailed: 0, quarantinedFailed: 0, stuckProcessing: 0, oldestProcessingAgeMs: null });
     expect(mocks.getLightweightServiceFromQuery).toHaveBeenCalledTimes(1);
     expect(mocks.getServiceFromQuery).not.toHaveBeenCalled();
     expect(mocks.getWritableServiceFromQuery).not.toHaveBeenCalled();
@@ -87,6 +87,8 @@ describe('health API outbox recovery', () => {
       pending: 3,
       processing: 5,
       failed: 0,
+      retryableFailed: 0,
+      quarantinedFailed: 0,
       stuckProcessing: 3,
       oldestProcessingAgeMs: 1200000
     });

--- a/tests/apps/longmemeval-codex-judge.test.ts
+++ b/tests/apps/longmemeval-codex-judge.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 
@@ -34,7 +34,7 @@ function runJudge(args: string[], env: Record<string, string> = {}): Promise<Cli
   });
 }
 
-function writeMockCodex(mode: 'normal' | 'ambiguous' | 'fail' = 'normal'): { bin: string; promptPath: string; argsPath: string; envPath: string } {
+function writeMockCodex(mode: 'normal' | 'ambiguous' | 'fail' = 'normal', failPromptIncludes = ''): { bin: string; promptPath: string; argsPath: string; envPath: string } {
   const dir = mkdtempSync(path.join(tmpdir(), 'cml-longmemeval-codex-judge-'));
   const bin = path.join(dir, 'codex-mock.mjs');
   const promptPath = path.join(dir, 'prompts.txt');
@@ -47,6 +47,11 @@ process.stdin.setEncoding('utf8');
 process.stdin.on('data', chunk => { prompt += chunk; });
 process.stdin.on('end', () => {
   appendFileSync(${JSON.stringify(promptPath)}, prompt + '\\n---PROMPT---\\n');
+  const failPromptIncludes = ${JSON.stringify(failPromptIncludes)};
+  if (failPromptIncludes && prompt.includes(failPromptIncludes)) {
+    console.error('judge failed for selected prompt: token=ak');
+    process.exit(7);
+  }
   const answer = ${JSON.stringify(mode)} === 'ambiguous'
     ? 'no, not yes'
     : (prompt.includes('Model Response: jasmine tea') ? 'yes' : 'no');
@@ -105,6 +110,8 @@ describe('LongMemEval Codex-compatible judge wrapper', () => {
     expect(result.stdout).toContain('LongMemEval Codex-compatible judge');
     expect(result.stdout).toContain('not the unmodified upstream official evaluator');
     expect(result.stdout).toContain('LONGMEMEVAL_CODEX_BIN');
+    expect(result.stdout).toContain('--checkpoint PATH');
+    expect(result.stdout).toContain('--resume');
   });
 
   it('judges hypotheses with the upstream answer-check prompt via stdin and writes JSONL results', async () => {
@@ -151,6 +158,134 @@ describe('LongMemEval Codex-compatible judge wrapper', () => {
     expect(result.stdout).toContain('Accuracy: 0');
     const [row] = readFileSync(files.out, 'utf8').trim().split('\n').map((line) => JSON.parse(line));
     expect(row.autoeval_label).toEqual({ model: 'codex-cli', label: false });
+  });
+
+  it('streams evaluated rows to JSONL checkpoints and resumes without re-scoring completed hypotheses', async () => {
+    const mock = writeMockCodex('normal', 'Model Response: black coffee');
+    const files = writeFixtureFiles();
+    const checkpoint = path.join(path.dirname(files.out), 'judge-checkpoint.json');
+
+    const first = await runJudge(['--hyp', files.hyp, '--ref', files.ref, '--out', files.out, '--checkpoint', checkpoint], {
+      LONGMEMEVAL_CODEX_BIN: mock.bin
+    });
+
+    expect(first.status).toBe(1);
+    expect(first.stderr).toContain('Codex judge failed for q2');
+    const partialRows = readFileSync(files.out, 'utf8').trim().split('\n').map((line) => JSON.parse(line));
+    expect(partialRows.map((row) => row.question_id)).toEqual(['q1']);
+    expect(partialRows[0].autoeval_label).toEqual({ model: 'codex-cli', label: true });
+    let checkpointData = JSON.parse(readFileSync(checkpoint, 'utf8')) as Record<string, any>;
+    expect(checkpointData.status).toBe('judge_failed');
+    expect(checkpointData.judge).toMatchObject({ total: 2, completed: 1 });
+
+    const secondMock = writeMockCodex();
+    const second = await runJudge(['--hyp', files.hyp, '--ref', files.ref, '--out', files.out, '--checkpoint', checkpoint, '--resume'], {
+      LONGMEMEVAL_CODEX_BIN: secondMock.bin
+    });
+
+    expect(second.status).toBe(0);
+    expect(second.stderr).toBe('');
+    expect(second.stdout).toContain('Accuracy: 0.5');
+    const finalRows = readFileSync(files.out, 'utf8').trim().split('\n').map((line) => JSON.parse(line));
+    expect(finalRows.map((row) => row.question_id)).toEqual(['q1', 'q2']);
+    expect(finalRows.map((row) => row.autoeval_label.label)).toEqual([true, false]);
+    const firstPromptLog = readFileSync(mock.promptPath, 'utf8');
+    const secondPromptLog = readFileSync(secondMock.promptPath, 'utf8');
+    expect((firstPromptLog.match(/Model Response: jasmine tea/g) ?? [])).toHaveLength(1);
+    expect((firstPromptLog.match(/Model Response: black coffee/g) ?? [])).toHaveLength(1);
+    expect((secondPromptLog.match(/Model Response: jasmine tea/g) ?? [])).toHaveLength(0);
+    expect((secondPromptLog.match(/Model Response: black coffee/g) ?? [])).toHaveLength(1);
+    checkpointData = JSON.parse(readFileSync(checkpoint, 'utf8')) as Record<string, any>;
+    expect(checkpointData.status).toBe('completed');
+    expect(checkpointData.judge).toMatchObject({ total: 2, completed: 2 });
+  });
+
+  it('refuses to overwrite managed outputs without --resume or --force and allows explicit --force restart', async () => {
+    const mock = writeMockCodex();
+    const files = writeFixtureFiles();
+    const checkpoint = path.join(path.dirname(files.out), 'judge-checkpoint.json');
+    writeFileSync(files.out, 'stale result must survive', 'utf8');
+    chmodSync(files.out, 0o200);
+
+    const blocked = await runJudge(['--hyp', files.hyp, '--ref', files.ref, '--out', files.out, '--checkpoint', checkpoint], {
+      LONGMEMEVAL_CODEX_BIN: mock.bin
+    });
+    chmodSync(files.out, 0o600);
+
+    expect(blocked.status).toBe(1);
+    expect(blocked.stderr).toContain('Refusing to overwrite existing judge output');
+    expect(readFileSync(files.out, 'utf8')).toBe('stale result must survive');
+    expect(existsSync(checkpoint)).toBe(false);
+
+    const forced = await runJudge(['--hyp', files.hyp, '--ref', files.ref, '--out', files.out, '--checkpoint', checkpoint, '--force'], {
+      LONGMEMEVAL_CODEX_BIN: mock.bin
+    });
+
+    expect(forced.status).toBe(0);
+    const rows = readFileSync(files.out, 'utf8').trim().split('\n').map((line) => JSON.parse(line));
+    expect(rows.map((row) => row.question_id)).toEqual(['q1', 'q2']);
+    const checkpointData = JSON.parse(readFileSync(checkpoint, 'utf8')) as Record<string, any>;
+    expect(checkpointData.status).toBe('completed');
+  });
+
+  it('rejects resume when input content changed or checkpoint progress no longer matches output rows', async () => {
+    const failingMock = writeMockCodex('normal', 'Model Response: black coffee');
+    const files = writeFixtureFiles();
+    const checkpoint = path.join(path.dirname(files.out), 'judge-checkpoint.json');
+    const first = await runJudge(['--hyp', files.hyp, '--ref', files.ref, '--out', files.out, '--checkpoint', checkpoint], {
+      LONGMEMEVAL_CODEX_BIN: failingMock.bin
+    });
+    expect(first.status).toBe(1);
+
+    writeFileSync(files.hyp, [
+      JSON.stringify({ question_id: 'q1', hypothesis: 'changed jasmine tea' }),
+      JSON.stringify({ question_id: 'q2', hypothesis: 'black coffee' })
+    ].join('\n') + '\n', 'utf8');
+    const changedInput = await runJudge(['--hyp', files.hyp, '--ref', files.ref, '--out', files.out, '--checkpoint', checkpoint, '--resume'], {
+      LONGMEMEVAL_CODEX_BIN: writeMockCodex().bin
+    });
+
+    expect(changedInput.status).toBe(1);
+    expect(changedInput.stderr).toContain('Resume checkpoint does not match current options');
+    expect(changedInput.stderr).toContain('run_options.hyp_sha256');
+    expect(changedInput.stderr).not.toContain(files.hyp);
+
+    writeFileSync(files.hyp, [
+      JSON.stringify({ question_id: 'q1', hypothesis: 'jasmine tea' }),
+      JSON.stringify({ question_id: 'q2', hypothesis: 'black coffee' })
+    ].join('\n') + '\n', 'utf8');
+    unlinkSync(files.out);
+    const missingOutput = await runJudge(['--hyp', files.hyp, '--ref', files.ref, '--out', files.out, '--checkpoint', checkpoint, '--resume'], {
+      LONGMEMEVAL_CODEX_BIN: writeMockCodex().bin
+    });
+
+    expect(missingOutput.status).toBe(1);
+    expect(missingOutput.stderr).toContain('Resume output is missing evaluated rows recorded by the checkpoint');
+  });
+
+  it('recovers when streamed output is ahead of checkpoint progress after a crash window', async () => {
+    const failingMock = writeMockCodex('normal', 'Model Response: black coffee');
+    const files = writeFixtureFiles();
+    const checkpoint = path.join(path.dirname(files.out), 'judge-checkpoint.json');
+    const first = await runJudge(['--hyp', files.hyp, '--ref', files.ref, '--out', files.out, '--checkpoint', checkpoint], {
+      LONGMEMEVAL_CODEX_BIN: failingMock.bin
+    });
+    expect(first.status).toBe(1);
+
+    const simulatedCrashedRow = {
+      question_id: 'q2',
+      hypothesis: 'black coffee',
+      autoeval_label: { model: 'codex-cli', label: false }
+    };
+    writeFileSync(files.out, `${readFileSync(files.out, 'utf8')}${JSON.stringify(simulatedCrashedRow)}\n`, 'utf8');
+
+    const resumed = await runJudge(['--hyp', files.hyp, '--ref', files.ref, '--out', files.out, '--checkpoint', checkpoint, '--resume']);
+
+    expect(resumed.status).toBe(0);
+    expect(resumed.stdout).toContain('Accuracy: 0.5');
+    const checkpointData = JSON.parse(readFileSync(checkpoint, 'utf8')) as Record<string, any>;
+    expect(checkpointData.status).toBe('completed');
+    expect(checkpointData.judge).toMatchObject({ total: 2, completed: 2 });
   });
 
   it('fails closed on hypothesis ids missing from references', async () => {

--- a/tests/apps/setup-health-api.test.ts
+++ b/tests/apps/setup-health-api.test.ts
@@ -43,8 +43,8 @@ function statsPayload() {
 
 function outboxPayload() {
   return {
-    embedding: { pending: 1, processing: 0, failed: 0, stuckProcessing: 0, oldestProcessingAgeMs: null, total: 4, rawError: 'PRIVATE_EMBED_ERROR_SHOULD_NOT_LEAK' },
-    vector: { pending: 0, processing: 0, failed: 0, stuckProcessing: 0, oldestProcessingAgeMs: null, total: 4, itemIds: ['PRIVATE_VECTOR_ITEM_SHOULD_NOT_LEAK'] },
+    embedding: { pending: 1, processing: 0, failed: 0, retryableFailed: 0, quarantinedFailed: 0, stuckProcessing: 0, oldestProcessingAgeMs: null, total: 4, rawError: 'PRIVATE_EMBED_ERROR_SHOULD_NOT_LEAK' },
+    vector: { pending: 0, processing: 0, failed: 0, retryableFailed: 0, quarantinedFailed: 0, stuckProcessing: 0, oldestProcessingAgeMs: null, total: 4, itemIds: ['PRIVATE_VECTOR_ITEM_SHOULD_NOT_LEAK'] },
   };
 }
 
@@ -87,7 +87,7 @@ describe('setup/provider health API', () => {
       setup: {
         scope: 'project',
         storage: { status: 'ok', totalEvents: 12, vectorCount: 8 },
-        outbox: { pending: 1, failed: 0, stuckProcessing: 0 },
+        outbox: { pending: 1, failed: 0, retryableFailed: 0, quarantinedFailed: 0, stuckProcessing: 0 },
       },
       providers: {
         claudeCli: { status: 'available', command: 'claude', authSignal: 'env-present' },

--- a/tests/apps/vector-command.test.ts
+++ b/tests/apps/vector-command.test.ts
@@ -28,6 +28,8 @@ describe('vector-status CLI helpers', () => {
           pending: 1,
           processing: 2,
           failed: 3,
+          retryableFailed: 1,
+          quarantinedFailed: 2,
           stuckProcessing: 1,
           oldestProcessingAgeMs: 120_000,
           total: 6,
@@ -38,6 +40,8 @@ describe('vector-status CLI helpers', () => {
           pending: 4,
           processing: 5,
           failed: 0,
+          retryableFailed: 0,
+          quarantinedFailed: 0,
           stuckProcessing: 2,
           oldestProcessingAgeMs: 245_000,
           total: 11,
@@ -56,6 +60,8 @@ describe('vector-status CLI helpers', () => {
     expect(output).toContain('pending=5');
     expect(output).toContain('processing=7');
     expect(output).toContain('failed=3');
+    expect(output).toContain('retryableFailed=1');
+    expect(output).toContain('quarantinedFailed=2');
     expect(output).toContain('stuck=3');
     expect(output).toContain('Oldest processing age: 4m');
     expect(output).toContain('Status: needs-attention');

--- a/tests/core/sqlite-event-store-outbox-stats.test.ts
+++ b/tests/core/sqlite-event-store-outbox-stats.test.ts
@@ -63,6 +63,12 @@ describe('SQLiteEventStore outbox health stats', () => {
       db,
       `INSERT INTO embedding_outbox (id, event_id, content, status, retry_count, created_at, processed_at, error_message)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      ['emb-retryable-failed', 'event-private-retryable', 'PRIVATE_CONTENT_SENTINEL', 'failed', 1, '2026-05-25T00:56:30.000Z', null, 'PRIVATE_RETRYABLE_ERROR_SENTINEL']
+    );
+    sqliteRun(
+      db,
+      `INSERT INTO embedding_outbox (id, event_id, content, status, retry_count, created_at, processed_at, error_message)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
       ['emb-done', 'event-private-5', 'PRIVATE_CONTENT_SENTINEL', 'done', 0, '2026-05-25T00:40:00.000Z', '2026-05-25T00:41:00.000Z', null]
     );
 
@@ -94,6 +100,12 @@ describe('SQLiteEventStore outbox health stats', () => {
       db,
       `INSERT INTO vector_outbox (job_id, item_kind, item_id, embedding_version, status, retry_count, error, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ['vec-retryable-failed', 'task_title', 'task-private-retryable', 'v1', 'failed', 1, 'PRIVATE_VECTOR_RETRYABLE_ERROR_SENTINEL', '2026-05-25T00:56:30.000Z', '2026-05-25T00:56:30.000Z']
+    );
+    sqliteRun(
+      db,
+      `INSERT INTO vector_outbox (job_id, item_kind, item_id, embedding_version, status, retry_count, error, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       ['vec-done', 'entry', 'entry-private-2', 'v1', 'done', 0, null, '2026-05-25T00:55:00.000Z', '2026-05-25T00:55:00.000Z']
     );
 
@@ -102,16 +114,20 @@ describe('SQLiteEventStore outbox health stats', () => {
     expect(stats.embedding).toEqual({
       pending: 1,
       processing: 2,
-      failed: 1,
-      total: 5,
+      failed: 2,
+      retryableFailed: 1,
+      quarantinedFailed: 1,
+      total: 6,
       stuckProcessing: 1,
       oldestProcessingAgeMs: 10 * 60 * 1000
     });
     expect(stats.vector).toEqual({
       pending: 1,
       processing: 2,
-      failed: 1,
-      total: 5,
+      failed: 2,
+      retryableFailed: 1,
+      quarantinedFailed: 1,
+      total: 6,
       stuckProcessing: 1,
       oldestProcessingAgeMs: 20 * 60 * 1000
     });

--- a/tests/core/vector-outbox-v2.test.ts
+++ b/tests/core/vector-outbox-v2.test.ts
@@ -452,6 +452,22 @@ describe('VectorOutbox V2', () => {
     expect(db.prepare('SELECT COUNT(*) AS count FROM vector_outbox').get()).toEqual({ count: 2 });
   });
 
+  it('keeps Lance commit conflicts retryable without consuming retry budget', async () => {
+    const db = createDb();
+    const outbox = new VectorOutbox(db, { embeddingVersion: 'test-v1', maxRetries: 1 });
+    const jobId = await outbox.enqueue('event', 'event-transient-conflict');
+
+    const claimed = await outbox.claimJobs(1);
+    expect(claimed).toHaveLength(1);
+    await outbox.markFailed(jobId, 'Lance commit conflict: concurrent writer committed first; please retry');
+
+    expect(db.prepare('SELECT status, retry_count, error FROM vector_outbox WHERE job_id = ?').get(jobId)).toEqual({
+      status: 'pending',
+      retry_count: 0,
+      error: 'Lance commit conflict: concurrent writer committed first; please retry'
+    });
+  });
+
   it('reports accurate reconcile and cleanup counts', async () => {
     const db = createDb();
     const outbox = new VectorOutbox(db, {


### PR DESCRIPTION
## Summary
- restore the lint script by adding ESLint 9 flat config and dev dependencies compatible with the repo's Node support
- harden the LongMemEval Codex judge with streamed JSONL checkpoints, safe resume/force behavior, input fingerprint validation, and redacted failure diagnostics
- expose retryable vs quarantined vector outbox failures through core stats, health API, vector CLI output, and dashboard setup/project/vector health UI

## Verification
- npm run lint
- npm run typecheck
- npm run build
- npm run smoke:dashboard
- npm run check:architecture
- npm test -- --run (143 files / 827 tests)
