### PR TITLE
feat: add evidence-grounded usefulness and harden vector imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-memory-layer",
-  "version": "1.0.55",
+  "version": "1.0.59",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-memory-layer",
-      "version": "1.0.55",
+      "version": "1.0.59",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-memory-layer",
-  "version": "1.0.58",
+  "version": "1.0.59",
   "description": "Project-scoped memory layer for Claude Code, Codex, Hermes, MCP, and dashboards",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-memory-layer",
-  "version": "1.0.55",
+  "version": "1.0.58",
   "description": "Project-scoped memory layer for Claude Code, Codex, Hermes, MCP, and dashboards",
   "main": "dist/index.js",
   "bin": {

--- a/scripts/dashboard-smoke.ts
+++ b/scripts/dashboard-smoke.ts
@@ -42,10 +42,18 @@ async function main(): Promise<void> {
     'global-empty-state',
     'disclosure-search-btn',
     'disclosure-scope-badge',
-    'Search → Expand → Source'
+    'Search → Expand → Source',
+    'view-usefulness',
+    'view-diagnostics',
+    'usefulness-history-list',
+    'overview-usefulness-strip',
+    'assets/js/usefulness.js'
   ]) {
     assertContains('dashboard HTML', html, needle);
   }
+  const usefulnessJs = readFileSync(join(process.cwd(), 'src/apps/dashboard/assets/js/usefulness.js'), 'utf-8');
+  assertContains('usefulness JS', usefulnessJs, 'usefulness-history');
+  assertContains('usefulness JS', usefulnessJs, 'loadDiagnosticsView');
   assertContains('session inspector JS', views, 'Open in Sessions');
   assertContains('session inspector JS', views, 'Jump target');
   assertContains('disclosure JS', disclosure, 'Inspect evidence');
@@ -57,6 +65,10 @@ async function main(): Promise<void> {
   try {
     await waitForHealth(baseUrl);
     await fetchOk(`${baseUrl}/api/projects`);
+    const historyBody = await fetchOk(`${baseUrl}/api/stats/usefulness-history?limit=5`).then(r => r.json());
+    if (!Array.isArray(historyBody.entries)) {
+      throw new Error('/api/stats/usefulness-history did not return an entries array');
+    }
     const page = await fetchOk(baseUrl).then(response => response.text());
     assertContains('served dashboard HTML', page, 'scope-context-bar');
     assertContains('served dashboard HTML', page, 'disclosure-search-btn');

--- a/specs/vector-writer-concurrency/context.md
+++ b/specs/vector-writer-concurrency/context.md
@@ -1,0 +1,20 @@
+# Vector Writer Concurrency Context
+
+## Observed failure
+
+During `claude-memory-layer import`, Lance reported concurrent commits where a
+`Delete` transaction conflicted with an `Append` transaction on the
+`conversations` table. Both `Vector worker error` and the command-level
+`Import failed` message were emitted, followed by a libc++ mutex abort.
+
+## Relevant implementation seams
+
+- `src/core/engine/memory-runtime-service.ts` starts polling workers and also
+  exposes explicit draining.
+- `src/core/vector-worker.ts` currently allows polling and draining to call the
+  same batch method without a mutual-exclusion gate.
+- `src/core/vector-store.ts` performs idempotent upsert as delete plus add.
+- `src/core/worker-lock.ts` already supplies stale-aware, project-scoped process
+  locking used by `process` and Mongo sync.
+- `src/apps/cli/index.ts` does not currently apply that lock to the Claude
+  import command and exits immediately on failure.

--- a/specs/vector-writer-concurrency/plan.md
+++ b/specs/vector-writer-concurrency/plan.md
@@ -1,0 +1,51 @@
+# Vector Writer Concurrency Implementation Plan
+
+> **Status**: Complete
+> **Created**: 2026-07-15
+
+## Phase 1 — Worker serialization
+
+- [x] Add a per-worker active-batch promise to legacy and V2 workers.
+- [x] Route polling and explicit drains through the same single-flight gate.
+- [x] Expose `waitForIdle()` and await it during runtime shutdown.
+- [x] Add deterministic overlap and shutdown-order tests.
+
+## Phase 2 — Lance conflict recovery
+
+- [x] Detect only Lance concurrent commit conflict messages.
+- [x] Evict/reopen the affected cached table before retrying the complete
+      idempotent delete/add operation.
+- [x] Use bounded exponential backoff and preserve immediate failure for other
+      errors.
+- [x] Add retry and no-retry unit tests with fake table handles.
+
+## Phase 3 — One-shot import lifecycle
+
+- [x] Extract project/global import lock path resolution and busy formatting.
+- [x] Acquire the worker lock before starting writable Claude, Codex, and Hermes import services.
+- [x] Release the lock and shut services down through `finally` paths.
+- [x] Replace immediate exits in import actions with deferred
+      `process.exitCode` assignment.
+- [x] Cover lock resolution, contention messaging, and cleanup with tests.
+
+## Phase 4 — Verification
+
+- [x] Run focused worker, runtime, import, and process command tests (36 passed after review fixes).
+- [x] Run the full test suite (156 files, 900 tests passed after review fixes).
+- [x] Run TypeScript typecheck.
+- [x] Run lint (0 errors; 41 pre-existing `no-explicit-any` warnings).
+- [x] Run the production build.
+- [x] Record completed items and follow-up risks below.
+
+## Post-implementation review — 2026-07-15
+
+- [x] Made `processAll()` stop-aware and made `waitForIdle()` re-check active
+      batches so shutdown cannot close storage between drain iterations.
+- [x] Made semantic daemon retrieval read-only and disabled retrieval tracing so
+      it cannot become an uncoordinated background vector writer.
+
+## Follow-up risk
+
+The project worker lock coordinates CML one-shot commands that participate in
+the lock protocol. A third-party process writing directly to the Lance path may
+still race; bounded commit-conflict retry is the defensive path for that case.

--- a/specs/vector-writer-concurrency/spec.md
+++ b/specs/vector-writer-concurrency/spec.md
@@ -1,0 +1,50 @@
+# Vector Writer Concurrency Specification
+
+> **Status**: Implemented
+> **Created**: 2026-07-15
+
+## 1. Problem
+
+Writable `MemoryService` initialization starts the legacy and V2 vector polling
+workers immediately. One-shot commands such as `import` then call
+`processPendingEmbeddings()`, which drains the same workers through
+`processAll()`. The polling call and the explicit drain can therefore enter
+`processBatch()` concurrently.
+
+Legacy LanceDB upserts are implemented as `delete(id)` followed by `add(rows)`.
+Concurrent batches can read adjacent table versions and produce an
+unresolvable Lance commit conflict (`Delete` versus `Append`). An immediate
+`process.exit(1)` can then tear down the native Lance runtime while another
+batch is still active, producing a secondary libc++ mutex abort.
+
+## 2. Required invariants
+
+1. A `VectorWorker` instance executes at most one batch at a time.
+2. A `VectorWorkerV2` instance executes at most one batch at a time.
+3. Runtime shutdown stops polling and waits for the active batch before closing
+   SQLite/shared services.
+4. Project-scoped one-shot import processing uses the same worker lock as the
+   `process` and Mongo sync commands.
+5. A recognized Lance commit conflict is retried from a newly opened table
+   handle with bounded backoff; unrelated errors fail immediately.
+6. CLI failures set a non-zero exit status only after service shutdown and lock
+   release have completed.
+
+## 3. Non-goals
+
+- Replacing LanceDB or changing the vector schema.
+- Making arbitrary user code that writes directly to LanceDB participate in
+  the project worker lock.
+- Retrying schema, permission, embedding, or general I/O failures.
+
+## 4. Acceptance criteria
+
+- Two overlapping `processBatch()` calls share one physical batch execution.
+- `processAll()` can overlap the background poll without concurrent vector
+  writes or duplicate outbox claims.
+- Shutdown does not close backing stores while a batch is active.
+- Concurrent import/process commands for the same storage scope do not both
+  become vector writers.
+- A synthetic Lance commit conflict succeeds after reopening/retrying, while a
+  non-conflict exception is returned without retry.
+- Focused tests, typecheck, and build pass.

--- a/src/adapters/claude/hooks/semantic-daemon.ts
+++ b/src/adapters/claude/hooks/semantic-daemon.ts
@@ -99,8 +99,9 @@ function getServiceForSession(sessionId: string): MemoryService {
       : path.join(os.homedir(), '.claude-code', 'memory'),
     projectHash: projectInfo?.projectHash,
     projectPath: projectInfo?.projectPath,
-    readOnly: false,
-    embeddingOnly: true,
+    // The daemon only serves retrieval requests. Keeping it read-only prevents
+    // a long-lived query process from becoming an uncoordinated Lance writer.
+    readOnly: true,
     analyticsEnabled: false,
     sharedStoreConfig: DISABLED_SHARED_STORE_CONFIG
   });
@@ -125,7 +126,8 @@ export async function handleSemanticDaemonRequest(raw: string): Promise<Semantic
         sessionId: input.sessionId,
         intentRewrite: true,
         adaptiveRerank: true,
-        projectScopeMode: 'strict'
+        projectScopeMode: 'strict',
+        recordTrace: false
       });
     } catch (error) {
       if (!isVectorSessionFilterError(error)) {
@@ -139,7 +141,8 @@ export async function handleSemanticDaemonRequest(raw: string): Promise<Semantic
         minScore: input.minScore,
         intentRewrite: true,
         adaptiveRerank: true,
-        projectScopeMode: 'strict'
+        projectScopeMode: 'strict',
+        recordTrace: false
       });
     }
 

--- a/src/adapters/claude/hooks/session-start.ts
+++ b/src/adapters/claude/hooks/session-start.ts
@@ -3,6 +3,7 @@
  * Called when a new Claude Code session starts
  */
 
+import { randomUUID } from 'crypto';
 import { getLightweightMemoryService } from '../../../services/memory-service.js';
 import { registerSession } from '../../../core/registry/session-registry.js';
 import { ensureDaemonRunning } from './semantic-daemon-client.js';
@@ -44,10 +45,34 @@ export async function main(): Promise<string> {
 
     let context = '';
     if (recentEvents.length > 0) {
+      const injectedEvents = recentEvents.slice(0, 3);
       context = `## Previous Session Context\n\nYou have worked on this project before. Here are some relevant memories:\n\n`;
-      for (const event of recentEvents.slice(0, 3)) {
+      for (const event of injectedEvents) {
         const date = event.timestamp.toISOString().split('T')[0];
         context += `- **${date}**: ${event.content.slice(0, 150)}...\n`;
+      }
+
+      // Session-start injections used to be invisible to usefulness metrics.
+      // Track them like prompt-time retrievals so helpfulness evaluation and
+      // the evidence history cover this injection path too. One shared batch
+      // id groups the injected memories into a single history entry.
+      const batchTraceId = randomUUID();
+      for (const event of injectedEvents) {
+        try {
+          await memoryService.recordRetrieval(
+            event.id,
+            input.session_id,
+            0.5,
+            '[session-start] recent project context',
+            {
+              traceId: batchTraceId,
+              source: 'session_start',
+              // Only the first 150 chars are injected above — grounding must
+              // be measured against that snapshot, not the full event.
+              injectedContent: event.content.slice(0, 150)
+            }
+          );
+        } catch { /* non-critical telemetry */ }
       }
     }
 

--- a/src/adapters/claude/hooks/user-prompt-submit.ts
+++ b/src/adapters/claude/hooks/user-prompt-submit.ts
@@ -75,12 +75,18 @@ function getDynamicMinScore(prompt: string): number {
   return BASE_MIN_SCORE;
 }
 
+/**
+ * The exact memory text placed into the prompt. Also recorded per retrieval
+ * (memory_helpfulness.injected_content) so grounding evaluation compares
+ * answers against what the model actually saw, not the full stored event.
+ */
+function memoryInjectionPreview(content: string): string {
+  return content.length > 300 ? content.substring(0, 300) + '...' : content;
+}
+
 function formatMemoryContext(items: Array<{ type: string; content: string }>): string {
   if (items.length === 0) return '';
-  const lines = items.map((m) => {
-    const preview = m.content.length > 300 ? m.content.substring(0, 300) + '...' : m.content;
-    return `- [${m.type}] ${preview}`;
-  });
+  const lines = items.map((m) => `- [${m.type}] ${memoryInjectionPreview(m.content)}`);
   return `💡 **Related memories found:**\n\n${lines.join('\n\n')}`;
 }
 
@@ -383,6 +389,10 @@ export async function main(): Promise<string> {
         getHookInjectionPolicy()
       );
 
+      // One trace id shared by the query trace and every helpfulness row it
+      // produced, so the dashboard can show question -> memories -> evidence.
+      const retrievalTraceId = randomUUID();
+
       if (injectableMemories.length > 0) {
         // Increment access count only for high-confidence memories injected into the prompt.
         const eventIds = injectableMemories.map((m) => m.id).filter((v): v is string => Boolean(v));
@@ -398,7 +408,12 @@ export async function main(): Promise<string> {
               m.id,
               input.session_id,
               m.score ?? minScore,
-              input.prompt
+              input.prompt,
+              {
+                traceId: retrievalTraceId,
+                source: 'user_prompt',
+                injectedContent: memoryInjectionPreview(m.content)
+              }
             );
           } catch { /* non-critical */ }
         }
@@ -411,6 +426,7 @@ export async function main(): Promise<string> {
       const selectedIds = injectableMemories.map((m) => m.id).filter((v): v is string => Boolean(v));
       try {
         await memoryService.recordQueryTrace({
+          traceId: retrievalTraceId,
           sessionId: input.session_id,
           queryText: retrievalQuery,
           rawQueryText: input.prompt,

--- a/src/apps/cli/codex-import-runner.ts
+++ b/src/apps/cli/codex-import-runner.ts
@@ -76,9 +76,6 @@ export async function runCodexImportOnce(
     : deps.getMemoryServiceForProject(targetProjectPath);
   const importer = deps.createImporter(memoryService, { sessionsDir: options.sessionsDir });
 
-  await memoryService.initialize();
-  await memoryService.ensureEmbeddingModelForImport({ autoMigrate: true });
-
   const importOptions: ImportOptions = {
     limit: parsePositiveInteger(options.limit, 'limit'),
     sessionLimit: parsePositiveInteger(options.sessionLimit, 'session-limit'),
@@ -91,6 +88,9 @@ export async function runCodexImportOnce(
   let result: ImportResult;
 
   try {
+    await memoryService.initialize();
+    await memoryService.ensureEmbeddingModelForImport({ autoMigrate: true });
+
     if (options.session) {
       mode = 'session';
       result = await importer.importSessionFile(options.session, {

--- a/src/apps/cli/hermes-import-runner.ts
+++ b/src/apps/cli/hermes-import-runner.ts
@@ -81,9 +81,6 @@ export async function runHermesImportOnce(
     : deps.getMemoryServiceForProject(targetProjectPath);
   const importer = deps.createImporter(memoryService, { stateDbPath: getStateDbPathOption(options) });
 
-  await memoryService.initialize();
-  await memoryService.ensureEmbeddingModelForImport({ autoMigrate: true });
-
   const importOptions: ImportOptions = {
     limit: parsePositiveInteger(options.limit, 'limit'),
     sessionLimit: parsePositiveInteger(options.sessionLimit, 'session-limit'),
@@ -96,6 +93,9 @@ export async function runHermesImportOnce(
   let result: ImportResult;
 
   try {
+    await memoryService.initialize();
+    await memoryService.ensureEmbeddingModelForImport({ autoMigrate: true });
+
     if (options.session) {
       mode = 'session';
       result = await importer.importSession(options.session, {

--- a/src/apps/cli/import-command.ts
+++ b/src/apps/cli/import-command.ts
@@ -1,0 +1,60 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { getProjectStoragePath as defaultGetProjectStoragePath } from '../../core/registry/project-path.js';
+
+export interface RawImportCommandOptions {
+  project?: string;
+  session?: string;
+  all?: boolean;
+  lockPath?: string;
+}
+
+export interface ImportCommandLockOptions {
+  storageScope: 'project' | 'global';
+  projectPath?: string;
+  lockPath: string;
+}
+
+export interface ImportCommandLockDeps {
+  cwd?: () => string;
+  homedir?: () => string;
+  getProjectStoragePath?: (projectPath: string) => string;
+}
+
+export function resolveImportCommandLockOptions(
+  options: RawImportCommandOptions,
+  deps: ImportCommandLockDeps = {}
+): ImportCommandLockOptions {
+  if (options.lockPath !== undefined && options.lockPath.trim().length === 0) {
+    throw new Error('--lock-path must not be empty');
+  }
+
+  const useGlobalStorage = options.all === true && !options.project && !options.session;
+  if (useGlobalStorage) {
+    const globalStoragePath = path.join((deps.homedir ?? os.homedir)(), '.claude-code', 'memory');
+    return {
+      storageScope: 'global',
+      lockPath: options.lockPath ?? path.join(globalStoragePath, 'vector-worker.lock')
+    };
+  }
+
+  const projectPath = options.project ?? (deps.cwd ?? (() => process.cwd()))();
+  const getProjectStoragePath = deps.getProjectStoragePath ?? defaultGetProjectStoragePath;
+  return {
+    storageScope: 'project',
+    projectPath,
+    lockPath: options.lockPath ?? path.join(getProjectStoragePath(projectPath), 'vector-worker.lock')
+  };
+}
+
+export function formatImportLockBusy(options: ImportCommandLockOptions, holderPid: number | null): string {
+  return [
+    'Another vector worker is already running; import was not started.',
+    `Storage scope: ${options.storageScope}`,
+    ...(options.projectPath ? [`Project: ${options.projectPath}`] : []),
+    `holderPid=${holderPid ?? 'unknown'}`,
+    `lockPath=${options.lockPath}`,
+    'Stop the active writer or retry after it finishes.'
+  ].join('\n');
+}

--- a/src/apps/cli/index.ts
+++ b/src/apps/cli/index.ts
@@ -107,6 +107,10 @@ import {
   resolveProcessCommandOptions
 } from './process-command.js';
 import {
+  formatImportLockBusy,
+  resolveImportCommandLockOptions
+} from './import-command.js';
+import {
   formatVectorStatusJsonReport,
   formatVectorStatusReport,
   resolveVectorStatusCommandOptions
@@ -2007,6 +2011,7 @@ program
   .option('--session-limit <number>', 'Limit recent matching sessions to import')
   .option('-f, --force', 'Force reimport: delete existing events and reimport with turn_id grouping')
   .option('--embedding-model <name>', `Embedding model override (default: ${DEFAULT_EMBEDDING_MODEL}, or env CLAUDE_MEMORY_EMBEDDING_MODEL; fallback: ${DEFAULT_EMBEDDING_FALLBACK_MODEL} or env CLAUDE_MEMORY_EMBEDDING_FALLBACK_MODEL)`)
+  .option('--lock-path <path>', 'Override vector worker lock path (advanced)')
   .option('-v, --verbose', 'Show detailed progress')
   .action(async (options) => {
     const startTime = Date.now();
@@ -2018,9 +2023,8 @@ program
       process.env.CLAUDE_MEMORY_EMBEDDING_MODEL = options.embeddingModel;
     }
 
-    // Use project-specific memory service
-    const service = getMemoryServiceForProject(targetProjectPath);
-    const importer = createSessionHistoryImporter(service);
+    let service: MemoryService | undefined;
+    let workerLock: WorkerLock | undefined;
 
     const importOpts = {
       limit: parsePositiveIntegerOption(options.limit, 'limit'),
@@ -2031,6 +2035,22 @@ program
     };
 
     try {
+      const lockOptions = resolveImportCommandLockOptions(options);
+      workerLock = new WorkerLock(lockOptions.lockPath);
+      const lockResult = workerLock.acquire();
+      if (!lockResult.acquired) {
+        console.log(formatImportLockBusy(
+          lockOptions,
+          'holderPid' in lockResult ? lockResult.holderPid : null
+        ));
+        return;
+      }
+
+      service = lockOptions.storageScope === 'global'
+        ? getDefaultMemoryService()
+        : getMemoryServiceForProject(targetProjectPath);
+      const importer = createSessionHistoryImporter(service);
+
       console.log('\n⏳ Initializing memory service...');
       await service.initialize();
       console.log(`  ✅ Ready (embedder: ${service.getEmbeddingModelName()})\n`);
@@ -2066,28 +2086,17 @@ program
         // Import all sessions from all projects
         console.log('📥 Importing all sessions from all projects');
         console.log('   ⚠️  Using global storage (use -p for project-specific)\n');
-        const globalService = getDefaultMemoryService();
-        const globalImporter = createSessionHistoryImporter(globalService);
-        await globalService.initialize();
-        console.log(`  ✅ Global service ready (embedder: ${globalService.getEmbeddingModelName()})`);
-        const globalMigration = await globalService.ensureEmbeddingModelForImport({ autoMigrate: true });
-        if (globalMigration.changed) {
-          console.log('🔁 Global embedding migration detected');
-          console.log(`   Previous: ${globalMigration.previousModel || 'legacy-unknown'}`);
-          console.log(`   Current:  ${globalMigration.currentModel}`);
-          console.log(`   Re-queued embeddings: ${globalMigration.enqueued}`);
-        }
-        result = await globalImporter.importAll(importOpts);
+        console.log(`  ✅ Global service ready (embedder: ${service.getEmbeddingModelName()})`);
+        result = await importer.importAll(importOpts);
 
         // Process embeddings
         console.log('\n🧠 Processing embeddings...');
-        const embedCount = await globalService.processPendingEmbeddings();
+        const embedCount = await service.processPendingEmbeddings();
 
         const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
         printImportSummary(result, embedCount);
         console.log(`\n⏱️  Completed in ${elapsed}s`);
 
-        await globalService.shutdown();
         return;
       } else {
         // Default: import current project
@@ -2107,10 +2116,15 @@ program
       printImportSummary(result, embedCount);
       console.log(`\n⏱️  Completed in ${elapsed}s`);
 
-      await service.shutdown();
     } catch (error) {
       console.error('\n❌ Import failed:', error);
-      process.exit(1);
+      process.exitCode = 1;
+    } finally {
+      await service?.shutdown().catch(shutdownError => {
+        console.error('\n⚠️  Import shutdown failed:', shutdownError);
+        process.exitCode = 1;
+      });
+      workerLock?.release();
     }
   });
 
@@ -2209,10 +2223,23 @@ codexCmd
   .option('--session-limit <number>', 'Limit recent matching sessions to import')
   .option('-f, --force', 'Delete existing events for each imported session before reimporting')
   .option('-v, --verbose', 'Show detailed progress')
+  .option('--lock-path <path>', 'Override vector worker lock path (advanced)')
   .option('--no-process-embeddings', 'Skip processing pending embeddings after import')
   .action(async (options) => {
     const startTime = Date.now();
+    let workerLock: WorkerLock | undefined;
     try {
+      const lockOptions = resolveImportCommandLockOptions(options);
+      workerLock = new WorkerLock(lockOptions.lockPath);
+      const lockResult = workerLock.acquire();
+      if (!lockResult.acquired) {
+        console.log(formatImportLockBusy(
+          lockOptions,
+          'holderPid' in lockResult ? lockResult.holderPid : null
+        ));
+        return;
+      }
+
       if (options.all && !options.project && !options.session) {
         console.log('\n📥 Importing all Codex sessions into global memory');
         console.log('   ⚠️  Use --project to keep memory scoped to one project.\n');
@@ -2233,7 +2260,9 @@ codexCmd
       console.log(`\n⏱️  Codex import completed in ${elapsed}s (${outcome.mode}, ${outcome.storageScope} storage)`);
     } catch (error) {
       console.error('Codex import failed:', error instanceof Error ? error.message : error);
-      process.exit(1);
+      process.exitCode = 1;
+    } finally {
+      workerLock?.release();
     }
   });
 
@@ -2292,10 +2321,23 @@ hermesCmd
   .option('--session-limit <number>', 'Limit recent matching sessions to import')
   .option('-f, --force', 'Delete existing events for each imported session before reimporting')
   .option('-v, --verbose', 'Show detailed progress')
+  .option('--lock-path <path>', 'Override vector worker lock path (advanced)')
   .option('--no-process-embeddings', 'Skip processing pending embeddings after import')
   .action(async (options) => {
     const startTime = Date.now();
+    let workerLock: WorkerLock | undefined;
     try {
+      const lockOptions = resolveImportCommandLockOptions(options);
+      workerLock = new WorkerLock(lockOptions.lockPath);
+      const lockResult = workerLock.acquire();
+      if (!lockResult.acquired) {
+        console.log(formatImportLockBusy(
+          lockOptions,
+          'holderPid' in lockResult ? lockResult.holderPid : null
+        ));
+        return;
+      }
+
       if (options.all && !options.project && !options.session) {
         console.log('\n📥 Importing all Hermes sessions into global memory');
         console.log('   ⚠️  Use --project to keep memory scoped to one project.\n');
@@ -2316,7 +2358,9 @@ hermesCmd
       console.log(`\n⏱️  Hermes import completed in ${elapsed}s (${outcome.mode}, ${outcome.storageScope} storage)`);
     } catch (error) {
       console.error('Hermes import failed:', error instanceof Error ? error.message : error);
-      process.exit(1);
+      process.exitCode = 1;
+    } finally {
+      workerLock?.release();
     }
   });
 

--- a/src/apps/dashboard/assets/js/bootstrap.js
+++ b/src/apps/dashboard/assets/js/bootstrap.js
@@ -311,6 +311,7 @@ function setupEventListeners() {
   }
 
   setupDisclosureSearchListeners();
+  setupUsefulnessViewListeners();
 }
 
 // --- Data Fetching ---

--- a/src/apps/dashboard/assets/js/overview.js
+++ b/src/apps/dashboard/assets/js/overview.js
@@ -1097,6 +1097,11 @@ function updateGraduationBars() {
 }
 
 function updateMemoryUsefulnessUI() {
+  // Keep the compact Overview strip in sync (defined in usefulness.js;
+  // absent in isolated test harnesses).
+  if (typeof updateOverviewUsefulnessStrip === 'function') {
+    updateOverviewUsefulnessStrip();
+  }
   const scoreEl = document.getElementById('memory-usefulness-score');
   const summaryEl = document.getElementById('memory-usefulness-summary');
   const breakdownEl = document.getElementById('memory-usefulness-breakdown');

--- a/src/apps/dashboard/assets/js/state.js
+++ b/src/apps/dashboard/assets/js/state.js
@@ -67,7 +67,13 @@ const state = {
   disclosureSource: null,
   isDisclosureLoading: false,
   playgroundLastRun: null,
-  isPlaygroundLoading: false
+  isPlaygroundLoading: false,
+  usefulnessWindow: '7d',
+  usefulnessHistory: [],
+  usefulnessHistoryOffset: 0,
+  usefulnessHistoryHasMore: false,
+  usefulnessHistoryFilter: true,
+  isUsefulnessHistoryLoading: false
 };
 
 // Utils

--- a/src/apps/dashboard/assets/js/usefulness.js
+++ b/src/apps/dashboard/assets/js/usefulness.js
@@ -1,0 +1,301 @@
+/**
+ * Usefulness view — memory usefulness score, helpfulness distribution, and
+ * the per-question evidence history (question → injected memories → answer
+ * snippets that prove the memory was used).
+ * Also hosts the Diagnostics view loader (vector health, operations,
+ * perspective aggregates moved off the Overview page).
+ */
+
+const USEFULNESS_HISTORY_PAGE_SIZE = 20;
+
+// --- Usefulness view ---
+
+async function loadUsefulnessView() {
+  state.usefulnessHistoryOffset = 0;
+  state.usefulnessHistory = [];
+
+  const [memoryUsefulness, helpfulness, retrievalTraces, retrievalReviewQueue, mostAccessed, adherenceSummary] = await Promise.all([
+    fetch(apiUrl(`${API_BASE}/stats/usefulness`, { window: state.usefulnessWindow || '7d' })).then(r => r.json()).catch(() => null),
+    fetch(apiUrl(`${API_BASE}/stats/helpfulness`, { limit: 5 })).then(r => r.json()).catch(() => null),
+    fetch(apiUrl(`${API_BASE}/stats/retrieval-traces`, { limit: 20 })).then(r => r.json()).catch(() => null),
+    fetch(apiUrl(`${API_BASE}/stats/retrieval-review-queue`, { limit: 10 })).then(r => r.json()).catch(() => null),
+    fetch(apiUrl(`${API_BASE}/stats/most-accessed`, { limit: 10 })).then(r => r.json()).catch(() => null),
+    fetchAdherenceSummary().catch(() => null)
+  ]);
+
+  state.memoryUsefulness = memoryUsefulness;
+  state.helpfulness = helpfulness;
+  state.retrievalTraces = retrievalTraces;
+  state.retrievalReviewQueue = retrievalReviewQueue;
+  state.mostAccessed = mostAccessed;
+  state.adherenceSummary = adherenceSummary;
+
+  updateMemoryUsefulnessUI();
+  updateHelpfulnessUI();
+  updateMostHelpfulList();
+  updateTopAccessedEventsUI();
+  updateAdherenceSummaryUI();
+  updateRetrievalTraceUI();
+
+  await loadUsefulnessHistory({ reset: true });
+}
+
+async function loadUsefulnessHistory(options = {}) {
+  const reset = Boolean(options.reset);
+  if (state.isUsefulnessHistoryLoading) return;
+  state.isUsefulnessHistoryLoading = true;
+
+  const listEl = document.getElementById('usefulness-history-list');
+  const loadMoreBtn = document.getElementById('usefulness-history-load-more');
+  if (reset) {
+    state.usefulnessHistoryOffset = 0;
+    state.usefulnessHistory = [];
+    if (listEl) listEl.innerHTML = '<div class="disclosure-empty">Loading evidence history...</div>';
+  }
+
+  try {
+    const res = await fetch(apiUrl(`${API_BASE}/stats/usefulness-history`, {
+      limit: USEFULNESS_HISTORY_PAGE_SIZE,
+      offset: state.usefulnessHistoryOffset,
+      withSelectionsOnly: state.usefulnessHistoryFilter ? 'true' : 'false'
+    }));
+    const data = await res.json();
+    const entries = data.entries || [];
+
+    state.usefulnessHistory = state.usefulnessHistory.concat(entries);
+    state.usefulnessHistoryOffset += entries.length;
+    state.usefulnessHistoryHasMore = Boolean(data.hasMore) && entries.length > 0;
+  } catch (error) {
+    console.error('Failed to load usefulness history:', error);
+    state.usefulnessHistoryHasMore = false;
+  } finally {
+    state.isUsefulnessHistoryLoading = false;
+  }
+
+  renderUsefulnessHistory();
+  if (loadMoreBtn) loadMoreBtn.hidden = !state.usefulnessHistoryHasMore;
+}
+
+function usefulnessScoreBadge(score) {
+  if (score === null || score === undefined) {
+    return '<span class="evidence-score score-pending" title="Measured automatically at session end">pending</span>';
+  }
+  const cls = score >= 0.7 ? 'score-high' : score >= 0.4 ? 'score-mid' : 'score-low';
+  return `<span class="evidence-score ${cls}">${(score * 100).toFixed(0)}%</span>`;
+}
+
+function groundingBadge(score) {
+  if (score === null || score === undefined) return '';
+  const cls = score >= 0.5 ? 'score-high' : score >= 0.3 ? 'score-mid' : 'score-low';
+  return `<span class="evidence-score ${cls}" title="How much of this memory was reused in the answer">grounding ${(score * 100).toFixed(0)}%</span>`;
+}
+
+function renderUsefulnessHistory() {
+  const listEl = document.getElementById('usefulness-history-list');
+  if (!listEl) return;
+
+  const entries = state.usefulnessHistory || [];
+  if (entries.length === 0) {
+    listEl.innerHTML = `
+      <div class="disclosure-empty">
+        No retrieval history yet. Evidence appears here after memories are injected
+        into prompts and the session ends (helpfulness is measured at session end).
+      </div>`;
+    return;
+  }
+
+  listEl.innerHTML = entries.map((entry, index) => {
+    const time = entry.createdAt ? new Date(entry.createdAt).toLocaleString() : '';
+    const isSessionStart = entry.kind === 'session_start';
+    const icon = isSessionStart ? 'ri-restart-line' : 'ri-question-line';
+    const memories = entry.memories || [];
+    const measured = memories.filter(m => m.helpfulnessScore !== null && m.helpfulnessScore !== undefined);
+    const grounded = memories.filter(m => (m.contentOverlapScore || 0) >= 0.3);
+    const bestScore = measured.length > 0 ? Math.max(...measured.map(m => m.helpfulnessScore)) : null;
+
+    const statusChips = [
+      `<span class="evidence-chip">${memories.length} injected</span>`,
+      grounded.length > 0
+        ? `<span class="evidence-chip chip-grounded"><i class="ri-double-quotes-l"></i> ${grounded.length} used in answer</span>`
+        : (measured.length > 0 ? '<span class="evidence-chip chip-unused">not reused in answer</span>' : '<span class="evidence-chip">awaiting evaluation</span>'),
+      entry.confidence ? `<span class="evidence-chip">${escapeHtml(entry.confidence)}</span>` : ''
+    ].join('');
+
+    const memoriesHtml = memories.length === 0
+      ? ((entry.selectedCount || 0) > 0
+        ? `<div class="evidence-memory-empty">${entry.selectedCount} memories were selected, but per-memory tracking is unavailable for this query (automatic retrieval or pre-upgrade data).</div>`
+        : '<div class="evidence-memory-empty">No memories were injected for this question.</div>')
+      : memories.map(m => {
+        const evidence = m.evidence || [];
+        const evidenceHtml = evidence.length === 0
+          ? ''
+          : `<div class="evidence-matches">
+              ${evidence.slice(0, 3).map(match => `
+                <div class="evidence-match">
+                  <div class="evidence-match-row">
+                    <span class="evidence-match-label"><i class="ri-brain-line"></i> memory</span>
+                    <span class="evidence-match-text">${escapeHtml(match.memorySnippet || '')}</span>
+                  </div>
+                  <div class="evidence-match-row">
+                    <span class="evidence-match-label answer"><i class="ri-chat-4-line"></i> answer</span>
+                    <span class="evidence-match-text">${escapeHtml(match.responseSnippet || '')}</span>
+                  </div>
+                  <div class="evidence-match-meta">${escapeHtml(match.matchType || '')} · ${((match.similarity || 0) * 100).toFixed(0)}% similar</div>
+                </div>
+              `).join('')}
+            </div>`;
+        return `
+          <div class="evidence-memory">
+            <div class="evidence-memory-header">
+              <span class="evidence-memory-summary" onclick="openDetailModalByEvent(${jsAttrArg(m.eventId)})" title="Open memory detail">
+                ${escapeHtml(m.summary || '(no summary)')}
+              </span>
+              <span class="evidence-memory-scores">
+                ${groundingBadge(m.contentOverlapScore)}
+                ${usefulnessScoreBadge(m.helpfulnessScore)}
+              </span>
+            </div>
+            ${evidenceHtml}
+          </div>
+        `;
+      }).join('');
+
+    return `
+      <div class="evidence-entry${bestScore !== null && bestScore >= 0.7 ? ' entry-helpful' : ''}" data-evidence-index="${index}">
+        <div class="evidence-entry-header" onclick="toggleUsefulnessEntry(${index})">
+          <i class="${icon} evidence-entry-icon"></i>
+          <div class="evidence-entry-question">
+            ${escapeHtml(entry.question || '(no question text)')}
+            <div class="evidence-entry-meta">${escapeHtml(time)}${entry.strategy ? ` · ${escapeHtml(entry.strategy)}` : ''}${entry.sessionId ? ` · session ${escapeHtml(String(entry.sessionId).slice(0, 8))}` : ''}</div>
+          </div>
+          <div class="evidence-entry-chips">${statusChips}</div>
+          <i class="ri-arrow-down-s-line evidence-entry-caret"></i>
+        </div>
+        <div class="evidence-entry-body" hidden>
+          ${memoriesHtml}
+        </div>
+      </div>
+    `;
+  }).join('');
+}
+
+function toggleUsefulnessEntry(index) {
+  const entry = document.querySelector(`.evidence-entry[data-evidence-index="${index}"]`);
+  if (!entry) return;
+  const body = entry.querySelector('.evidence-entry-body');
+  const caret = entry.querySelector('.evidence-entry-caret');
+  if (!body) return;
+  body.hidden = !body.hidden;
+  if (caret) caret.classList.toggle('open', !body.hidden);
+}
+
+// --- Overview usefulness strip (compact hero on the Overview page) ---
+
+function updateOverviewUsefulnessStrip() {
+  const scoreEl = document.getElementById('overview-usefulness-score');
+  const noteEl = document.getElementById('overview-usefulness-note');
+  const metricsEl = document.getElementById('overview-usefulness-metrics');
+  if (!scoreEl || !noteEl) return;
+
+  const payload = state.memoryUsefulness;
+  if (!payload || payload.error || !payload.score) {
+    scoreEl.textContent = '-';
+    scoreEl.className = 'memory-usefulness-score score-unknown';
+    noteEl.textContent = 'No usefulness telemetry yet — inject some memories first.';
+    if (metricsEl) metricsEl.innerHTML = '';
+    return;
+  }
+
+  const score = payload.score || {};
+  const metrics = payload.metrics || {};
+  const counts = payload.counts || {};
+  const label = score.label || 'unknown';
+  scoreEl.textContent = Number(score.value || 0).toFixed(1).replace(/\.0$/, '');
+  scoreEl.className = `memory-usefulness-score score-${label}`;
+
+  const topDiagnostic = (payload.diagnostics || [])[0];
+  noteEl.textContent = topDiagnostic
+    ? topDiagnostic.title
+    : `Memory is ${label} in the last ${payload.window || 'window'} — open Usefulness for per-question evidence.`;
+
+  if (metricsEl) {
+    const pct = (v) => v === undefined || v === null ? 'n/a' : `${(v * 100).toFixed(0)}%`;
+    metricsEl.innerHTML = `
+      <span title="Average of measured helpfulness scores"><strong>${pct(metrics.avgHelpfulnessScore)}</strong> helpfulness</span>
+      <span title="How much injected memory content reappears in answers"><strong>${pct(metrics.contentGroundingRate)}</strong> grounding</span>
+      <span title="Share of prompts that ran a memory check"><strong>${pct(metrics.memoryHitRate)}</strong> hit rate</span>
+      <span><strong>${formatNumber(counts.retrievalQueries || 0)}</strong> queries</span>
+    `;
+  }
+}
+
+// --- Diagnostics view ---
+
+async function loadDiagnosticsView() {
+  const [operationsStats, perspectiveStats, vectorHealth] = await Promise.all([
+    fetch(apiUrl(`${API_BASE}/stats/operations`, { windowDays: operationStatsWindowDays() })).then(r => r.ok ? r.json() : null).catch(() => null),
+    fetch(apiUrl(`${API_BASE}/stats/perspective`, { windowDays: operationStatsWindowDays() })).then(r => r.ok ? r.json() : null).catch(() => null),
+    fetch(apiUrl(`${API_BASE}/health`)).then(r => r.ok ? r.json() : null).catch(() => null)
+  ]);
+
+  state.operationsStats = operationsStats;
+  state.perspectiveStats = perspectiveStats;
+  state.vectorHealth = vectorHealth;
+
+  updateOperationsStatsUI();
+  updatePerspectiveStatsUI();
+  updateVectorHealthUI();
+}
+
+// --- Listeners (wired once at bootstrap) ---
+
+function setupUsefulnessViewListeners() {
+  const strip = document.getElementById('overview-usefulness-strip');
+  if (strip) {
+    strip.addEventListener('click', () => switchView('usefulness'));
+    strip.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        switchView('usefulness');
+      }
+    });
+  }
+
+  const refreshBtn = document.getElementById('usefulness-refresh');
+  if (refreshBtn) {
+    refreshBtn.addEventListener('click', () => loadUsefulnessView());
+  }
+
+  const diagnosticsRefreshBtn = document.getElementById('diagnostics-refresh');
+  if (diagnosticsRefreshBtn) {
+    diagnosticsRefreshBtn.addEventListener('click', () => loadDiagnosticsView());
+  }
+
+  const filterToggle = document.getElementById('usefulness-history-filter');
+  if (filterToggle) {
+    filterToggle.addEventListener('change', () => {
+      state.usefulnessHistoryFilter = filterToggle.checked;
+      loadUsefulnessHistory({ reset: true });
+    });
+  }
+
+  const loadMoreBtn = document.getElementById('usefulness-history-load-more');
+  if (loadMoreBtn) {
+    loadMoreBtn.addEventListener('click', () => loadUsefulnessHistory());
+  }
+
+  document.querySelectorAll('#usefulness-window-controls .sort-btn').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const windowValue = btn.dataset.useWindow;
+      if (!windowValue) return;
+      document.querySelectorAll('#usefulness-window-controls .sort-btn').forEach(b => {
+        b.classList.toggle('active', b.dataset.useWindow === windowValue);
+      });
+      state.usefulnessWindow = windowValue;
+      const memoryUsefulness = await fetch(apiUrl(`${API_BASE}/stats/usefulness`, { window: windowValue }))
+        .then(r => r.json()).catch(() => null);
+      state.memoryUsefulness = memoryUsefulness;
+      updateMemoryUsefulnessUI();
+    });
+  });
+}

--- a/src/apps/dashboard/assets/js/views.js
+++ b/src/apps/dashboard/assets/js/views.js
@@ -19,11 +19,13 @@ function switchView(viewName, options = {}) {
 
   // Load view content
   switch (viewName) {
+    case 'usefulness': return loadUsefulnessView();
     case 'knowledge-graph': return loadKnowledgeGraphView();
     case 'memory-banks': return loadMemoryBanksView();
     case 'sessions': return loadSessionInspectorView();
     case 'user-prompts': return loadUserPromptsView();
     case 'playground': return loadPlaygroundView();
+    case 'diagnostics': return loadDiagnosticsView();
     case 'configuration': return loadConfigurationView();
     default: return Promise.resolve();
   }

--- a/src/apps/dashboard/index.html
+++ b/src/apps/dashboard/index.html
@@ -48,6 +48,10 @@
             <i class="ri-dashboard-line"></i>
             <span>Overview</span>
           </li>
+          <li class="nav-item" data-nav="usefulness">
+            <i class="ri-medal-line"></i>
+            <span>Usefulness</span>
+          </li>
           <li class="nav-item" data-nav="knowledge-graph">
             <i class="ri-database-2-line"></i>
             <span>Knowledge Graph</span>
@@ -67,6 +71,10 @@
           <li class="nav-item" data-nav="playground">
             <i class="ri-flask-line"></i>
             <span>Playground</span>
+          </li>
+          <li class="nav-item" data-nav="diagnostics">
+            <i class="ri-heart-pulse-line"></i>
+            <span>Diagnostics</span>
           </li>
           <li class="nav-item" data-nav="configuration">
             <i class="ri-settings-4-line"></i>
@@ -92,8 +100,8 @@
         <!-- Header -->
         <header class="top-header">
           <div class="page-title">
-            <h1>Dashboard</h1>
-            <p>Real-time memory visualization & management</p>
+            <h1>Overview</h1>
+            <p>At-a-glance health, activity, and memory pipeline — drill into Usefulness for evidence</p>
           </div>
 
           <div class="header-actions">
@@ -153,6 +161,22 @@
             <div class="stat-label">
               <i class="ri-node-tree"></i> Vector Nodes
             </div>
+          </div>
+        </div>
+
+        <!-- Usefulness hero strip: the one-line answer to "is memory helping?" -->
+        <div class="card usefulness-strip" id="overview-usefulness-strip" role="button" tabindex="0" title="Open the Usefulness page for evidence history">
+          <div class="usefulness-strip-score">
+            <div class="memory-usefulness-score score-unknown" id="overview-usefulness-score">-</div>
+            <div class="usefulness-strip-caption">Memory Usefulness</div>
+          </div>
+          <div class="usefulness-strip-body">
+            <div id="overview-usefulness-note" class="usefulness-strip-note">Measuring whether injected memories actually helped answers…</div>
+            <div id="overview-usefulness-metrics" class="usefulness-strip-metrics"></div>
+          </div>
+          <div class="usefulness-strip-cta">
+            <span>Evidence history</span>
+            <i class="ri-arrow-right-line"></i>
           </div>
         </div>
 
@@ -258,42 +282,6 @@
             </div>
 
 
-            <!-- Progressive Disclosure Search -->
-            <div class="card disclosure-card">
-              <div class="card-header" style="align-items:flex-end;">
-                <div class="card-title">
-                  <i class="ri-search-eye-line"></i>
-                  <span>Progressive Retrieval Disclosure</span>
-                </div>
-                <div id="disclosure-scope-badge" class="scope-mini-badge">Search → Expand → Source · Project scope follows sidebar</div>
-                <div class="disclosure-controls">
-                  <label class="disclosure-toggle"><input type="checkbox" id="disclosure-include-shared"> Shared</label>
-                  <select id="disclosure-strategy" class="project-dropdown compact">
-                    <option value="auto">auto</option>
-                    <option value="fast">fast</option>
-                    <option value="deep">deep</option>
-                  </select>
-                  <input id="disclosure-topk" class="search-input compact" type="number" min="1" max="20" value="8" title="Top K">
-                </div>
-              </div>
-              <div class="disclosure-search-row">
-                <div class="search-wrapper disclosure-search-wrapper">
-                  <i class="ri-search-line"></i>
-                  <input type="text" id="disclosure-search-input" class="search-input" placeholder="Search memory with search → expand → source...">
-                </div>
-                <button id="disclosure-search-btn" class="btn btn-secondary"><i class="ri-search-eye-line"></i><span>Search</span></button>
-              </div>
-              <div id="disclosure-status" class="disclosure-status"></div>
-              <div class="disclosure-layout">
-                <div id="disclosure-results" class="disclosure-results">
-                  <div class="disclosure-empty">Search memory to inspect compact envelopes, expansion context, and raw sources.</div>
-                </div>
-                <div id="disclosure-drilldown" class="disclosure-drilldown">
-                  <div class="disclosure-empty">No result selected.</div>
-                </div>
-              </div>
-            </div>
-
             <!-- Activity Chart -->
             <div class="card">
                <div class="card-header">
@@ -322,22 +310,6 @@
                 <div id="status-dot" class="status-dot"></div>
                 <span id="status-text" style="color:var(--text-muted); font-weight:500;">Idle</span>
               </div>
-            </div>
-
-            <!-- Vector Health -->
-            <div class="card">
-              <div class="card-header" style="align-items:flex-start;">
-                <div class="card-title">
-                  <i class="ri-pulse-line"></i>
-                  <span>Vector Health</span>
-                </div>
-                <button id="vector-health-recover-btn" class="sort-btn" title="Recover stale processing and retryable failed outbox jobs">Recover</button>
-              </div>
-              <div id="vector-health-summary" style="padding:8px 0; font-size:13px; color:var(--text-muted);">Loading vector health...</div>
-              <div id="vector-health-queue-list" class="shared-list" style="margin-top:10px;">
-                <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
-              </div>
-              <div id="vector-health-recovery-result" style="padding:8px 0 0; font-size:12px; color:var(--text-muted);">No recovery run in this dashboard session.</div>
             </div>
 
             <!-- Shared Knowledge -->
@@ -387,21 +359,84 @@
                 <div class="section-label">Graduation Distribution</div>
                 <div id="graduation-bars"></div>
               </div>
+            </div>
 
-              <div style="margin-top:20px;">
-                <div class="section-label">Memory Usefulness Score</div>
-                <div class="memory-usefulness-panel">
-                  <div class="memory-usefulness-header">
-                    <div class="memory-usefulness-score score-unknown" id="memory-usefulness-score">-</div>
-                    <div id="memory-usefulness-summary" class="memory-usefulness-summary">Loading...</div>
+          </div>
+
+        </div>
+      </div>
+
+      <!-- ========== VIEW: Usefulness ========== -->
+      <div id="view-usefulness" class="page-view">
+        <header class="top-header">
+          <div class="page-title">
+            <h1>Memory Usefulness</h1>
+            <p>Did injected memories actually help? Score, per-question evidence, and retrieval quality</p>
+          </div>
+          <div class="header-actions">
+            <span id="usefulness-window-controls" style="display:flex; gap:6px;">
+              <button class="sort-btn" data-use-window="24h">24h</button>
+              <button class="sort-btn active" data-use-window="7d">7d</button>
+              <button class="sort-btn" data-use-window="30d">30d</button>
+            </span>
+            <button id="usefulness-refresh" class="btn btn-secondary">
+              <i class="ri-refresh-line"></i>
+              <span>Refresh</span>
+            </button>
+          </div>
+        </header>
+
+        <div class="usefulness-grid">
+          <!-- Left: evidence history (the star of this page) -->
+          <div class="usefulness-main-col">
+            <div class="card">
+              <div class="card-header" style="align-items:flex-end;">
+                <div>
+                  <div class="card-title">
+                    <i class="ri-chat-check-line"></i>
+                    <span>Evidence History — Question → Memories → Answer</span>
                   </div>
-                  <div id="memory-usefulness-breakdown" class="memory-usefulness-breakdown"></div>
-                  <div id="memory-usefulness-diagnostics" class="memory-usefulness-diagnostics"></div>
+                  <div class="session-muted" style="margin-top:6px;">
+                    Each question, the memories injected for it, and the answer snippets proving the memory was used.
+                  </div>
                 </div>
+                <div class="disclosure-controls">
+                  <label class="disclosure-toggle">
+                    <input type="checkbox" id="usefulness-history-filter" checked> With memories only
+                  </label>
+                </div>
+              </div>
+              <div id="usefulness-history-list" class="usefulness-history-list">
+                <div class="disclosure-empty">Loading evidence history...</div>
+              </div>
+              <div class="usefulness-history-footer">
+                <button id="usefulness-history-load-more" class="btn btn-secondary" hidden>
+                  <i class="ri-arrow-down-line"></i><span>Load more</span>
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <!-- Right: score, distribution, retrieval quality -->
+          <div class="usefulness-side-col">
+            <div class="card">
+              <div class="card-header">
+                <div class="card-title">
+                  <i class="ri-medal-line"></i>
+                  <span>Usefulness Score</span>
+                </div>
+              </div>
+              <div class="memory-usefulness-panel">
+                <div class="memory-usefulness-header">
+                  <div class="memory-usefulness-score score-unknown" id="memory-usefulness-score">-</div>
+                  <div id="memory-usefulness-summary" class="memory-usefulness-summary">Loading...</div>
+                </div>
+                <div id="memory-usefulness-breakdown" class="memory-usefulness-breakdown"></div>
+                <div id="memory-usefulness-diagnostics" class="memory-usefulness-diagnostics"></div>
               </div>
 
               <div style="margin-top:20px;">
-                <div class="section-label">Helpfulness</div>
+                <div class="section-label">Helpfulness Distribution</div>
                 <div id="helpfulness-summary" style="padding:8px 0; font-size:13px; color:var(--text-muted);">Loading...</div>
               </div>
 
@@ -430,13 +465,19 @@
                   <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
                 </div>
               </div>
+            </div>
 
-              <div style="margin-top:20px;">
-                <div class="section-label">Retrieval Trace (1:1)</div>
-                <div id="retrieval-trace-summary" style="padding:8px 0; font-size:13px; color:var(--text-muted);">Loading...</div>
-                <div id="retrieval-trace-list" class="shared-list">
-                  <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
+            <div class="card">
+              <div class="card-header">
+                <div class="card-title">
+                  <i class="ri-route-line"></i>
+                  <span>Retrieval Quality</span>
                 </div>
+              </div>
+              <div class="section-label">Retrieval Trace (1:1)</div>
+              <div id="retrieval-trace-summary" style="padding:8px 0; font-size:13px; color:var(--text-muted);">Loading...</div>
+              <div id="retrieval-trace-list" class="shared-list">
+                <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
               </div>
 
               <div style="margin-top:20px;">
@@ -447,122 +488,7 @@
                 </div>
               </div>
             </div>
-
-            <!-- Memory Operations -->
-            <div class="card">
-              <div class="card-header">
-                <div class="card-title">
-                  <i class="ri-stack-line"></i>
-                  <span>Memory Operations</span>
-                </div>
-              </div>
-              <div id="operations-stats-summary" style="padding:8px 0; font-size:13px; color:var(--text-muted);">Loading operation aggregates...</div>
-
-              <div style="margin-top:16px;">
-                <div class="section-label">Facet Dimensions</div>
-                <div id="operations-facets-list" class="shared-list">
-                  <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
-                </div>
-              </div>
-
-              <div style="margin-top:16px;">
-                <div class="section-label">Action Statuses</div>
-                <div id="operations-actions-list" class="shared-list">
-                  <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
-                </div>
-              </div>
-
-              <div style="margin-top:16px;">
-                <div class="section-label">Active Lease Types</div>
-                <div id="operations-leases-list" class="shared-list">
-                  <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
-                </div>
-              </div>
-
-              <div style="margin-top:16px;">
-                <div class="section-label">Retention Decisions</div>
-                <div id="operations-retention-list" class="shared-list">
-                  <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
-                </div>
-              </div>
-
-              <div style="margin-top:16px;">
-                <div class="section-label">Governance Audit by Day</div>
-                <div id="operations-governance-list" class="shared-list">
-                  <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
-                </div>
-              </div>
-
-              <div style="margin-top:16px;">
-                <div class="section-label">Lesson Confidence</div>
-                <div id="operations-lessons-list" class="shared-list">
-                  <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
-                </div>
-              </div>
-            </div>
-
-            <!-- Perspective Memory -->
-            <div class="card">
-              <div class="card-header">
-                <div class="card-title">
-                  <i class="ri-team-line"></i>
-                  <span>Perspective Memory</span>
-                </div>
-              </div>
-              <div id="perspective-stats-summary" style="padding:8px 0; font-size:13px; color:var(--text-muted);">Loading perspective aggregates...</div>
-
-              <div style="margin-top:16px;">
-                <div class="section-label">Actor Card Panel</div>
-                <div id="perspective-cards-list" class="shared-list">
-                  <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
-                </div>
-              </div>
-
-              <div style="margin-top:16px;">
-                <div class="section-label">Actors & Session Membership</div>
-                <div id="perspective-actors-list" class="shared-list">
-                  <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
-                </div>
-              </div>
-
-              <div style="margin-top:16px;">
-                <div class="section-label">Observation Timeline / Filters</div>
-                <div id="perspective-observations-list" class="shared-list">
-                  <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
-                </div>
-              </div>
-
-              <div style="margin-top:16px;">
-                <div class="section-label">Observer → Observed Graph</div>
-                <div id="perspective-graph-list" class="shared-list">
-                  <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
-                </div>
-              </div>
-
-              <div style="margin-top:16px;">
-                <div class="section-label">Source Evidence Coverage</div>
-                <div id="perspective-evidence-list" class="shared-list">
-                  <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
-                </div>
-              </div>
-
-              <div style="margin-top:16px;">
-                <div class="section-label">Contradiction Review Queue</div>
-                <div id="perspective-contradictions-list" class="shared-list">
-                  <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
-                </div>
-              </div>
-
-              <div style="margin-top:16px;">
-                <div class="section-label">What Changed After Consolidation?</div>
-                <div id="perspective-activity-list" class="shared-list">
-                  <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
-                </div>
-              </div>
-            </div>
-
           </div>
-
         </div>
       </div>
 
@@ -723,6 +649,189 @@
             <div class="disclosure-empty">Expansion/source details will appear here.</div>
           </div>
         </div>
+
+        <!-- Progressive Disclosure Search -->
+        <div class="card disclosure-card" style="margin-top:16px;">
+          <div class="card-header" style="align-items:flex-end;">
+            <div class="card-title">
+              <i class="ri-search-eye-line"></i>
+              <span>Progressive Retrieval Disclosure</span>
+            </div>
+            <div id="disclosure-scope-badge" class="scope-mini-badge">Search → Expand → Source · Project scope follows sidebar</div>
+            <div class="disclosure-controls">
+              <label class="disclosure-toggle"><input type="checkbox" id="disclosure-include-shared"> Shared</label>
+              <select id="disclosure-strategy" class="project-dropdown compact">
+                <option value="auto">auto</option>
+                <option value="fast">fast</option>
+                <option value="deep">deep</option>
+              </select>
+              <input id="disclosure-topk" class="search-input compact" type="number" min="1" max="20" value="8" title="Top K">
+            </div>
+          </div>
+          <div class="disclosure-search-row">
+            <div class="search-wrapper disclosure-search-wrapper">
+              <i class="ri-search-line"></i>
+              <input type="text" id="disclosure-search-input" class="search-input" placeholder="Search memory with search → expand → source...">
+            </div>
+            <button id="disclosure-search-btn" class="btn btn-secondary"><i class="ri-search-eye-line"></i><span>Search</span></button>
+          </div>
+          <div id="disclosure-status" class="disclosure-status"></div>
+          <div class="disclosure-layout">
+            <div id="disclosure-results" class="disclosure-results">
+              <div class="disclosure-empty">Search memory to inspect compact envelopes, expansion context, and raw sources.</div>
+            </div>
+            <div id="disclosure-drilldown" class="disclosure-drilldown">
+              <div class="disclosure-empty">No result selected.</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ========== VIEW: Diagnostics ========== -->
+      <div id="view-diagnostics" class="page-view">
+        <header class="top-header">
+          <div class="page-title">
+            <h1>Diagnostics</h1>
+            <p>Internal pipeline health: vector queues, memory operations, and perspective layers</p>
+          </div>
+          <div class="header-actions">
+            <button id="diagnostics-refresh" class="btn btn-secondary">
+              <i class="ri-refresh-line"></i>
+              <span>Refresh</span>
+            </button>
+          </div>
+        </header>
+
+        <div class="diagnostics-grid">
+          <!-- Vector Health -->
+          <div class="card">
+            <div class="card-header" style="align-items:flex-start;">
+              <div class="card-title">
+                <i class="ri-pulse-line"></i>
+                <span>Vector Health</span>
+              </div>
+              <button id="vector-health-recover-btn" class="sort-btn" title="Recover stale processing and retryable failed outbox jobs">Recover</button>
+            </div>
+            <div id="vector-health-summary" style="padding:8px 0; font-size:13px; color:var(--text-muted);">Loading vector health...</div>
+            <div id="vector-health-queue-list" class="shared-list" style="margin-top:10px;">
+              <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
+            </div>
+            <div id="vector-health-recovery-result" style="padding:8px 0 0; font-size:12px; color:var(--text-muted);">No recovery run in this dashboard session.</div>
+          </div>
+
+          <!-- Memory Operations -->
+          <div class="card">
+            <div class="card-header">
+              <div class="card-title">
+                <i class="ri-stack-line"></i>
+                <span>Memory Operations</span>
+              </div>
+            </div>
+            <div id="operations-stats-summary" style="padding:8px 0; font-size:13px; color:var(--text-muted);">Loading operation aggregates...</div>
+
+            <div style="margin-top:16px;">
+              <div class="section-label">Facet Dimensions</div>
+              <div id="operations-facets-list" class="shared-list">
+                <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
+              </div>
+            </div>
+
+            <div style="margin-top:16px;">
+              <div class="section-label">Action Statuses</div>
+              <div id="operations-actions-list" class="shared-list">
+                <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
+              </div>
+            </div>
+
+            <div style="margin-top:16px;">
+              <div class="section-label">Active Lease Types</div>
+              <div id="operations-leases-list" class="shared-list">
+                <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
+              </div>
+            </div>
+
+            <div style="margin-top:16px;">
+              <div class="section-label">Retention Decisions</div>
+              <div id="operations-retention-list" class="shared-list">
+                <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
+              </div>
+            </div>
+
+            <div style="margin-top:16px;">
+              <div class="section-label">Governance Audit by Day</div>
+              <div id="operations-governance-list" class="shared-list">
+                <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
+              </div>
+            </div>
+
+            <div style="margin-top:16px;">
+              <div class="section-label">Lesson Confidence</div>
+              <div id="operations-lessons-list" class="shared-list">
+                <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Perspective Memory -->
+          <div class="card">
+            <div class="card-header">
+              <div class="card-title">
+                <i class="ri-team-line"></i>
+                <span>Perspective Memory</span>
+              </div>
+            </div>
+            <div id="perspective-stats-summary" style="padding:8px 0; font-size:13px; color:var(--text-muted);">Loading perspective aggregates...</div>
+
+            <div style="margin-top:16px;">
+              <div class="section-label">Actor Card Panel</div>
+              <div id="perspective-cards-list" class="shared-list">
+                <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
+              </div>
+            </div>
+
+            <div style="margin-top:16px;">
+              <div class="section-label">Actors & Session Membership</div>
+              <div id="perspective-actors-list" class="shared-list">
+                <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
+              </div>
+            </div>
+
+            <div style="margin-top:16px;">
+              <div class="section-label">Observation Timeline / Filters</div>
+              <div id="perspective-observations-list" class="shared-list">
+                <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
+              </div>
+            </div>
+
+            <div style="margin-top:16px;">
+              <div class="section-label">Observer → Observed Graph</div>
+              <div id="perspective-graph-list" class="shared-list">
+                <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
+              </div>
+            </div>
+
+            <div style="margin-top:16px;">
+              <div class="section-label">Source Evidence Coverage</div>
+              <div id="perspective-evidence-list" class="shared-list">
+                <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
+              </div>
+            </div>
+
+            <div style="margin-top:16px;">
+              <div class="section-label">Contradiction Review Queue</div>
+              <div id="perspective-contradictions-list" class="shared-list">
+                <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
+              </div>
+            </div>
+
+            <div style="margin-top:16px;">
+              <div class="section-label">What Changed After Consolidation?</div>
+              <div id="perspective-activity-list" class="shared-list">
+                <div style="padding:12px; text-align:center; color:var(--text-muted); font-size:13px;">Loading...</div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
 
       <!-- ========== VIEW: Configuration ========== -->
@@ -816,6 +925,7 @@
   <script src="assets/js/overview.js"></script>
   <script src="assets/js/modals.js"></script>
   <script src="assets/js/views.js"></script>
+  <script src="assets/js/usefulness.js"></script>
   <script src="assets/js/chat.js"></script>
   <script src="assets/js/disclosure.js"></script>
 </body>

--- a/src/apps/dashboard/style.css
+++ b/src/apps/dashboard/style.css
@@ -2401,3 +2401,323 @@ body {
   border-color: rgba(0, 240, 255, 0.18);
 }
 
+
+/* ============================================================
+   Usefulness page & Overview usefulness strip
+   ============================================================ */
+
+.usefulness-strip {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin-bottom: 24px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.15s ease;
+}
+
+.usefulness-strip:hover,
+.usefulness-strip:focus-visible {
+  border-color: var(--accent-primary);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.usefulness-strip-score {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  min-width: 96px;
+}
+
+.usefulness-strip-caption {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+}
+
+.usefulness-strip-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.usefulness-strip-note {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin-bottom: 6px;
+}
+
+.usefulness-strip-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.usefulness-strip-metrics strong {
+  color: var(--text-primary);
+}
+
+.usefulness-strip-cta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--accent-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.usefulness-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+  gap: 24px;
+  align-items: start;
+}
+
+.usefulness-side-col {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+@media (max-width: 1200px) {
+  .usefulness-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Evidence history */
+
+.usefulness-history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.usefulness-history-footer {
+  margin-top: 14px;
+  text-align: center;
+}
+
+.evidence-entry {
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  background: rgba(15, 16, 25, 0.5);
+  overflow: hidden;
+}
+
+.evidence-entry.entry-helpful {
+  border-left: 3px solid var(--success);
+}
+
+.evidence-entry-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.evidence-entry-header:hover {
+  background: rgba(123, 97, 255, 0.08);
+}
+
+.evidence-entry-icon {
+  font-size: 16px;
+  color: var(--accent-primary);
+  flex-shrink: 0;
+}
+
+.evidence-entry-question {
+  flex: 1;
+  min-width: 0;
+  font-size: 13px;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.evidence-entry-meta {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-top: 3px;
+}
+
+.evidence-entry-chips {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.evidence-chip {
+  font-size: 11px;
+  color: var(--text-secondary);
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 999px;
+  padding: 2px 9px;
+  white-space: nowrap;
+}
+
+.evidence-chip.chip-grounded {
+  color: var(--success);
+  background: rgba(0, 227, 150, 0.12);
+}
+
+.evidence-chip.chip-unused {
+  color: var(--warning);
+  background: rgba(254, 176, 25, 0.12);
+}
+
+.evidence-entry-caret {
+  color: var(--text-muted);
+  transition: transform 0.2s ease;
+  flex-shrink: 0;
+}
+
+.evidence-entry-caret.open {
+  transform: rotate(180deg);
+}
+
+.evidence-entry-body {
+  border-top: 1px solid var(--border-subtle);
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.evidence-memory-empty {
+  font-size: 12px;
+  color: var(--text-muted);
+  text-align: center;
+  padding: 8px;
+}
+
+.evidence-memory {
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  padding: 10px 12px;
+  background: rgba(22, 23, 35, 0.55);
+}
+
+.evidence-memory-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.evidence-memory-summary {
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.evidence-memory-summary:hover {
+  color: var(--accent-secondary);
+}
+
+.evidence-memory-scores {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.evidence-score {
+  font-size: 11px;
+  font-weight: 600;
+  border-radius: 6px;
+  padding: 2px 7px;
+  white-space: nowrap;
+}
+
+.evidence-score.score-high {
+  color: var(--success);
+  background: rgba(0, 227, 150, 0.12);
+}
+
+.evidence-score.score-mid {
+  color: var(--warning);
+  background: rgba(254, 176, 25, 0.12);
+}
+
+.evidence-score.score-low {
+  color: var(--error);
+  background: rgba(255, 69, 96, 0.12);
+}
+
+.evidence-score.score-pending {
+  color: var(--text-muted);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.evidence-matches {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.evidence-match {
+  border-left: 2px solid var(--accent-primary);
+  padding: 6px 10px;
+  background: rgba(123, 97, 255, 0.06);
+  border-radius: 0 8px 8px 0;
+}
+
+.evidence-match-row {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  font-size: 12px;
+}
+
+.evidence-match-label {
+  color: var(--accent-primary);
+  font-size: 10.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  flex-shrink: 0;
+  width: 68px;
+}
+
+.evidence-match-label.answer {
+  color: var(--accent-secondary);
+}
+
+.evidence-match-text {
+  color: var(--text-secondary);
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.evidence-match-meta {
+  font-size: 10.5px;
+  color: var(--text-muted);
+  margin-top: 3px;
+}
+
+/* Diagnostics page */
+
+.diagnostics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  gap: 24px;
+  align-items: start;
+}

--- a/src/apps/server/api/stats.ts
+++ b/src/apps/server/api/stats.ts
@@ -666,6 +666,7 @@ type KpiMetrics = {
 
 type MemoryUsefulnessComponentKey =
   | 'avgHelpfulnessScore'
+  | 'contentGroundingRate'
   | 'usefulRecallRate'
   | 'memoryHitRate'
   | 'retrievalUsageRate'
@@ -698,6 +699,9 @@ type HelpfulnessStatsLike = {
   helpful?: number;
   neutral?: number;
   unhelpful?: number;
+  contentEvaluated?: number;
+  avgContentOverlap?: number;
+  groundedCount?: number;
 };
 
 type RetrievalTraceLike = {
@@ -1001,6 +1005,7 @@ function buildMemoryUsefulnessDiagnostics(input: {
     queryYieldRate: number;
     evaluationCoverage: number;
     selectionRate: number;
+    contentGroundingRate?: number;
   };
   counts: {
     promptCount: number;
@@ -1011,6 +1016,7 @@ function buildMemoryUsefulnessDiagnostics(input: {
     candidateMemories: number;
     totalEvaluated: number;
     totalRetrievals: number;
+    contentEvaluated?: number;
   };
 }): MemoryUsefulnessDiagnostic[] {
   const { metrics, counts } = input;
@@ -1065,6 +1071,21 @@ function buildMemoryUsefulnessDiagnostics(input: {
       title: 'Injected memories are not translating into outcomes',
       detail: `${counts.totalEvaluated} evaluated retrievals averaged ${(metrics.avgHelpfulnessScore * 100).toFixed(1)}% helpfulness.`,
       action: 'Review low-scoring retrieval samples for stale decisions, cross-project noise, or raw transcript snippets.'
+    });
+  }
+
+  const contentEvaluated = counts.contentEvaluated ?? 0;
+  const contentGroundingRate = metrics.contentGroundingRate ?? 0;
+  if (contentEvaluated >= 5 && contentGroundingRate < 0.3) {
+    diagnostics.push({
+      key: 'low-content-grounding',
+      severity: 'warn',
+      metric: 'contentGroundingRate',
+      value: contentGroundingRate,
+      target: 0.3,
+      title: 'Answers rarely reuse injected memory content',
+      detail: `${contentEvaluated} retrievals were checked against later responses, but grounding averaged ${(contentGroundingRate * 100).toFixed(1)}%.`,
+      action: 'Injected memories may be topically related but not actionable. Review the evidence history for memories that never appear in answers, and tighten injection thresholds or improve memory quality.'
     });
   }
 
@@ -1163,6 +1184,9 @@ function computeMemoryUsefulnessSummary(
   const helpful = Number(helpfulness.helpful || 0);
   const neutral = Number(helpfulness.neutral || 0);
   const unhelpful = Number(helpfulness.unhelpful || 0);
+  const contentEvaluated = Number(helpfulness.contentEvaluated || 0);
+  const avgContentOverlap = Number(helpfulness.avgContentOverlap || 0);
+  const groundedCount = Number(helpfulness.groundedCount || 0);
 
   const retrievalsPerPrompt = safeRatio(retrievalQueries, promptCount);
   const metrics = {
@@ -1171,6 +1195,8 @@ function computeMemoryUsefulnessSummary(
     memoryHitRate: round(safeRatio(memoryCheckedPrompts, promptCount)),
     retrievalUsageRate: round(Math.min(1, retrievalsPerPrompt)),
     queryYieldRate: round(safeRatio(queriesWithSelected, retrievalQueries)),
+    contentGroundingRate: round(normalizeMetric(avgContentOverlap)),
+    groundedRecallRate: round(safeRatio(groundedCount, contentEvaluated)),
     evaluationCoverage: round(safeRatio(totalEvaluated, totalRetrievals)),
     retrievalsPerPrompt: round(retrievalsPerPrompt),
     avgCandidatesPerQuery: round(safeRatio(totalCandidateCount, retrievalQueries), 2),
@@ -1197,13 +1223,16 @@ function computeMemoryUsefulnessSummary(
     totalRetrievals,
     helpful,
     neutral,
-    unhelpful
+    unhelpful,
+    contentEvaluated,
+    groundedCount
   };
 
   const componentSpecs: Omit<MemoryUsefulnessComponent, 'contribution'>[] = [
-    { key: 'avgHelpfulnessScore', label: 'Average helpfulness score', value: metrics.avgHelpfulnessScore, weight: 0.3, available: totalEvaluated > 0 },
-    { key: 'usefulRecallRate', label: 'Useful recall rate', value: metrics.usefulRecallRate, weight: 0.25, available: totalEvaluated > 0 },
-    { key: 'memoryHitRate', label: 'Memory hit rate', value: metrics.memoryHitRate, weight: 0.2, available: promptCount > 0 },
+    { key: 'avgHelpfulnessScore', label: 'Average helpfulness score', value: metrics.avgHelpfulnessScore, weight: 0.25, available: totalEvaluated > 0 },
+    { key: 'contentGroundingRate', label: 'Answer grounding rate', value: metrics.contentGroundingRate, weight: 0.15, available: contentEvaluated > 0 },
+    { key: 'usefulRecallRate', label: 'Useful recall rate', value: metrics.usefulRecallRate, weight: 0.2, available: totalEvaluated > 0 },
+    { key: 'memoryHitRate', label: 'Memory hit rate', value: metrics.memoryHitRate, weight: 0.15, available: promptCount > 0 },
     { key: 'retrievalUsageRate', label: 'Retrieval usage rate', value: metrics.retrievalUsageRate, weight: 0.15, available: promptCount > 0 },
     { key: 'queryYieldRate', label: 'Query yield rate', value: metrics.queryYieldRate, weight: 0.1, available: retrievalQueries > 0 }
   ];
@@ -1805,6 +1834,53 @@ statsRouter.get('/usefulness', async (c) => {
   } catch (error) {
     console.error('[stats/usefulness] failed to calculate dashboard metrics', error);
     return c.json({ error: 'Unable to calculate memory usefulness statistics' }, 500);
+  } finally {
+    await memoryService.shutdown();
+  }
+});
+
+// GET /api/stats/usefulness-history - Per-question evidence history:
+// which memories were injected for each question, how helpful they measured,
+// and the matched answer snippets that justify the score.
+statsRouter.get('/usefulness-history', async (c) => {
+  const limit = Math.min(parseInt(c.req.query('limit') || '20', 10) || 20, 100);
+  const offset = Math.max(parseInt(c.req.query('offset') || '0', 10) || 0, 0);
+  const sessionId = c.req.query('sessionId') || undefined;
+  const withSelectionsOnly = c.req.query('withSelectionsOnly') === 'true';
+  const memoryService = getLightweightServiceFromQuery(c);
+
+  try {
+    await memoryService.initialize();
+    const entries = await memoryService.getUsefulnessHistory({
+      limit,
+      offset,
+      sessionId,
+      withSelectionsOnly
+    });
+
+    return c.json({
+      limit,
+      offset,
+      hasMore: entries.length >= limit,
+      entries: entries.map((entry) => ({
+        traceId: entry.traceId,
+        kind: entry.kind,
+        sessionId: entry.sessionId,
+        // The user's question (raw prompt) is the point of this endpoint and
+        // is already exposed by /api/events; the rewritten query text is
+        // intentionally omitted (matches /api/stats/retrieval-traces).
+        question: entry.question,
+        strategy: entry.strategy,
+        confidence: entry.confidence,
+        candidateCount: entry.candidateCount,
+        selectedCount: entry.selectedCount,
+        createdAt: entry.createdAt.toISOString(),
+        memories: entry.memories
+      }))
+    });
+  } catch (error) {
+    console.error('[stats/usefulness-history] failed to load evidence history', error);
+    return c.json({ limit, offset, hasMore: false, entries: [] });
   } finally {
     await memoryService.shutdown();
   }

--- a/src/core/engine/memory-runtime-service.ts
+++ b/src/core/engine/memory-runtime-service.ts
@@ -150,8 +150,16 @@ export function createMemoryRuntimeService(deps: MemoryRuntimeServicesDeps): Mem
         vectorWorkerV2.stop();
       }
 
-      await deps.sharedMemoryServices.close();
-      await deps.sqliteStore.close();
+      await Promise.all([
+        vectorWorker?.waitForIdle(),
+        vectorWorkerV2?.waitForIdle()
+      ]);
+
+      try {
+        await deps.sharedMemoryServices.close();
+      } finally {
+        await deps.sqliteStore.close();
+      }
     },
 
     async processPendingEmbeddings(): Promise<number> {

--- a/src/core/engine/retrieval-analytics-service.ts
+++ b/src/core/engine/retrieval-analytics-service.ts
@@ -45,6 +45,53 @@ export interface HelpfulnessStats {
   helpful: number;
   neutral: number;
   unhelpful: number;
+  /** Evaluated retrievals that had responses to check content grounding against */
+  contentEvaluated?: number;
+  /** Average content-grounding score (0..1) over contentEvaluated rows */
+  avgContentOverlap?: number;
+  /** Rows whose content grounding cleared the "actually used" threshold */
+  groundedCount?: number;
+}
+
+export interface UsefulnessEvidenceMatch {
+  memorySnippet: string;
+  responseSnippet: string;
+  responseEventId: string;
+  similarity: number;
+  matchType: string;
+}
+
+export interface UsefulnessHistoryMemory {
+  eventId: string;
+  eventType: string | null;
+  summary: string;
+  retrievalScore: number;
+  helpfulnessScore: number | null;
+  contentOverlapScore: number | null;
+  evidence: UsefulnessEvidenceMatch[];
+  measuredAt: string | null;
+  source: string;
+}
+
+export interface UsefulnessHistoryEntry {
+  traceId: string | null;
+  kind: 'query' | 'session_start';
+  sessionId: string | null;
+  question: string;
+  queryText: string | null;
+  strategy: string | null;
+  confidence: string | null;
+  candidateCount: number;
+  selectedCount: number;
+  createdAt: Date;
+  memories: UsefulnessHistoryMemory[];
+}
+
+export interface UsefulnessHistoryOptions {
+  limit?: number;
+  offset?: number;
+  sessionId?: string;
+  withSelectionsOnly?: boolean;
 }
 
 export interface HelpfulMemory {
@@ -106,6 +153,7 @@ export interface RetrievalAnalyticsStore {
   getUnevaluatedSessions(currentSessionId: string, limit?: number): Promise<string[]>;
   getHelpfulMemories(limit?: number): Promise<HelpfulMemory[]>;
   getHelpfulnessStats(since?: Date): Promise<HelpfulnessStats>;
+  getUsefulnessHistory?(options?: UsefulnessHistoryOptions): Promise<UsefulnessHistoryEntry[]>;
 }
 
 export interface RetrievalAnalyticsServiceDeps {
@@ -169,6 +217,16 @@ export class RetrievalAnalyticsService {
   async getHelpfulnessStats(since?: Date): Promise<HelpfulnessStats> {
     await this.deps.initialize();
     return this.deps.retrievalStore.getHelpfulnessStats(since);
+  }
+
+  /**
+   * Per-question evidence history: which memories were injected for each
+   * retrieval query and how useful they turned out to be.
+   */
+  async getUsefulnessHistory(options: UsefulnessHistoryOptions = {}): Promise<UsefulnessHistoryEntry[]> {
+    await this.deps.initialize();
+    if (!this.deps.retrievalStore.getUsefulnessHistory) return [];
+    return this.deps.retrievalStore.getUsefulnessHistory(options);
   }
 
   /**

--- a/src/core/engine/retrieval-orchestrator.ts
+++ b/src/core/engine/retrieval-orchestrator.ts
@@ -43,6 +43,8 @@ export interface RetrieveMemoriesOptions {
 }
 
 export interface RecordQueryTraceInput {
+  /** Caller-provided trace id so helpfulness rows can link back to this trace */
+  traceId?: string;
   sessionId?: string;
   queryText: string;
   rawQueryText?: string;
@@ -80,6 +82,7 @@ interface RetrievalTraceDetail {
 export interface RetrievalTraceStore {
   getHelpfulnessStats(): Promise<HelpfulnessStats>;
   recordRetrievalTrace(input: {
+    traceId?: string;
     sessionId?: string;
     projectHash?: string;
     queryText: string;
@@ -97,7 +100,13 @@ export interface RetrievalTraceStore {
 
 export interface RetrievalAccessStore {
   incrementAccessCount(eventIds: string[]): Promise<void>;
-  recordRetrieval(eventId: string, sessionId: string, score: number, query: string): Promise<void>;
+  recordRetrieval(
+    eventId: string,
+    sessionId: string,
+    score: number,
+    query: string,
+    options?: { traceId?: string; source?: string; injectedContent?: string }
+  ): Promise<void>;
 }
 
 export interface RetrievalOrchestratorDeps {
@@ -227,10 +236,11 @@ export class RetrievalOrchestrator {
     eventId: string,
     sessionId: string,
     score: number,
-    query: string
+    query: string,
+    options?: { traceId?: string; source?: string; injectedContent?: string }
   ): Promise<void> {
     await this.deps.initialize();
-    await this.deps.accessStore.recordRetrieval(eventId, sessionId, score, query);
+    await this.deps.accessStore.recordRetrieval(eventId, sessionId, score, query, options);
   }
 
   private resolveGraphHopOptions(

--- a/src/core/engine/retrieval-services.ts
+++ b/src/core/engine/retrieval-services.ts
@@ -146,7 +146,11 @@ export type {
   RetrievalAnalyticsServiceDeps,
   RetrievalAnalyticsStore,
   RetrievalTrace,
-  RetrievalTraceStats
+  RetrievalTraceStats,
+  UsefulnessEvidenceMatch,
+  UsefulnessHistoryEntry,
+  UsefulnessHistoryMemory,
+  UsefulnessHistoryOptions
 } from './retrieval-analytics-service.js';
 export {
   RetrievalDisclosureService,

--- a/src/core/sqlite-event-store.ts
+++ b/src/core/sqlite-event-store.ts
@@ -37,6 +37,7 @@ import {
 import { MarkdownMirror } from './markdown-mirror.js';
 import { VectorOutbox, type OutboxConfig } from './vector-outbox.js';
 import { normalizeRetrievalDebugLanes, type RetrievalDebugLane } from './retrieval-debug-lanes.js';
+import { computeMemoryUsageEvidence, type EvidenceMatch } from './usefulness-evidence.js';
 
 export interface SQLiteEventStoreOptions extends SQLiteOptions {
   markdownMirrorRoot?: string;
@@ -903,6 +904,21 @@ export class SQLiteEventStore {
       }
     } catch {
       // action edge table may not exist in partial migrations
+    }
+
+    // Best-effort forward migration for helpfulness evidence columns:
+    // trace_id links each injected memory back to its retrieval_traces row
+    // (question -> memory), content grounding measures whether later
+    // assistant responses actually reused the memory's content.
+    this.addColumnIfMissing('memory_helpfulness', 'trace_id', 'TEXT');
+    this.addColumnIfMissing('memory_helpfulness', 'source', `TEXT DEFAULT 'user_prompt'`);
+    this.addColumnIfMissing('memory_helpfulness', 'content_overlap_score', 'REAL');
+    this.addColumnIfMissing('memory_helpfulness', 'evidence_json', 'TEXT');
+    this.addColumnIfMissing('memory_helpfulness', 'injected_content', 'TEXT');
+    try {
+      sqliteExec(this.db, `CREATE INDEX IF NOT EXISTS idx_helpfulness_trace ON memory_helpfulness(trace_id);`);
+    } catch {
+      // index/table may not exist in partial migrations
     }
 
     // Best-effort forward migration for retrieval trace detail columns
@@ -2206,16 +2222,31 @@ export class SQLiteEventStore {
   /**
    * Record a memory retrieval for helpfulness tracking
    */
-  async recordRetrieval(eventId: string, sessionId: string, score: number, query: string): Promise<void> {
+  async recordRetrieval(
+    eventId: string,
+    sessionId: string,
+    score: number,
+    query: string,
+    options?: { traceId?: string; source?: string; injectedContent?: string }
+  ): Promise<void> {
     if (this.readOnly) return;
     await this.initialize();
 
     const id = randomUUID();
+    // created_at needs millisecond precision: datetime('now') is second-only,
+    // so the triggering prompt (stored moments earlier with an ISO ms
+    // timestamp in the same second) would count as "after" the retrieval.
     sqliteRun(
       this.db,
-      `INSERT INTO memory_helpfulness (id, event_id, session_id, retrieval_score, query_preview, created_at)
-       VALUES (?, ?, ?, ?, ?, datetime('now'))`,
-      [id, eventId, sessionId, score, query.slice(0, 100)]
+      `INSERT INTO memory_helpfulness (id, event_id, session_id, retrieval_score, query_preview, trace_id, source, injected_content, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        id, eventId, sessionId, score, query.slice(0, 200),
+        options?.traceId || null,
+        options?.source || 'user_prompt',
+        options?.injectedContent ? options.injectedContent.slice(0, 2000) : null,
+        new Date().toISOString()
+      ]
     );
   }
 
@@ -2261,6 +2292,21 @@ export class SQLiteEventStore {
 
     const promptEvents = sessionEvents.filter((e: any) => e.event_type === 'user_prompt');
     const toolEvents = sessionEvents.filter((e: any) => e.event_type === 'tool_observation');
+    const responseEvents = sessionEvents.filter((e: any) => e.event_type === 'agent_response');
+
+    // Look up the injected memories' content once so each retrieval can be
+    // checked for content grounding against the responses that followed it.
+    const retrievedEventIds = Array.from(new Set(retrievals.map((r) => r.event_id as string).filter(Boolean)));
+    const memoryContentById = new Map<string, string>();
+    for (let i = 0; i < retrievedEventIds.length; i += 100) {
+      const chunk = retrievedEventIds.slice(i, i + 100);
+      const rows = sqliteAll<{ id: string; content: string }>(
+        this.db,
+        `SELECT id, content FROM events WHERE id IN (${chunk.map(() => '?').join(',')})`,
+        chunk
+      );
+      for (const row of rows) memoryContentById.set(row.id, row.content);
+    }
 
     // Count successful vs failed tools
     let toolSuccessCount = 0;
@@ -2275,15 +2321,25 @@ export class SQLiteEventStore {
     }
     const toolSuccessRatio = toolTotalCount > 0 ? toolSuccessCount / toolTotalCount : 0.5;
 
+    // Events store ISO timestamps while memory_helpfulness.created_at uses
+    // SQLite datetime('now') ("YYYY-MM-DD HH:MM:SS", UTC). Comparing the raw
+    // strings marks any same-day event as "after", so compare epoch millis.
+    const toEpochMs = (value: unknown): number => {
+      const raw = String(value || '');
+      const iso = raw.includes('T') ? raw : `${raw.replace(' ', 'T')}Z`;
+      const ms = new Date(iso).getTime();
+      return Number.isFinite(ms) ? ms : 0;
+    };
+
     for (const retrieval of retrievals) {
-      const retrievalTime = retrieval.created_at as string;
+      const retrievalTimeMs = toEpochMs(retrieval.created_at);
 
       // 1. Session continued after retrieval?
-      const eventsAfter = sessionEvents.filter((e: any) => e.timestamp > retrievalTime);
+      const eventsAfter = sessionEvents.filter((e: any) => toEpochMs(e.timestamp) > retrievalTimeMs);
       const sessionContinued = eventsAfter.length > 0 ? 1 : 0;
 
       // 2. How many prompts came after?
-      const promptsAfter = promptEvents.filter((e: any) => e.timestamp > retrievalTime);
+      const promptsAfter = promptEvents.filter((e: any) => toEpochMs(e.timestamp) > retrievalTimeMs);
       const promptCountAfter = promptsAfter.length;
 
       // 3. Was a similar query asked again? (simple word overlap check)
@@ -2301,18 +2357,51 @@ export class SQLiteEventStore {
         }
       }
 
+      // 4. Content grounding: did the assistant responses after this
+      //    retrieval actually reuse the memory's content? This is the most
+      //    direct usefulness signal we have — the behavioral signals below
+      //    only approximate it.
+      const responsesAfter = responseEvents
+        .filter((e: any) => toEpochMs(e.timestamp) > retrievalTimeMs)
+        .map((e: any) => ({ id: e.id as string, content: e.content as string }));
+      // Grounding must be checked against what was actually injected into the
+      // prompt (hooks truncate memories), not the full stored event — otherwise
+      // facts the model never saw would count as "used". Full content is the
+      // fallback for legacy rows recorded before the snapshot column existed.
+      const memoryContent = (retrieval.injected_content as string)
+        || memoryContentById.get(retrieval.event_id as string)
+        || '';
+      let contentOverlapScore: number | null = null;
+      let evidenceMatches: EvidenceMatch[] = [];
+      if (responsesAfter.length > 0 && memoryContent) {
+        const evidence = computeMemoryUsageEvidence(memoryContent, responsesAfter);
+        contentOverlapScore = evidence.contentOverlapScore;
+        evidenceMatches = evidence.matches;
+      }
+
       // Calculate helpfulness score
       // Weights tuned for shopping-assistant-like corpora where sessions
       // continue on the same topic (was_reasked was over-penalising normal conversation flow)
       const retrievalScore = retrieval.retrieval_score as number || 0;
       // More prompts after retrieval = memory was actually useful to the conversation
       const promptNorm = Math.min(promptCountAfter / 2, 1.0);
-      const helpfulnessScore = (
-        0.40 * Math.min(retrievalScore, 1.0) +
-        0.30 * promptNorm +
-        0.20 * toolSuccessRatio +
-        0.10 * (sessionContinued ? 1.0 : 0.0)
-      );
+      // When content grounding is measurable it dominates the score; the
+      // legacy behavioral-only formula remains the fallback (e.g. session
+      // ended right after retrieval, so no responses followed).
+      const helpfulnessScore = contentOverlapScore !== null
+        ? (
+          0.45 * contentOverlapScore +
+          0.20 * Math.min(retrievalScore, 1.0) +
+          0.15 * promptNorm +
+          0.10 * toolSuccessRatio +
+          0.10 * (sessionContinued ? 1.0 : 0.0)
+        )
+        : (
+          0.40 * Math.min(retrievalScore, 1.0) +
+          0.30 * promptNorm +
+          0.20 * toolSuccessRatio +
+          0.10 * (sessionContinued ? 1.0 : 0.0)
+        );
 
       sqliteRun(
         this.db,
@@ -2320,10 +2409,14 @@ export class SQLiteEventStore {
          SET session_continued = ?, prompt_count_after = ?,
              tool_success_count = ?, tool_total_count = ?,
              was_reasked = ?, helpfulness_score = ?,
+             content_overlap_score = ?, evidence_json = ?,
              measured_at = datetime('now')
          WHERE id = ?`,
         [sessionContinued, promptCountAfter, toolSuccessCount, toolTotalCount,
-         wasReasked, helpfulnessScore, retrieval.id]
+         wasReasked, helpfulnessScore,
+         contentOverlapScore,
+         evidenceMatches.length > 0 ? JSON.stringify(evidenceMatches) : null,
+         retrieval.id]
       );
     }
   }
@@ -2377,6 +2470,9 @@ export class SQLiteEventStore {
     helpful: number;
     neutral: number;
     unhelpful: number;
+    contentEvaluated: number;
+    avgContentOverlap: number;
+    groundedCount: number;
   }> {
     await this.initialize();
 
@@ -2388,6 +2484,15 @@ export class SQLiteEventStore {
       ? `WHERE datetime(created_at) >= datetime(?)`
       : ``;
 
+    // Read-only dashboards can open legacy DBs where the grounding-column
+    // migration never ran; degrade to zeros instead of failing the query.
+    const hasGroundingColumns = this.hasTableColumn('memory_helpfulness', 'content_overlap_score');
+    const groundingSelect = hasGroundingColumns
+      ? `COUNT(content_overlap_score) as content_evaluated,
+         AVG(content_overlap_score) as avg_content_overlap,
+         SUM(CASE WHEN content_overlap_score >= 0.3 THEN 1 ELSE 0 END) as grounded_count`
+      : `0 as content_evaluated, 0 as avg_content_overlap, 0 as grounded_count`;
+
     const stats = sqliteGet<Record<string, unknown>>(
       this.db,
       `SELECT
@@ -2395,7 +2500,8 @@ export class SQLiteEventStore {
          COUNT(*) as total_evaluated,
          SUM(CASE WHEN helpfulness_score >= 0.7 THEN 1 ELSE 0 END) as helpful,
          SUM(CASE WHEN helpfulness_score >= 0.4 AND helpfulness_score < 0.7 THEN 1 ELSE 0 END) as neutral,
-         SUM(CASE WHEN helpfulness_score < 0.4 THEN 1 ELSE 0 END) as unhelpful
+         SUM(CASE WHEN helpfulness_score < 0.4 THEN 1 ELSE 0 END) as unhelpful,
+         ${groundingSelect}
        FROM memory_helpfulness
        ${evaluatedWhere}`,
       sinceIso ? [sinceIso] : []
@@ -2413,8 +2519,229 @@ export class SQLiteEventStore {
       totalRetrievals: (totalRow?.total as number) || 0,
       helpful: (stats?.helpful as number) || 0,
       neutral: (stats?.neutral as number) || 0,
-      unhelpful: (stats?.unhelpful as number) || 0
+      unhelpful: (stats?.unhelpful as number) || 0,
+      contentEvaluated: (stats?.content_evaluated as number) || 0,
+      avgContentOverlap: Math.round(((stats?.avg_content_overlap as number) || 0) * 100) / 100,
+      groundedCount: (stats?.grounded_count as number) || 0
     };
+  }
+
+  /**
+   * Per-question usefulness history: each retrieval query (or session-start
+   * injection batch) with the memories it injected, their measured
+   * helpfulness, content grounding, and evidence snippets. Powers the
+   * dashboard's evidence-history drill-down.
+   */
+  async getUsefulnessHistory(options: {
+    limit?: number;
+    offset?: number;
+    sessionId?: string;
+    withSelectionsOnly?: boolean;
+  } = {}): Promise<Array<{
+    traceId: string | null;
+    kind: 'query' | 'session_start';
+    sessionId: string | null;
+    question: string;
+    queryText: string | null;
+    strategy: string | null;
+    confidence: string | null;
+    candidateCount: number;
+    selectedCount: number;
+    createdAt: Date;
+    memories: Array<{
+      eventId: string;
+      eventType: string | null;
+      summary: string;
+      retrievalScore: number;
+      helpfulnessScore: number | null;
+      contentOverlapScore: number | null;
+      evidence: EvidenceMatch[];
+      measuredAt: string | null;
+      source: string;
+    }>;
+  }>> {
+    await this.initialize();
+
+    const limit = Math.min(Math.max(options.limit ?? 20, 1), 100);
+    const offset = Math.max(options.offset ?? 0, 0);
+
+    // Read-only dashboards can open legacy DBs where the trace-link migration
+    // (trace_id/source columns) never ran; fall back to trace-only history.
+    const hasTraceLink = this.hasTableColumn('memory_helpfulness', 'trace_id');
+
+    const sessionFilterTrace = options.sessionId ? `AND session_id = ?` : '';
+    const selectionFilter = options.withSelectionsOnly ? `AND selected_count > 0` : '';
+    const params: unknown[] = [];
+    if (options.sessionId) params.push(options.sessionId);
+    if (hasTraceLink && options.sessionId) params.push(options.sessionId);
+    params.push(limit, offset);
+
+    // Unified, paginated timeline of "questions": retrieval traces plus
+    // session-start injection batches (which have no retrieval_traces row).
+    const sessionStartBranch = hasTraceLink
+      ? `UNION ALL
+         SELECT 'session_start' AS kind,
+                COALESCE(trace_id, 'ss-' || session_id) AS id,
+                session_id,
+                MIN(created_at) AS created_at
+         FROM memory_helpfulness
+         WHERE source = 'session_start' ${sessionFilterTrace}
+         GROUP BY COALESCE(trace_id, 'ss-' || session_id), session_id`
+      : '';
+    const heads = sqliteAll<Record<string, unknown>>(
+      this.db,
+      `SELECT * FROM (
+         SELECT 'query' AS kind, trace_id AS id, session_id, created_at
+         FROM retrieval_traces
+         WHERE 1=1 ${sessionFilterTrace} ${selectionFilter}
+         ${sessionStartBranch}
+       )
+       ORDER BY created_at DESC
+       LIMIT ? OFFSET ?`,
+      params
+    );
+
+    const entries: Array<{
+      traceId: string | null;
+      kind: 'query' | 'session_start';
+      sessionId: string | null;
+      question: string;
+      queryText: string | null;
+      strategy: string | null;
+      confidence: string | null;
+      candidateCount: number;
+      selectedCount: number;
+      createdAt: Date;
+      memories: Array<{
+        eventId: string;
+        eventType: string | null;
+        summary: string;
+        retrievalScore: number;
+        helpfulnessScore: number | null;
+        contentOverlapScore: number | null;
+        evidence: EvidenceMatch[];
+        measuredAt: string | null;
+        source: string;
+      }>;
+    }> = [];
+
+    for (const head of heads) {
+      const kind = head.kind as 'query' | 'session_start';
+      const headId = head.id as string;
+
+      let trace: Record<string, unknown> | undefined;
+      if (kind === 'query') {
+        trace = sqliteGet<Record<string, unknown>>(
+          this.db,
+          `SELECT * FROM retrieval_traces WHERE trace_id = ?`,
+          [headId]
+        );
+        if (!trace) continue;
+      }
+
+      // Helpfulness rows for this head: primary link via trace_id; legacy
+      // fallback matches by session + selected event id within ±3 minutes.
+      let helpRows: Record<string, unknown>[] = hasTraceLink
+        ? sqliteAll<Record<string, unknown>>(
+          this.db,
+          `SELECT * FROM memory_helpfulness WHERE trace_id = ? ORDER BY created_at ASC`,
+          [headId]
+        )
+        : [];
+      if (kind === 'query' && helpRows.length === 0 && trace) {
+        const selectedIds: string[] = (() => {
+          try { return JSON.parse((trace.selected_event_ids as string) || '[]'); } catch { return []; }
+        })();
+        if (selectedIds.length > 0 && trace.session_id) {
+          const legacyOnlyFilter = hasTraceLink ? `AND trace_id IS NULL` : '';
+          helpRows = sqliteAll<Record<string, unknown>>(
+            this.db,
+            `SELECT * FROM memory_helpfulness
+             WHERE session_id = ? ${legacyOnlyFilter}
+               AND event_id IN (${selectedIds.map(() => '?').join(',')})
+               AND ABS(strftime('%s', created_at) - strftime('%s', ?)) <= 180
+             ORDER BY created_at ASC`,
+            [trace.session_id, ...selectedIds, trace.created_at]
+          );
+        }
+      }
+      if (kind === 'session_start' && helpRows.length === 0 && headId.startsWith('ss-')) {
+        helpRows = sqliteAll<Record<string, unknown>>(
+          this.db,
+          `SELECT * FROM memory_helpfulness
+           WHERE source = 'session_start' AND trace_id IS NULL AND session_id = ?
+           ORDER BY created_at ASC`,
+          [head.session_id]
+        );
+      }
+
+      // Hydrate memory summaries.
+      const eventIds = Array.from(new Set(helpRows.map((row) => row.event_id as string).filter(Boolean)));
+      const eventById = new Map<string, { content: string; event_type: string }>();
+      if (eventIds.length > 0) {
+        const rows = sqliteAll<{ id: string; content: string; event_type: string }>(
+          this.db,
+          `SELECT id, content, event_type FROM events WHERE id IN (${eventIds.map(() => '?').join(',')})`,
+          eventIds
+        );
+        for (const row of rows) eventById.set(row.id, row);
+      }
+
+      const memories = helpRows.map((row) => {
+        const event = eventById.get(row.event_id as string);
+        let evidence: EvidenceMatch[] = [];
+        try {
+          const parsed = JSON.parse((row.evidence_json as string) || '[]');
+          if (Array.isArray(parsed)) evidence = parsed;
+        } catch { /* legacy/corrupt rows have no evidence */ }
+        const summary = event
+          ? event.content.substring(0, 240) + (event.content.length > 240 ? '…' : '')
+          : '(event no longer available)';
+        return {
+          eventId: row.event_id as string,
+          eventType: event?.event_type ?? null,
+          summary,
+          retrievalScore: (row.retrieval_score as number) ?? 0,
+          helpfulnessScore: row.measured_at ? ((row.helpfulness_score as number) ?? null) : null,
+          contentOverlapScore: (row.content_overlap_score as number) ?? null,
+          evidence,
+          measuredAt: (row.measured_at as string) ?? null,
+          source: (row.source as string) || 'user_prompt'
+        };
+      });
+
+      if (kind === 'query' && trace) {
+        entries.push({
+          traceId: headId,
+          kind,
+          sessionId: (trace.session_id as string) ?? null,
+          question: (trace.raw_query_text as string) || (trace.query_text as string) || '',
+          queryText: (trace.query_text as string) ?? null,
+          strategy: (trace.strategy as string) ?? null,
+          confidence: (trace.confidence as string) ?? null,
+          candidateCount: (trace.candidate_count as number) ?? 0,
+          selectedCount: (trace.selected_count as number) ?? 0,
+          createdAt: toDateFromSQLite(trace.created_at as string),
+          memories
+        });
+      } else {
+        entries.push({
+          traceId: headId.startsWith('ss-') ? null : headId,
+          kind: 'session_start',
+          sessionId: (head.session_id as string) ?? null,
+          question: 'Session start — recent project context injected',
+          queryText: null,
+          strategy: 'session-start',
+          confidence: null,
+          candidateCount: memories.length,
+          selectedCount: memories.length,
+          createdAt: toDateFromSQLite(head.created_at as string),
+          memories
+        });
+      }
+    }
+
+    return entries;
   }
 
   /**
@@ -2578,6 +2905,7 @@ export class SQLiteEventStore {
 
 
   async recordRetrievalTrace(input: {
+    traceId?: string;
     sessionId?: string;
     projectHash?: string;
     queryText: string;
@@ -2607,7 +2935,7 @@ export class SQLiteEventStore {
   }): Promise<void> {
     await this.initialize();
 
-    const traceId = randomUUID();
+    const traceId = input.traceId || randomUUID();
     const queryRewriteKind = normalizeQueryRewriteKind(input.queryRewriteKind);
     const candidateDetails = normalizeRetrievalTraceDetails(input.candidateDetails);
     const selectedDetails = normalizeRetrievalTraceDetails(input.selectedDetails);

--- a/src/core/usefulness-evidence.ts
+++ b/src/core/usefulness-evidence.ts
@@ -1,0 +1,261 @@
+/**
+ * Usefulness Evidence
+ *
+ * Pure content-grounding analysis between an injected memory and the
+ * assistant responses that followed it. Answers "did the answer actually
+ * use this memory?" with a 0..1 grounding score plus the matched snippet
+ * pairs that justify it, so the dashboard can show evidence per question.
+ *
+ * Handles both space-delimited text and CJK-heavy text (character bigrams).
+ */
+
+export interface ResponseDocument {
+  id: string;
+  content: string;
+}
+
+export interface EvidenceMatch {
+  /** Snippet of the memory that was found in a response */
+  memorySnippet: string;
+  /** The region of the response where the match occurred */
+  responseSnippet: string;
+  /** Event id of the matching agent_response */
+  responseEventId: string;
+  /** 0..1 similarity of this snippet match */
+  similarity: number;
+  matchType: 'exact' | 'term-overlap';
+}
+
+export interface MemoryUsageEvidence {
+  /** 0..1 — how strongly the responses are grounded in this memory */
+  contentOverlapScore: number;
+  /** Fraction of memory snippets that matched some response (0..1) */
+  coverage: number;
+  /** Best matches, strongest first */
+  matches: EvidenceMatch[];
+}
+
+const MAX_SNIPPETS = 40;
+const MAX_MATCHES = 5;
+const MIN_SNIPPET_LENGTH = 12;
+const MAX_SNIPPET_LENGTH = 300;
+const RESPONSE_CONTEXT_CHARS = 160;
+const STRONG_MATCH_THRESHOLD = 0.55;
+// A snippet must carry at least this many informative tokens before any
+// match counts as evidence — otherwise a single generic word shared with the
+// answer (e.g. a "## Configuration" heading) scores as full grounding.
+const MIN_SNIPPET_TOKENS = 3;
+
+/** Words too generic to signal grounding on their own. */
+const STOP_TOKENS = new Set([
+  'the', 'and', 'for', 'that', 'this', 'with', 'from', 'have', 'has',
+  'was', 'were', 'are', 'not', 'but', 'you', 'your', 'can', 'will',
+  'should', 'would', 'could', 'when', 'what', 'which', 'their', 'there',
+  'then', 'than', 'into', 'over', 'also', 'only', 'some', 'such', 'use',
+  'used', 'using'
+]);
+
+/**
+ * Lowercase and strip punctuation/markdown so the same phrasing matches even
+ * when only punctuation differs. Applied consistently to memory snippets and
+ * responses, so exact-containment stays valid.
+ */
+function normalizeText(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9가-힣一-鿿぀-ヿ\s_/-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+// Latin/numeric identifiers (3+ chars) or runs of Hangul / CJK / kana.
+const TOKEN_PATTERN = /[a-z0-9_/-]{3,}|[가-힣一-鿿぀-ヿ]+/g;
+
+function tokenize(text: string): string[] {
+  const tokens: string[] = [];
+  const wordMatches = text.match(TOKEN_PATTERN) || [];
+  for (const rawMatch of wordMatches) {
+    const raw = rawMatch.replace(/^[/-]+|[/-]+$/g, '');
+    if (raw.length < 1) continue;
+    if (/^[a-z0-9_/-]+$/.test(raw)) {
+      if (raw.length >= 3 && !STOP_TOKENS.has(raw)) tokens.push(raw);
+      continue;
+    }
+    // CJK run: split into character bigrams so partial phrasing still matches.
+    if (raw.length === 1) {
+      tokens.push(raw);
+      continue;
+    }
+    for (let i = 0; i < raw.length - 1; i++) {
+      tokens.push(raw.slice(i, i + 2));
+    }
+  }
+  return tokens;
+}
+
+/**
+ * Split memory content into candidate snippets worth searching for in
+ * responses: lines and sentence-ish fragments of meaningful length.
+ */
+export function extractMemorySnippets(content: string): string[] {
+  const seen = new Set<string>();
+  const snippets: string[] = [];
+
+  const push = (raw: string) => {
+    const trimmed = raw.replace(/^[-*>\d.\s]+/, '').trim();
+    if (trimmed.length < MIN_SNIPPET_LENGTH) return;
+    const clipped = trimmed.slice(0, MAX_SNIPPET_LENGTH);
+    const key = normalizeText(clipped);
+    if (!key || key.length < MIN_SNIPPET_LENGTH || seen.has(key)) return;
+    seen.add(key);
+    snippets.push(clipped);
+  };
+
+  for (const line of content.split(/\n+/)) {
+    if (snippets.length >= MAX_SNIPPETS) break;
+    const trimmedLine = line.trim();
+    if (!trimmedLine) continue;
+    // Markdown headings are structural labels, not facts — a heading word
+    // reappearing in an answer says nothing about memory reuse.
+    if (/^#{1,6}\s/.test(trimmedLine)) continue;
+    if (trimmedLine.length <= MAX_SNIPPET_LENGTH) {
+      push(trimmedLine);
+      continue;
+    }
+    // Long line: fall back to sentence-ish fragments.
+    for (const sentence of trimmedLine.split(/(?<=[.!?。])\s+|;\s+/)) {
+      if (snippets.length >= MAX_SNIPPETS) break;
+      push(sentence);
+    }
+  }
+
+  return snippets;
+}
+
+function findResponseWindow(
+  normalizedResponse: string,
+  originalResponse: string,
+  needle: string
+): string {
+  const index = normalizedResponse.indexOf(needle);
+  if (index < 0) {
+    return originalResponse.slice(0, RESPONSE_CONTEXT_CHARS);
+  }
+  // The normalized text is not position-aligned with the original, so
+  // approximate by proportional position — good enough for a preview snippet.
+  const ratio = normalizedResponse.length > 0 ? index / normalizedResponse.length : 0;
+  const approxStart = Math.max(0, Math.floor(originalResponse.length * ratio) - 40);
+  return originalResponse.slice(approxStart, approxStart + RESPONSE_CONTEXT_CHARS).trim();
+}
+
+function findTermWindow(originalResponse: string, terms: string[]): string {
+  const lower = originalResponse.toLowerCase();
+  for (const term of terms) {
+    const index = lower.indexOf(term);
+    if (index >= 0) {
+      const start = Math.max(0, index - 40);
+      return originalResponse.slice(start, start + RESPONSE_CONTEXT_CHARS).trim();
+    }
+  }
+  return originalResponse.slice(0, RESPONSE_CONTEXT_CHARS).trim();
+}
+
+/**
+ * Compute how strongly a set of assistant responses is grounded in a
+ * memory's content, with per-snippet match evidence.
+ */
+export function computeMemoryUsageEvidence(
+  memoryContent: string,
+  responses: ResponseDocument[]
+): MemoryUsageEvidence {
+  const snippets = extractMemorySnippets(memoryContent);
+  if (snippets.length === 0 || responses.length === 0) {
+    return { contentOverlapScore: 0, coverage: 0, matches: [] };
+  }
+
+  const preparedResponses = responses
+    .map((response) => ({
+      id: response.id,
+      original: response.content,
+      normalized: normalizeText(response.content),
+      tokenSet: new Set(tokenize(normalizeText(response.content)))
+    }))
+    .filter((response) => response.normalized.length > 0);
+
+  if (preparedResponses.length === 0) {
+    return { contentOverlapScore: 0, coverage: 0, matches: [] };
+  }
+
+  const matches: EvidenceMatch[] = [];
+  let matchedSnippets = 0;
+  let bestSimilarity = 0;
+
+  let comparableSnippets = 0;
+  for (const snippet of snippets) {
+    const normalizedSnippet = normalizeText(snippet);
+    const snippetTokens = tokenize(normalizedSnippet);
+    if (snippetTokens.length < MIN_SNIPPET_TOKENS) continue;
+    comparableSnippets++;
+
+    let best: EvidenceMatch | null = null;
+
+    for (const response of preparedResponses) {
+      // 1) Exact normalized containment — the strongest possible signal.
+      if (normalizedSnippet.length >= MIN_SNIPPET_LENGTH && response.normalized.includes(normalizedSnippet)) {
+        best = {
+          memorySnippet: snippet,
+          responseSnippet: findResponseWindow(response.normalized, response.original, normalizedSnippet),
+          responseEventId: response.id,
+          similarity: 1,
+          matchType: 'exact'
+        };
+        break;
+      }
+
+      // 2) Term containment — what fraction of the snippet's tokens appear
+      //    in the response. Discriminative for facts, robust to rephrasing.
+      let hit = 0;
+      const matchedTerms: string[] = [];
+      for (const token of snippetTokens) {
+        if (response.tokenSet.has(token)) {
+          hit++;
+          if (matchedTerms.length < 5 && token.length >= 3) matchedTerms.push(token);
+        }
+      }
+      const containment = hit / snippetTokens.length;
+      const similarity = containment * 0.9; // cap below exact-match confidence
+      if (similarity >= STRONG_MATCH_THRESHOLD && (!best || similarity > best.similarity)) {
+        best = {
+          memorySnippet: snippet,
+          responseSnippet: findTermWindow(response.original, matchedTerms),
+          responseEventId: response.id,
+          similarity: Math.round(similarity * 100) / 100,
+          matchType: 'term-overlap'
+        };
+      }
+    }
+
+    if (best) {
+      matchedSnippets++;
+      bestSimilarity = Math.max(bestSimilarity, best.similarity);
+      matches.push(best);
+    }
+  }
+
+  if (comparableSnippets === 0) {
+    return { contentOverlapScore: 0, coverage: 0, matches: [] };
+  }
+
+  const coverage = matchedSnippets / comparableSnippets;
+  // Grounding blends "at least one strong reuse" with "how much of the
+  // memory was reused". A single exact quote should already score well.
+  const contentOverlapScore = Math.min(1, 0.65 * bestSimilarity + 0.35 * coverage);
+
+  matches.sort((a, b) => b.similarity - a.similarity);
+
+  return {
+    contentOverlapScore: Math.round(contentOverlapScore * 100) / 100,
+    coverage: Math.round(coverage * 100) / 100,
+    matches: matches.slice(0, MAX_MATCHES)
+  };
+}

--- a/src/core/vector-store.ts
+++ b/src/core/vector-store.ts
@@ -18,6 +18,9 @@ export interface SearchResult {
 
 type LanceTable = lancedb.Table;
 
+const MAX_LANCE_COMMIT_ATTEMPTS = 3;
+const LANCE_COMMIT_RETRY_BASE_DELAY_MS = 20;
+
 type VectorRow = {
   id: string;
   eventId: string;
@@ -204,10 +207,7 @@ export class VectorStore {
 
     const existingTable = await this.getExistingTable(tableName);
     if (existingTable) {
-      for (const row of rows) {
-        await existingTable.delete(`id = ${toLanceSqlString(row.id)}`);
-      }
-      await existingTable.add(rows);
+      await this.writeExistingRowsWithRetry(tableName, existingTable, rows);
       return;
     }
 
@@ -219,10 +219,33 @@ export class VectorStore {
         throw error;
       }
       const racedTable = await this.openTable(tableName);
-      for (const row of rows) {
-        await racedTable.delete(`id = ${toLanceSqlString(row.id)}`);
+      await this.writeExistingRowsWithRetry(tableName, racedTable, rows);
+    }
+  }
+
+  private async writeExistingRowsWithRetry(
+    tableName: string,
+    initialTable: LanceTable,
+    rows: VectorRow[]
+  ): Promise<void> {
+    let table = initialTable;
+
+    for (let attempt = 1; attempt <= MAX_LANCE_COMMIT_ATTEMPTS; attempt++) {
+      try {
+        for (const row of rows) {
+          await table.delete(`id = ${toLanceSqlString(row.id)}`);
+        }
+        await table.add(rows);
+        return;
+      } catch (error) {
+        if (!isLanceCommitConflict(error) || attempt === MAX_LANCE_COMMIT_ATTEMPTS) {
+          throw error;
+        }
+
+        this.tableCache.delete(tableName);
+        await delay(LANCE_COMMIT_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1));
+        table = await this.openTable(tableName);
       }
-      await racedTable.add(rows);
     }
   }
 
@@ -292,4 +315,15 @@ function toLanceSqlString(value: string): string {
 function isAlreadyExistsError(error: unknown): boolean {
   const message = String(error instanceof Error ? error.message : error).toLowerCase();
   return message.includes('already exists');
+}
+
+function isLanceCommitConflict(error: unknown): boolean {
+  const message = String(error instanceof Error ? error.message : error).toLowerCase();
+  return message.includes('commit conflict')
+    && message.includes('concurrent commit')
+    && message.includes('rerun the operation');
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/src/core/vector-worker.ts
+++ b/src/core/vector-worker.ts
@@ -44,6 +44,7 @@ export class VectorWorker {
   private running = false;
   private stopping = false;
   private pollTimeout: NodeJS.Timeout | null = null;
+  private activeBatch: Promise<number> | null = null;
 
   constructor(
     eventStore: EventStore,
@@ -83,6 +84,22 @@ export class VectorWorker {
    * Process a single batch of outbox items
    */
   async processBatch(): Promise<number> {
+    if (this.activeBatch) {
+      return this.activeBatch;
+    }
+
+    const batch = this.processBatchExclusive();
+    this.activeBatch = batch;
+    try {
+      return await batch;
+    } finally {
+      if (this.activeBatch === batch) {
+        this.activeBatch = null;
+      }
+    }
+  }
+
+  private async processBatchExclusive(): Promise<number> {
     const items = await this.eventStore.getPendingOutboxItems(this.config.batchSize);
 
     if (items.length === 0) {
@@ -185,9 +202,12 @@ export class VectorWorker {
     let processed: number;
 
     do {
+      if (this.stopping) {
+        break;
+      }
       processed = await this.processBatch();
       totalProcessed += processed;
-    } while (processed > 0);
+    } while (processed > 0 && !this.stopping);
 
     return totalProcessed;
   }
@@ -197,6 +217,18 @@ export class VectorWorker {
    */
   isRunning(): boolean {
     return this.running;
+  }
+
+  /** Wait for an in-flight batch before closing native/database resources. */
+  async waitForIdle(): Promise<void> {
+    while (this.activeBatch) {
+      const batch = this.activeBatch;
+      try {
+        await batch;
+      } catch {
+        // The caller that started the batch owns error reporting.
+      }
+    }
   }
 }
 
@@ -396,6 +428,7 @@ export class VectorWorkerV2 {
   private running = false;
   private stopping = false;
   private pollTimeout: NodeJS.Timeout | null = null;
+  private activeBatch: Promise<number> | null = null;
 
   constructor(
     db: Database,
@@ -440,6 +473,22 @@ export class VectorWorkerV2 {
    * Process a single batch of outbox jobs
    */
   async processBatch(): Promise<number> {
+    if (this.activeBatch) {
+      return this.activeBatch;
+    }
+
+    const batch = this.processBatchExclusive();
+    this.activeBatch = batch;
+    try {
+      return await batch;
+    } finally {
+      if (this.activeBatch === batch) {
+        this.activeBatch = null;
+      }
+    }
+  }
+
+  private async processBatchExclusive(): Promise<number> {
     const jobs = await this.outbox.claimJobs(this.config.batchSize);
 
     if (jobs.length === 0) {
@@ -532,9 +581,12 @@ export class VectorWorkerV2 {
     let processed: number;
 
     do {
+      if (this.stopping) {
+        break;
+      }
       processed = await this.processBatch();
       totalProcessed += processed;
-    } while (processed > 0);
+    } while (processed > 0 && !this.stopping);
 
     return totalProcessed;
   }
@@ -558,6 +610,18 @@ export class VectorWorkerV2 {
    */
   isRunning(): boolean {
     return this.running;
+  }
+
+  /** Wait for an in-flight batch before closing native/database resources. */
+  async waitForIdle(): Promise<void> {
+    while (this.activeBatch) {
+      const batch = this.activeBatch;
+      try {
+        await batch;
+      } catch {
+        // The caller that started the batch owns error reporting.
+      }
+    }
   }
 
   /**

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -66,7 +66,9 @@ import {
   type RetrievalOrchestrator,
   type RetrievalTrace,
   type RetrievalTraceStats,
-  type RetrieveMemoriesOptions
+  type RetrieveMemoriesOptions,
+  type UsefulnessHistoryEntry,
+  type UsefulnessHistoryOptions
 } from '../core/engine/retrieval-services.js';
 export { getProjectStoragePath, hashProjectPath } from '../core/registry/project-path.js';
 export {
@@ -541,8 +543,14 @@ export class MemoryService {
   /**
    * Record a memory retrieval for helpfulness tracking
    */
-  async recordRetrieval(eventId: string, sessionId: string, score: number, query: string): Promise<void> {
-    return this.retrievalOrchestrator.recordRetrieval(eventId, sessionId, score, query);
+  async recordRetrieval(
+    eventId: string,
+    sessionId: string,
+    score: number,
+    query: string,
+    options?: { traceId?: string; source?: string; injectedContent?: string }
+  ): Promise<void> {
+    return this.retrievalOrchestrator.recordRetrieval(eventId, sessionId, score, query, options);
   }
 
   /**
@@ -580,6 +588,15 @@ export class MemoryService {
    */
   async getHelpfulnessStats(since?: Date): Promise<HelpfulnessStats> {
     return this.retrievalAnalyticsService.getHelpfulnessStats(since);
+  }
+
+  /**
+   * Per-question usefulness/evidence history for the dashboard: each
+   * retrieval query with its injected memories, measured helpfulness,
+   * content grounding, and evidence snippets.
+   */
+  async getUsefulnessHistory(options: UsefulnessHistoryOptions = {}): Promise<UsefulnessHistoryEntry[]> {
+    return this.retrievalAnalyticsService.getUsefulnessHistory(options);
   }
 
   /**

--- a/tests/apps/codex-import-runner.test.ts
+++ b/tests/apps/codex-import-runner.test.ts
@@ -96,4 +96,13 @@ describe('Codex import runner', () => {
     await expect(runCodexImportOnce({ sessionLimit: '1.5' }, deps)).rejects.toThrow('Invalid --session-limit');
     await expect(runCodexImportOnce({ sessionLimit: '1e2' }, deps)).rejects.toThrow('Invalid --session-limit');
   });
+
+  it('shuts down the writable service when embedding migration setup fails', async () => {
+    projectService.ensureEmbeddingModelForImport.mockRejectedValueOnce(new Error('migration failed'));
+
+    await expect(runCodexImportOnce({}, deps)).rejects.toThrow('migration failed');
+
+    expect(projectService.shutdown).toHaveBeenCalledTimes(1);
+    expect(importer.importProject).not.toHaveBeenCalled();
+  });
 });

--- a/tests/apps/dashboard-usefulness-stats.test.ts
+++ b/tests/apps/dashboard-usefulness-stats.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => {
     getHelpfulnessStats: vi.fn(),
     getRecentRetrievalTraces: vi.fn(),
     getRetrievalTraceStats: vi.fn(),
+    getUsefulnessHistory: vi.fn(),
   };
 
   return {
@@ -62,9 +63,9 @@ class TestElement {
   classList = { add() {}, remove() {}, toggle() {} };
 }
 
-function loadOverviewWithElements(elements: Record<string, TestElement>) {
+function loadOverviewWithElements(elements: Record<string, TestElement>, files = ['state.js', 'views.js', 'overview.js']) {
   const dashboardDir = join(process.cwd(), 'src/apps/dashboard/assets/js');
-  const source = ['state.js', 'views.js', 'overview.js']
+  const source = files
     .map(file => readFileSync(join(dashboardDir, file), 'utf-8'))
     .join('\n');
   const context = {
@@ -81,14 +82,19 @@ function loadOverviewWithElements(elements: Record<string, TestElement>) {
     },
   };
 
+  const usefulnessHooks = files.includes('usefulness.js')
+    ? ', renderUsefulnessHistory, updateOverviewUsefulnessStrip'
+    : '';
   vm.runInNewContext(
-    `${source}\n;globalThis.__dashboardTestHooks = { state, updateMemoryUsefulnessUI, updateRetrievalTraceUI };`,
+    `${source}\n;globalThis.__dashboardTestHooks = { state, updateMemoryUsefulnessUI, updateRetrievalTraceUI${usefulnessHooks} };`,
     context
   );
   return (context as unknown as { __dashboardTestHooks: {
     state: Record<string, any>;
     updateMemoryUsefulnessUI: () => void;
     updateRetrievalTraceUI: () => void;
+    renderUsefulnessHistory: () => void;
+    updateOverviewUsefulnessStrip: () => void;
   }}).__dashboardTestHooks;
 }
 
@@ -113,6 +119,9 @@ describe('dashboard memory usefulness stats', () => {
       helpful: 3,
       neutral: 1,
       unhelpful: 0,
+      contentEvaluated: 3,
+      avgContentOverlap: 0.6,
+      groundedCount: 2,
     });
     mocks.service.getRecentRetrievalTraces.mockReset().mockResolvedValue([
       {
@@ -174,10 +183,12 @@ describe('dashboard memory usefulness stats', () => {
     const body = await res.json();
 
     expect(body.window).toBe('7d');
-    expect(body.score).toEqual({ value: 64.4, label: 'good', confidence: 1 });
+    expect(body.score).toEqual({ value: 64, label: 'good', confidence: 1 });
     expect(body.generatedAt).toBe('2026-05-08T12:00:00.000Z');
     expect(body.metrics).toMatchObject({
       avgHelpfulnessScore: 0.8,
+      contentGroundingRate: 0.6,
+      groundedRecallRate: 0.6667,
       usefulRecallRate: 0.75,
       memoryHitRate: 0.3333,
       retrievalUsageRate: 0.6667,
@@ -207,9 +218,12 @@ describe('dashboard memory usefulness stats', () => {
       unhelpful: 0,
       totalEvaluated: 4,
       totalRetrievals: 5,
+      contentEvaluated: 3,
+      groundedCount: 2,
     });
     expect(body.components.map((c: any) => c.key)).toEqual([
       'avgHelpfulnessScore',
+      'contentGroundingRate',
       'usefulRecallRate',
       'memoryHitRate',
       'retrievalUsageRate',
@@ -257,13 +271,77 @@ describe('dashboard memory usefulness stats', () => {
     mocks.service.getRecentRetrievalTraces.mockResolvedValue([]);
     const zeroRes = await createApp().request('/api/stats/usefulness?window=24h');
     const zeroBody = await zeroRes.json();
-    expect(zeroBody.score).toEqual({ value: 0, label: 'low', confidence: 0.35 });
+    expect(zeroBody.score).toEqual({ value: 0, label: 'low', confidence: 0.3 });
 
     mocks.service.getEventsAfter.mockResolvedValue([]);
     mocks.service.getRecentRetrievalTraces.mockResolvedValue([]);
     const emptyRes = await createApp().request('/api/stats/usefulness?window=24h');
     const emptyBody = await emptyRes.json();
     expect(emptyBody.score).toEqual({ value: 0, label: 'unknown', confidence: 0 });
+  });
+
+  it('returns per-question evidence history without rewritten query text', async () => {
+    mocks.service.getUsefulnessHistory.mockReset().mockResolvedValue([
+      {
+        traceId: 'trace-1',
+        kind: 'query',
+        sessionId: 's1',
+        question: 'how do I deploy this project?',
+        queryText: 'PRIVATE_REWRITTEN_QUERY_SHOULD_NOT_LEAK',
+        strategy: 'hybrid',
+        confidence: 'high',
+        candidateCount: 3,
+        selectedCount: 1,
+        createdAt: new Date('2026-05-08T10:10:00.000Z'),
+        memories: [
+          {
+            eventId: 'mem-1',
+            eventType: 'agent_response',
+            summary: 'The deploy port is 37777…',
+            retrievalScore: 0.9,
+            helpfulnessScore: 0.82,
+            contentOverlapScore: 0.7,
+            evidence: [
+              {
+                memorySnippet: 'The deploy port is 37777',
+                responseSnippet: 'the deploy port is 37777',
+                responseEventId: 'resp-1',
+                similarity: 1,
+                matchType: 'exact'
+              }
+            ],
+            measuredAt: '2026-05-08 10:20:00',
+            source: 'user_prompt'
+          }
+        ]
+      }
+    ]);
+
+    const res = await createApp().request('/api/stats/usefulness-history?limit=10');
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.entries).toHaveLength(1);
+    expect(body.entries[0]).toMatchObject({
+      traceId: 'trace-1',
+      kind: 'query',
+      question: 'how do I deploy this project?',
+      selectedCount: 1,
+    });
+    expect(body.entries[0]).not.toHaveProperty('queryText');
+    expect(JSON.stringify(body)).not.toContain('PRIVATE_REWRITTEN_QUERY_SHOULD_NOT_LEAK');
+    expect(body.entries[0].memories[0]).toMatchObject({
+      eventId: 'mem-1',
+      helpfulnessScore: 0.82,
+      contentOverlapScore: 0.7,
+    });
+    expect(body.entries[0].memories[0].evidence[0].matchType).toBe('exact');
+    expect(mocks.service.getUsefulnessHistory).toHaveBeenCalledWith({
+      limit: 10,
+      offset: 0,
+      sessionId: undefined,
+      withSelectionsOnly: false,
+    });
   });
 
   it('returns a generic error when usefulness calculation fails', async () => {
@@ -684,6 +762,99 @@ describe('dashboard memory usefulness stats', () => {
     expect(elements['retrieval-review-list'].innerHTML).toContain('Unable to load bad retrieval cases');
     expect(elements['retrieval-review-summary'].innerHTML).not.toContain('/Users/private/retrieval-store');
     expect(elements['retrieval-review-list'].innerHTML).not.toContain('PRIVATE_DASHBOARD_ERROR_SHOULD_NOT_LEAK');
+  });
+
+  it('renders the evidence history with question, grounding, and answer snippets', () => {
+    const elements = {
+      'usefulness-history-list': new TestElement(),
+    };
+    const hooks = loadOverviewWithElements(elements, ['state.js', 'views.js', 'overview.js', 'usefulness.js']);
+
+    hooks.state.usefulnessHistory = [
+      {
+        traceId: 'trace-1',
+        kind: 'query',
+        sessionId: 'session-abcdef123456',
+        question: 'how do I deploy this project?',
+        strategy: 'hybrid',
+        confidence: 'high',
+        candidateCount: 3,
+        selectedCount: 1,
+        createdAt: '2026-05-08T10:10:00.000Z',
+        memories: [
+          {
+            eventId: 'mem-1',
+            eventType: 'agent_response',
+            summary: 'The deploy port is 37777…',
+            retrievalScore: 0.9,
+            helpfulnessScore: 0.82,
+            contentOverlapScore: 0.7,
+            evidence: [
+              {
+                memorySnippet: 'The deploy port is 37777',
+                responseSnippet: 'the deploy port is 37777 <script>alert(1)</script>',
+                responseEventId: 'resp-1',
+                similarity: 1,
+                matchType: 'exact'
+              }
+            ],
+            measuredAt: '2026-05-08 10:20:00',
+            source: 'user_prompt'
+          }
+        ]
+      },
+      {
+        traceId: 'trace-untracked',
+        kind: 'query',
+        sessionId: 'session-2',
+        question: 'untracked automatic query',
+        strategy: 'auto',
+        confidence: 'high',
+        candidateCount: 4,
+        selectedCount: 2,
+        createdAt: '2026-05-08T09:00:00.000Z',
+        memories: []
+      }
+    ];
+
+    hooks.renderUsefulnessHistory();
+
+    const html = elements['usefulness-history-list'].innerHTML;
+    expect(html).toContain('how do I deploy this project?');
+    expect(html).toContain('1 used in answer');
+    expect(html).toContain('grounding 70%');
+    expect(html).toContain('82%');
+    expect(html).toContain('The deploy port is 37777');
+    // Evidence snippets must be HTML-escaped.
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+    // Selected-but-untracked traces explain themselves instead of claiming nothing was injected.
+    expect(html).toContain('2 memories were selected, but per-memory tracking is unavailable');
+  });
+
+  it('renders the overview usefulness strip from the usefulness payload', () => {
+    const elements = {
+      'overview-usefulness-score': new TestElement(),
+      'overview-usefulness-note': new TestElement(),
+      'overview-usefulness-metrics': new TestElement(),
+    };
+    const hooks = loadOverviewWithElements(elements, ['state.js', 'views.js', 'overview.js', 'usefulness.js']);
+
+    hooks.state.memoryUsefulness = {
+      window: '7d',
+      score: { value: 71.5, label: 'good', confidence: 0.9 },
+      metrics: { avgHelpfulnessScore: 0.8, contentGroundingRate: 0.55, memoryHitRate: 0.6 },
+      counts: { retrievalQueries: 42 },
+      diagnostics: [],
+    };
+
+    hooks.updateOverviewUsefulnessStrip();
+
+    expect(elements['overview-usefulness-score'].textContent).toBe('71.5');
+    expect(elements['overview-usefulness-score'].className).toContain('score-good');
+    expect(elements['overview-usefulness-metrics'].innerHTML).toContain('55%');
+    expect(elements['overview-usefulness-metrics'].innerHTML).toContain('42');
+    expect(elements['overview-usefulness-note'].textContent).toContain('good');
   });
 
   it('renders the usefulness score and component percentages in the overview dashboard', () => {

--- a/tests/apps/hermes-import-runner.test.ts
+++ b/tests/apps/hermes-import-runner.test.ts
@@ -96,4 +96,13 @@ describe('Hermes import runner', () => {
     await expect(runHermesImportOnce({ sessionLimit: '1.5' }, deps)).rejects.toThrow('Invalid --session-limit');
     await expect(runHermesImportOnce({ sessionLimit: '1e2' }, deps)).rejects.toThrow('Invalid --session-limit');
   });
+
+  it('shuts down the writable service when embedding migration setup fails', async () => {
+    projectService.ensureEmbeddingModelForImport.mockRejectedValueOnce(new Error('migration failed'));
+
+    await expect(runHermesImportOnce({}, deps)).rejects.toThrow('migration failed');
+
+    expect(projectService.shutdown).toHaveBeenCalledTimes(1);
+    expect(importer.importProject).not.toHaveBeenCalled();
+  });
 });

--- a/tests/apps/import-command.test.ts
+++ b/tests/apps/import-command.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatImportLockBusy,
+  resolveImportCommandLockOptions
+} from '../../src/apps/cli/import-command.js';
+
+const deps = {
+  cwd: () => '/repo/current',
+  homedir: () => '/home/tester',
+  getProjectStoragePath: (projectPath: string) => `/private-store/${projectPath.split('/').at(-1)}`
+};
+
+describe('import command worker lock', () => {
+  it('derives a project-scoped lock for default and selected-project imports', () => {
+    expect(resolveImportCommandLockOptions({}, deps)).toEqual({
+      storageScope: 'project',
+      projectPath: '/repo/current',
+      lockPath: '/private-store/current/vector-worker.lock'
+    });
+    expect(resolveImportCommandLockOptions({ project: '/repo/selected' }, deps)).toEqual({
+      storageScope: 'project',
+      projectPath: '/repo/selected',
+      lockPath: '/private-store/selected/vector-worker.lock'
+    });
+  });
+
+  it('uses the global memory lock only for unscoped all-session imports', () => {
+    expect(resolveImportCommandLockOptions({ all: true }, deps)).toEqual({
+      storageScope: 'global',
+      lockPath: '/home/tester/.claude-code/memory/vector-worker.lock'
+    });
+    expect(resolveImportCommandLockOptions({ all: true, session: '/tmp/one.jsonl' }, deps).storageScope)
+      .toBe('project');
+  });
+
+  it('allows a non-empty lock override and renders actionable contention output', () => {
+    const options = resolveImportCommandLockOptions({ lockPath: '/tmp/import.lock' }, deps);
+    expect(options.lockPath).toBe('/tmp/import.lock');
+    expect(formatImportLockBusy(options, 1234)).toContain('holderPid=1234');
+    expect(formatImportLockBusy(options, 1234)).toContain('import was not started');
+    expect(() => resolveImportCommandLockOptions({ lockPath: '  ' }, deps)).toThrow('--lock-path must not be empty');
+  });
+});

--- a/tests/core/memory-runtime-service.test.ts
+++ b/tests/core/memory-runtime-service.test.ts
@@ -36,6 +36,7 @@ function makeHarness(options?: { readOnly?: boolean; lightweightMode?: boolean; 
   const vectorWorker = {
     start: () => { calls.push('vectorWorker.start'); },
     stop: () => { calls.push('vectorWorker.stop'); },
+    waitForIdle: async () => { calls.push('vectorWorker.waitForIdle'); },
     processAll: async () => {
       calls.push('vectorWorker.processAll');
       return 3;
@@ -44,6 +45,7 @@ function makeHarness(options?: { readOnly?: boolean; lightweightMode?: boolean; 
   const vectorWorkerV2 = {
     start: () => { calls.push('vectorWorkerV2.start'); },
     stop: () => { calls.push('vectorWorkerV2.stop'); },
+    waitForIdle: async () => { calls.push('vectorWorkerV2.waitForIdle'); },
     processAll: async () => {
       calls.push('vectorWorkerV2.processAll');
       return 5;
@@ -196,6 +198,8 @@ describe('createMemoryRuntimeService', () => {
       'endless.shutdown',
       'vectorWorker.stop',
       'vectorWorkerV2.stop',
+      'vectorWorker.waitForIdle',
+      'vectorWorkerV2.waitForIdle',
       'shared.close',
       'sqlite.close'
     ]);
@@ -257,8 +261,33 @@ describe('createMemoryRuntimeService', () => {
       'graduationWorker.stop',
       'endless.shutdown',
       'vectorWorker.stop',
+      'vectorWorker.waitForIdle',
       'shared.close',
       'sqlite.close'
     ]);
+  });
+
+  it('waits for an active vector batch before closing backing services', async () => {
+    const harness = makeHarness();
+    let releaseIdle!: () => void;
+    const idle = new Promise<void>(resolve => {
+      releaseIdle = resolve;
+    });
+    harness.vectorWorker.waitForIdle = async () => {
+      harness.calls.push('vectorWorker.waitForIdle:blocked');
+      await idle;
+    };
+    await harness.service.initialize();
+    harness.calls.length = 0;
+
+    const shutdown = harness.service.shutdown();
+    await Promise.resolve();
+
+    expect(harness.calls).toContain('vectorWorker.waitForIdle:blocked');
+    expect(harness.calls).not.toContain('shared.close');
+
+    releaseIdle();
+    await shutdown;
+    expect(harness.calls.slice(-2)).toEqual(['shared.close', 'sqlite.close']);
   });
 });

--- a/tests/core/usefulness-evidence.test.ts
+++ b/tests/core/usefulness-evidence.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeMemoryUsageEvidence,
+  extractMemorySnippets
+} from '../../src/core/usefulness-evidence.js';
+
+describe('extractMemorySnippets', () => {
+  it('splits memory content into meaningful line snippets', () => {
+    const snippets = extractMemorySnippets(
+      'The deploy port is 37777.\n\n- release script: scripts/release-npm.sh\nok'
+    );
+    expect(snippets).toContain('The deploy port is 37777.');
+    expect(snippets).toContain('release script: scripts/release-npm.sh');
+    // Too-short fragments are dropped.
+    expect(snippets).not.toContain('ok');
+  });
+
+  it('deduplicates repeated lines', () => {
+    const snippets = extractMemorySnippets('same fact repeated here\nsame fact repeated here');
+    expect(snippets).toHaveLength(1);
+  });
+});
+
+describe('computeMemoryUsageEvidence', () => {
+  it('detects exact reuse of memory content in a response', () => {
+    const result = computeMemoryUsageEvidence(
+      'The deploy port is 37777 and the release script is scripts/release-npm.sh.',
+      [{ id: 'resp-1', content: 'Sure — the deploy port is 37777 and the release script is scripts/release-npm.sh, so run that.' }]
+    );
+
+    expect(result.contentOverlapScore).toBeGreaterThan(0.6);
+    expect(result.matches.length).toBeGreaterThan(0);
+    expect(result.matches[0]).toMatchObject({
+      matchType: 'exact',
+      responseEventId: 'resp-1',
+      similarity: 1
+    });
+  });
+
+  it('detects rephrased reuse through term overlap', () => {
+    const result = computeMemoryUsageEvidence(
+      'Use npm publish --otp with the claude-memory-layer package after running typecheck.',
+      [{ id: 'resp-2', content: 'First run typecheck, then publish the claude-memory-layer package via npm publish --otp.' }]
+    );
+
+    expect(result.contentOverlapScore).toBeGreaterThan(0.3);
+    expect(result.matches[0].matchType).toBe('term-overlap');
+    expect(result.matches[0].responseEventId).toBe('resp-2');
+  });
+
+  it('scores unrelated responses near zero', () => {
+    const result = computeMemoryUsageEvidence(
+      'The deploy port is 37777 and the release script is scripts/release-npm.sh.',
+      [{ id: 'resp-3', content: 'Completely unrelated discussion about weather patterns and marine biology today.' }]
+    );
+
+    expect(result.contentOverlapScore).toBeLessThan(0.2);
+    expect(result.matches).toHaveLength(0);
+  });
+
+  it('handles Korean content via character bigrams', () => {
+    const result = computeMemoryUsageEvidence(
+      '배포 포트는 37777이고 릴리즈 스크립트는 release-npm.sh 입니다.',
+      [{ id: 'resp-4', content: '네, 배포 포트는 37777이고 릴리즈 스크립트는 release-npm.sh 입니다. 실행할게요.' }]
+    );
+
+    expect(result.contentOverlapScore).toBeGreaterThan(0.5);
+    expect(result.matches.length).toBeGreaterThan(0);
+  });
+
+  it('returns empty evidence when there are no responses', () => {
+    const result = computeMemoryUsageEvidence('some memory content here', []);
+    expect(result).toEqual({ contentOverlapScore: 0, coverage: 0, matches: [] });
+  });
+
+  it('does not treat a shared markdown heading as grounding evidence', () => {
+    const result = computeMemoryUsageEvidence(
+      '## Configuration',
+      [{ id: 'resp-h', content: 'You can change the configuration in the settings file.' }]
+    );
+
+    expect(result.contentOverlapScore).toBe(0);
+    expect(result.matches).toHaveLength(0);
+  });
+
+  it('ignores snippets with too few informative tokens', () => {
+    // "the configuration" carries a single informative token — matching it
+    // in an answer proves nothing about memory reuse.
+    const result = computeMemoryUsageEvidence(
+      'the configuration',
+      [{ id: 'resp-t', content: 'Update the configuration now.' }]
+    );
+
+    expect(result.contentOverlapScore).toBe(0);
+    expect(result.matches).toHaveLength(0);
+  });
+
+  it('skips heading lines but still matches factual lines below them', () => {
+    const result = computeMemoryUsageEvidence(
+      '## Deploy\nThe deploy port is 37777 and the release script is scripts/release-npm.sh.',
+      [{ id: 'resp-d', content: 'Deploy info: the deploy port is 37777 and the release script is scripts/release-npm.sh.' }]
+    );
+
+    expect(result.contentOverlapScore).toBeGreaterThan(0.6);
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0].memorySnippet).toContain('deploy port');
+  });
+});

--- a/tests/core/usefulness-history.test.ts
+++ b/tests/core/usefulness-history.test.ts
@@ -1,0 +1,317 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createRequire } from 'node:module';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { SQLiteEventStore } from '../../src/core/sqlite-event-store.js';
+
+const require = createRequire(import.meta.url);
+const Database = require('better-sqlite3') as typeof import('better-sqlite3');
+
+const tempDirs: string[] = [];
+
+function tempDbPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'cml-usefulness-history-'));
+  tempDirs.push(dir);
+  return join(dir, 'events.sqlite');
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+async function appendEvent(
+  store: SQLiteEventStore,
+  eventType: 'user_prompt' | 'agent_response' | 'tool_observation',
+  sessionId: string,
+  content: string,
+  timestamp: Date
+): Promise<string> {
+  const result = await store.append({ eventType, sessionId, content, timestamp });
+  if (!result.success) throw new Error(`append failed: ${result.error}`);
+  return result.eventId;
+}
+
+describe('usefulness evidence history (store integration)', () => {
+  it('links question -> injected memory -> grounded helpfulness with evidence', async () => {
+    const store = new SQLiteEventStore(tempDbPath());
+    await store.initialize();
+
+    const past = new Date('2026-01-01T10:00:00.000Z');
+    const memoryId = await appendEvent(
+      store,
+      'agent_response',
+      'old-session',
+      'The deploy port is 37777 and the release script is scripts/release-npm.sh.',
+      past
+    );
+
+    await appendEvent(store, 'user_prompt', 's1', 'how do I deploy this project?', new Date('2026-01-02T10:00:00.000Z'));
+    await store.recordRetrieval(memoryId, 's1', 0.9, 'how do I deploy this project?', {
+      traceId: 'trace-1',
+      source: 'user_prompt'
+    });
+    await store.recordRetrievalTrace({
+      traceId: 'trace-1',
+      sessionId: 's1',
+      queryText: 'how do I deploy this project?',
+      rawQueryText: 'how do I deploy this project?',
+      strategy: 'hybrid',
+      candidateEventIds: [memoryId],
+      selectedEventIds: [memoryId],
+      confidence: 'high'
+    });
+
+    // Assistant answer that clearly reuses the memory (a day later, so it is
+    // unambiguously "after" the retrieval row's datetime('now') timestamp).
+    await appendEvent(
+      store,
+      'agent_response',
+      's1',
+      'You deploy it like this: the deploy port is 37777 and the release script is scripts/release-npm.sh.',
+      new Date('2100-01-01T10:00:00.000Z')
+    );
+
+    await store.evaluateSessionHelpfulness('s1');
+
+    const stats = await store.getHelpfulnessStats();
+    expect(stats.totalEvaluated).toBe(1);
+    expect(stats.contentEvaluated).toBe(1);
+    expect(stats.avgContentOverlap).toBeGreaterThan(0.5);
+    expect(stats.groundedCount).toBe(1);
+
+    const history = await store.getUsefulnessHistory();
+    expect(history).toHaveLength(1);
+    const entry = history[0];
+    expect(entry.kind).toBe('query');
+    expect(entry.traceId).toBe('trace-1');
+    expect(entry.question).toBe('how do I deploy this project?');
+    expect(entry.memories).toHaveLength(1);
+    expect(entry.memories[0].eventId).toBe(memoryId);
+    expect(entry.memories[0].helpfulnessScore).toBeGreaterThan(0.5);
+    expect(entry.memories[0].contentOverlapScore).toBeGreaterThan(0.5);
+    expect(entry.memories[0].evidence.length).toBeGreaterThan(0);
+    expect(entry.memories[0].evidence[0].responseSnippet.length).toBeGreaterThan(0);
+
+    await store.close();
+  });
+
+  it('grounds against the injected snapshot, not the full stored event', async () => {
+    const store = new SQLiteEventStore(tempDbPath());
+    await store.initialize();
+
+    // A memory whose distinctive fact lives beyond the 300-char injection cut.
+    const filler = 'This memory starts with generic filler text that pads the beginning of the event. '.repeat(4);
+    const lateFact = 'The production database password rotation runs every fourteen days via cron.';
+    const memoryId = await appendEvent(
+      store,
+      'agent_response',
+      'old-session',
+      `${filler}\n${lateFact}`,
+      new Date('2026-01-01T10:00:00.000Z')
+    );
+
+    const injectedSnapshot = `${filler}\n${lateFact}`.substring(0, 300);
+    await store.recordRetrieval(memoryId, 's-snap', 0.9, 'how does rotation work?', {
+      traceId: 'trace-snap',
+      injectedContent: injectedSnapshot
+    });
+    await store.recordRetrievalTrace({
+      traceId: 'trace-snap',
+      sessionId: 's-snap',
+      queryText: 'how does rotation work?',
+      rawQueryText: 'how does rotation work?',
+      strategy: 'hybrid',
+      candidateEventIds: [memoryId],
+      selectedEventIds: [memoryId],
+      confidence: 'high'
+    });
+
+    // The answer contains ONLY the late fact the model never saw.
+    await appendEvent(
+      store,
+      'agent_response',
+      's-snap',
+      `Answering: ${lateFact}`,
+      new Date('2100-01-01T10:00:00.000Z')
+    );
+
+    await store.evaluateSessionHelpfulness('s-snap');
+
+    const history = await store.getUsefulnessHistory();
+    const memory = history[0]?.memories?.[0];
+    expect(memory).toBeDefined();
+    // The un-injected fact must not count as grounding evidence.
+    expect(memory!.evidence.every(e => !e.memorySnippet.includes('fourteen days'))).toBe(true);
+    expect(memory!.contentOverlapScore ?? 0).toBeLessThan(0.3);
+
+    await store.close();
+  });
+
+  it('does not count the triggering prompt as activity after the retrieval', async () => {
+    const dbPath = tempDbPath();
+    const store = new SQLiteEventStore(dbPath);
+    await store.initialize();
+
+    const memoryId = await appendEvent(
+      store,
+      'agent_response',
+      'old-session',
+      'Some earlier memory content about deployments.',
+      new Date('2026-01-01T10:00:00.000Z')
+    );
+
+    // Same-second flow as the real hook: the prompt is stored (ms ISO
+    // timestamp), then the retrieval is recorded moments later.
+    await appendEvent(store, 'user_prompt', 's-now', 'current question about deploys', new Date());
+    await store.recordRetrieval(memoryId, 's-now', 0.8, 'current question about deploys', { traceId: 'trace-now' });
+
+    await store.evaluateSessionHelpfulness('s-now');
+
+    const db = new Database(dbPath, { readonly: true });
+    const row = db.prepare(`SELECT prompt_count_after, session_continued FROM memory_helpfulness WHERE session_id = 's-now'`).get() as any;
+    db.close();
+
+    expect(row.prompt_count_after).toBe(0);
+    expect(row.session_continued).toBe(0);
+
+    await store.close();
+  });
+
+  it('keeps the behavioral fallback when no responses follow the retrieval', async () => {
+    const store = new SQLiteEventStore(tempDbPath());
+    await store.initialize();
+
+    const memoryId = await appendEvent(
+      store,
+      'agent_response',
+      'old-session',
+      'Remember to bump the version before publishing.',
+      new Date('2026-01-01T10:00:00.000Z')
+    );
+    await store.recordRetrieval(memoryId, 's2', 0.8, 'publish flow?', { traceId: 'trace-2' });
+
+    await store.evaluateSessionHelpfulness('s2');
+
+    const stats = await store.getHelpfulnessStats();
+    expect(stats.totalEvaluated).toBe(1);
+    expect(stats.contentEvaluated).toBe(0);
+
+    await store.close();
+  });
+
+  it('surfaces session-start injection batches as history entries', async () => {
+    const store = new SQLiteEventStore(tempDbPath());
+    await store.initialize();
+
+    const memoryId = await appendEvent(
+      store,
+      'agent_response',
+      'old-session',
+      'Previous work: refactored the retrieval orchestrator for trace linking.',
+      new Date('2026-01-01T10:00:00.000Z')
+    );
+    await store.recordRetrieval(memoryId, 's3', 0.5, '[session-start] recent project context', {
+      traceId: 'batch-1',
+      source: 'session_start'
+    });
+
+    const history = await store.getUsefulnessHistory();
+    expect(history).toHaveLength(1);
+    expect(history[0].kind).toBe('session_start');
+    expect(history[0].strategy).toBe('session-start');
+    expect(history[0].memories).toHaveLength(1);
+    expect(history[0].memories[0].source).toBe('session_start');
+    // Not yet evaluated -> no helpfulness score exposed.
+    expect(history[0].memories[0].helpfulnessScore).toBeNull();
+
+    await store.close();
+  });
+
+  it('degrades gracefully on a read-only legacy DB without the new columns', async () => {
+    const dbPath = tempDbPath();
+    // Build a pre-migration schema by hand: no trace_id/source/grounding columns.
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE events (
+        id TEXT PRIMARY KEY, event_type TEXT NOT NULL, session_id TEXT NOT NULL,
+        timestamp TEXT NOT NULL, content TEXT NOT NULL, canonical_key TEXT NOT NULL,
+        dedupe_key TEXT UNIQUE, metadata TEXT, access_count INTEGER DEFAULT 0, last_accessed_at TEXT
+      );
+      CREATE TABLE memory_helpfulness (
+        id TEXT PRIMARY KEY, event_id TEXT NOT NULL, session_id TEXT NOT NULL,
+        retrieval_score REAL DEFAULT 0, query_preview TEXT,
+        session_continued INTEGER DEFAULT 0, prompt_count_after INTEGER DEFAULT 0,
+        tool_success_count INTEGER DEFAULT 0, tool_total_count INTEGER DEFAULT 0,
+        was_reasked INTEGER DEFAULT 0, helpfulness_score REAL DEFAULT 0.5,
+        created_at TEXT DEFAULT (datetime('now')), measured_at TEXT
+      );
+      CREATE TABLE retrieval_traces (
+        trace_id TEXT PRIMARY KEY, session_id TEXT, project_hash TEXT,
+        query_text TEXT NOT NULL, raw_query_text TEXT, query_rewrite_kind TEXT, strategy TEXT,
+        candidate_event_ids TEXT, selected_event_ids TEXT,
+        candidate_details_json TEXT, selected_details_json TEXT,
+        candidate_count INTEGER DEFAULT 0, selected_count INTEGER DEFAULT 0,
+        confidence TEXT, fallback_trace TEXT, created_at TEXT DEFAULT (datetime('now'))
+      );
+    `);
+    db.prepare(`INSERT INTO events (id, event_type, session_id, timestamp, content, canonical_key)
+                VALUES ('legacy-mem', 'agent_response', 'old', '2026-01-01T10:00:00.000Z', 'legacy memory content for read-only test', 'ck')`).run();
+    db.prepare(`INSERT INTO memory_helpfulness (id, event_id, session_id, retrieval_score, query_preview, helpfulness_score, measured_at)
+                VALUES ('h1', 'legacy-mem', 's-legacy', 0.7, 'legacy question', 0.75, datetime('now'))`).run();
+    db.prepare(`INSERT INTO retrieval_traces (trace_id, session_id, query_text, raw_query_text, strategy, candidate_event_ids, selected_event_ids, candidate_count, selected_count)
+                VALUES ('t-legacy', 's-legacy', 'legacy question', 'legacy question', 'keyword', '["legacy-mem"]', '["legacy-mem"]', 1, 1)`).run();
+    db.close();
+
+    const store = new SQLiteEventStore(dbPath, { readonly: true });
+    await store.initialize();
+
+    const stats = await store.getHelpfulnessStats();
+    expect(stats.totalEvaluated).toBe(1);
+    expect(stats.contentEvaluated).toBe(0);
+    expect(stats.avgContentOverlap).toBe(0);
+
+    const history = await store.getUsefulnessHistory();
+    expect(history).toHaveLength(1);
+    expect(history[0].question).toBe('legacy question');
+    expect(history[0].memories).toHaveLength(1);
+    expect(history[0].memories[0].eventId).toBe('legacy-mem');
+    expect(history[0].memories[0].evidence).toEqual([]);
+
+    await store.close();
+  });
+
+  it('falls back to session+event matching for legacy rows without trace_id', async () => {
+    const store = new SQLiteEventStore(tempDbPath());
+    await store.initialize();
+
+    const memoryId = await appendEvent(
+      store,
+      'agent_response',
+      'old-session',
+      'Legacy memory content used before trace linking existed.',
+      new Date('2026-01-01T10:00:00.000Z')
+    );
+    // Legacy row: no traceId option (trace_id NULL).
+    await store.recordRetrieval(memoryId, 's4', 0.7, 'legacy question');
+    await store.recordRetrievalTrace({
+      sessionId: 's4',
+      queryText: 'legacy question',
+      rawQueryText: 'legacy question',
+      strategy: 'keyword',
+      candidateEventIds: [memoryId],
+      selectedEventIds: [memoryId],
+      confidence: 'suggested'
+    });
+
+    const history = await store.getUsefulnessHistory();
+    expect(history).toHaveLength(1);
+    expect(history[0].memories).toHaveLength(1);
+    expect(history[0].memories[0].eventId).toBe(memoryId);
+
+    await store.close();
+  });
+});

--- a/tests/core/vector-store-v2.test.ts
+++ b/tests/core/vector-store-v2.test.ts
@@ -139,4 +139,30 @@ describe('VectorStore V2 upsert', () => {
       expect.objectContaining({ id: 'task-1' })
     ]);
   });
+
+  it('reopens and retries an idempotent upsert after a Lance commit conflict', async () => {
+    const table = mocks.makeTable('conversations');
+    table.delete.mockRejectedValueOnce(new Error(
+      'lance error: Commit conflict: concurrent commit cannot be resolved. Please rerun the operation.'
+    ));
+    const store = new VectorStore('/tmp/cml-vectors');
+
+    await expect(store.upsert(record())).resolves.toBeUndefined();
+
+    expect(mocks.db.openTable).toHaveBeenCalledTimes(2);
+    expect(table.delete).toHaveBeenCalledTimes(2);
+    expect(table.add).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry unrelated Lance write failures', async () => {
+    const table = mocks.makeTable('conversations');
+    table.delete.mockRejectedValueOnce(new Error('permission denied'));
+    const store = new VectorStore('/tmp/cml-vectors');
+
+    await expect(store.upsert(record())).rejects.toThrow('permission denied');
+
+    expect(mocks.db.openTable).toHaveBeenCalledTimes(1);
+    expect(table.delete).toHaveBeenCalledTimes(1);
+    expect(table.add).not.toHaveBeenCalled();
+  });
 });

--- a/tests/core/vector-worker-concurrency.test.ts
+++ b/tests/core/vector-worker-concurrency.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { VectorWorker, VectorWorkerV2 } from '../../src/core/vector-worker.js';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(resolvePromise => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe('vector worker batch serialization', () => {
+  it('shares one physical legacy batch across overlapping callers', async () => {
+    const pending = deferred<never[]>();
+    const getPendingOutboxItems = vi.fn(() => pending.promise);
+    const worker = new VectorWorker(
+      { getPendingOutboxItems } as never,
+      {} as never,
+      {} as never
+    );
+
+    const first = worker.processBatch();
+    const second = worker.processBatch();
+
+    expect(getPendingOutboxItems).toHaveBeenCalledTimes(1);
+    pending.resolve([]);
+    await expect(Promise.all([first, second])).resolves.toEqual([0, 0]);
+  });
+
+  it('shares one physical V2 batch across overlapping callers', async () => {
+    const pending = deferred<never[]>();
+    const claimJobs = vi.fn(() => pending.promise);
+    const worker = new VectorWorkerV2(
+      {} as never,
+      {} as never,
+      {} as never
+    );
+    (worker as unknown as { outbox: { claimJobs: typeof claimJobs } }).outbox = { claimJobs };
+
+    const first = worker.processBatch();
+    const second = worker.processBatch();
+
+    expect(claimJobs).toHaveBeenCalledTimes(1);
+    pending.resolve([]);
+    await expect(Promise.all([first, second])).resolves.toEqual([0, 0]);
+  });
+
+  it.each([
+    ['legacy', () => new VectorWorker({} as never, {} as never, {} as never)],
+    ['V2', () => new VectorWorkerV2({} as never, {} as never, {} as never)]
+  ])('stops draining %s work after the active batch completes during shutdown', async (_kind, createWorker) => {
+    const worker = createWorker();
+    let resolveFirst!: (value: number) => void;
+    const first = new Promise<number>(resolve => {
+      resolveFirst = resolve;
+    });
+    const processBatch = vi.spyOn(worker, 'processBatch')
+      .mockImplementationOnce(() => first)
+      .mockResolvedValue(1);
+
+    const draining = worker.processAll();
+    worker.stop();
+    resolveFirst(1);
+
+    await expect(draining).resolves.toBe(1);
+    expect(processBatch).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Add evidence-grounded memory usefulness measurement by linking injected memory snapshots, retrieval traces, later assistant responses, and content-overlap evidence.
- Add usefulness history APIs and dashboard views for score breakdowns, retrieval quality, diagnostics, and per-question evidence inspection.
- Serialize legacy and V2 vector worker batches so background polling and explicit drains cannot write to LanceDB concurrently.
- Add project/global worker locks for Claude, Codex, and Hermes imports, bounded Lance commit-conflict retries, and stop-aware graceful shutdown.
- Keep the semantic retrieval daemon read-only so it cannot become an uncoordinated background vector writer.
- Release the combined changes as `claude-memory-layer@1.0.59`.

## Why

Memory usefulness previously relied mostly on behavioral signals and did not show whether injected memory was actually reflected in the resulting answer.

Separately, `claude-memory-layer import` could run the polling worker and `processAll()` at the same time. LanceDB upserts use delete followed by append, so overlapping batches could produce concurrent commit conflicts. Immediate process termination could then abort while native Lance work was still active, resulting in a secondary libc++ mutex failure.

## User and developer impact

- Usefulness scores now have auditable, content-grounded evidence and can be inspected from the dashboard.
- Import and manual embedding processing no longer overlap within a worker instance.
- Concurrent CML import/process commands coordinate through the same storage-scoped lock.
- Recognized Lance commit conflicts retry from a reopened table handle without masking unrelated failures.
- Shutdown waits for active vector work before closing SQLite and native resources.
- Existing `--no-process-embeddings` and import failure paths preserve cleanup semantics.

## Implementation notes

- Added the vector writer concurrency specification and completed implementation plan under `specs/vector-writer-concurrency/`.
- Added single-flight batch gates and idle waiting to both vector worker implementations.
- Added bounded exponential backoff for recognized Lance concurrent commit conflicts.
- Added project/global import lock resolution and actionable contention output.
- Made Codex and Hermes import initialization part of their guaranteed shutdown lifecycle.
- Preserved the published 1.0.58 usefulness/dashboard baseline while applying the concurrency fixes in 1.0.59.

## Validation

- `npm run typecheck`
- `npm run lint` — 0 errors; 44 existing `no-explicit-any` warnings
- `npm run test:run` — 158 test files, 920 tests passed
- `npm run build`
- `npm publish --dry-run`
- Verified npm registry `latest` points to `claude-memory-layer@1.0.59`
