### PR TITLE
feat(registry): route git worktrees to the main checkout's memory store

### DIFF
--- a/src/core/registry/git-utils.ts
+++ b/src/core/registry/git-utils.ts
@@ -1,0 +1,29 @@
+/**
+ * Low-level git helpers shared by project identity resolvers.
+ */
+
+import { execFileSync } from 'node:child_process';
+
+/**
+ * These take precedence over `-C <dir>`, so an inherited value would silently
+ * resolve a different repository than the one being asked about.
+ */
+const REPO_OVERRIDING_GIT_ENV = ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_COMMON_DIR'];
+
+/** Run a read-only git command in the given directory. Returns trimmed stdout, or null on any failure. */
+export function runGit(projectPath: string, args: string[]): string | null {
+  const env = { ...process.env };
+  for (const key of REPO_OVERRIDING_GIT_ENV) delete env[key];
+
+  try {
+    const output = execFileSync('git', ['-C', projectPath, ...args], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 1_000,
+      env
+    }).trim();
+    return output || null;
+  } catch {
+    return null;
+  }
+}

--- a/src/core/registry/project-path.ts
+++ b/src/core/registry/project-path.ts
@@ -9,6 +9,8 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
+import { runGit } from './git-utils.js';
+
 /**
  * Normalize and resolve a project path, handling symlinks when possible.
  */
@@ -24,13 +26,51 @@ export function normalizeProjectPath(projectPath: string): string {
   }
 }
 
+/** Cache of hash basis per normalized path; git layout does not change within a process run. */
+const hashBasisCache = new Map<string, string>();
+
+function computeHashBasisPath(normalizedPath: string): string {
+  const commonDir = runGit(normalizedPath, ['rev-parse', '--git-common-dir']);
+  if (!commonDir) return normalizedPath;
+
+  const absoluteCommonDir = path.isAbsolute(commonDir)
+    ? commonDir
+    : path.resolve(normalizedPath, commonDir);
+  if (path.basename(absoluteCommonDir) !== '.git') return normalizedPath;
+  const mainCheckoutRoot = normalizeProjectPath(path.dirname(absoluteCommonDir));
+
+  const topLevel = runGit(normalizedPath, ['rev-parse', '--show-toplevel']);
+  if (!topLevel) return normalizedPath;
+
+  // Inside the main checkout (its root or any subdirectory) the top level is
+  // the main checkout root, and the caller's own path is kept so existing
+  // project hashes never shift. Only a worktree, whose top level differs from
+  // the checkout owning the shared .git, is redirected onto the main checkout.
+  return normalizeProjectPath(topLevel) === mainCheckoutRoot ? normalizedPath : mainCheckoutRoot;
+}
+
+/**
+ * Resolve the path a project hash should be derived from, so that a git
+ * worktree hashes to the same value as the main checkout it shares a .git
+ * with. Main checkouts, subdirectories, and non-git paths hash to themselves.
+ */
+function resolveHashBasisPath(normalizedPath: string): string {
+  const cached = hashBasisCache.get(normalizedPath);
+  if (cached !== undefined) return cached;
+
+  const basis = computeHashBasisPath(normalizedPath);
+  hashBasisCache.set(normalizedPath, basis);
+  return basis;
+}
+
 /**
  * Generate a stable 8-character hash from a normalized project path.
  */
 export function hashProjectPath(projectPath: string): string {
   const normalizedPath = normalizeProjectPath(projectPath);
+  const hashBasis = resolveHashBasisPath(normalizedPath);
   return crypto.createHash('sha256')
-    .update(normalizedPath)
+    .update(hashBasis)
     .digest('hex')
     .slice(0, 8);
 }

--- a/src/core/registry/repo-identity.ts
+++ b/src/core/registry/repo-identity.ts
@@ -7,10 +7,10 @@
  */
 
 import * as crypto from 'node:crypto';
-import { execFileSync } from 'node:child_process';
 import * as path from 'node:path';
 
 import { hashProjectPath, normalizeProjectPath } from './project-path.js';
+import { runGit } from './git-utils.js';
 
 export type RepoIdentityKind = 'git-remote-common-dir' | 'git-common-dir' | 'path-fallback';
 
@@ -94,19 +94,6 @@ export function sanitizeGitRemote(value: string | null | undefined): string | nu
     .replace(/:/, '/');
   const safe = withoutScheme.replace(/^[^@\s/]+@/, '').replace(/\/+/g, '/').toLowerCase();
   return safe.length > 0 ? safe : null;
-}
-
-function runGit(projectPath: string, args: string[]): string | null {
-  try {
-    const output = execFileSync('git', ['-C', projectPath, ...args], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-      timeout: 1_000
-    }).trim();
-    return output || null;
-  } catch {
-    return null;
-  }
 }
 
 function normalizeGitPath(value: string | null, basePath: string): string | null {

--- a/tests/core/project-path.test.ts
+++ b/tests/core/project-path.test.ts
@@ -1,0 +1,81 @@
+import { execFileSync } from 'node:child_process';
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { hashProjectPath } from '../../src/core/registry/project-path.js';
+
+function git(cwd: string, args: string[]): void {
+  execFileSync('git', args, { cwd, stdio: 'ignore' });
+}
+
+/** The pre-existing hash: sha256 of the realpath, with no git resolution. */
+function legacyPathHash(target: string): string {
+  return crypto.createHash('sha256').update(fs.realpathSync(target)).digest('hex').slice(0, 8);
+}
+
+describe('hashProjectPath worktree convergence', () => {
+  let tmpRoot: string;
+  let mainRoot: string;
+  let mainSubdir: string;
+  let worktreeRoot: string;
+  let standaloneDir: string;
+
+  beforeAll(() => {
+    tmpRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'cml-project-path-')));
+    mainRoot = path.join(tmpRoot, 'main');
+    mainSubdir = path.join(mainRoot, 'src', 'core');
+    worktreeRoot = path.join(tmpRoot, 'worktree');
+    standaloneDir = path.join(tmpRoot, 'standalone');
+
+    fs.mkdirSync(mainRoot);
+    fs.mkdirSync(mainSubdir, { recursive: true });
+    fs.mkdirSync(standaloneDir);
+
+    git(mainRoot, ['init', '-q']);
+    git(mainRoot, ['config', 'user.email', 'test@example.com']);
+    git(mainRoot, ['config', 'user.name', 'Test']);
+    git(mainRoot, ['commit', '-q', '--allow-empty', '-m', 'init']);
+    git(mainRoot, ['worktree', 'add', '-q', worktreeRoot, '-b', 'feature']);
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('hashes a worktree checkout the same as its main checkout', () => {
+    expect(hashProjectPath(worktreeRoot)).toBe(hashProjectPath(mainRoot));
+  });
+
+  it('keeps the main checkout on its pre-existing path hash', () => {
+    expect(hashProjectPath(mainRoot)).toBe(legacyPathHash(mainRoot));
+  });
+
+  it('keeps a subdirectory of the main checkout on its own pre-existing hash', () => {
+    expect(hashProjectPath(mainSubdir)).toBe(legacyPathHash(mainSubdir));
+    expect(hashProjectPath(mainSubdir)).not.toBe(hashProjectPath(mainRoot));
+  });
+
+  it('keeps a non-git directory on its own pre-existing hash', () => {
+    expect(hashProjectPath(standaloneDir)).toBe(legacyPathHash(standaloneDir));
+    expect(hashProjectPath(standaloneDir)).not.toBe(hashProjectPath(mainRoot));
+  });
+
+  it('ignores inherited git env vars that would resolve another repository', () => {
+    // A path not hashed above, so the per-process cache cannot mask the env handling.
+    const uncachedDir = path.join(tmpRoot, 'standalone-env');
+    fs.mkdirSync(uncachedDir);
+
+    const previous = process.env.GIT_DIR;
+    process.env.GIT_DIR = path.join(mainRoot, '.git');
+    try {
+      expect(hashProjectPath(uncachedDir)).toBe(legacyPathHash(uncachedDir));
+    } finally {
+      if (previous === undefined) delete process.env.GIT_DIR;
+      else process.env.GIT_DIR = previous;
+    }
+  });
+});


### PR DESCRIPTION
## 문제

같은 프로젝트를 git worktree로 만들면 별도 프로젝트로 인식되어 메모리가 따로 쌓였습니다.

`hashProjectPath`(`src/core/registry/project-path.ts`)가 디렉토리의 realpath만 해싱했기 때문입니다. worktree는 자기 고유의 파일시스템 경로에 있으므로 다른 해시가 나오고, 결과적으로 `~/.claude-code/memory/projects/<hash>/` 아래 별도 store가 생성됐습니다.

`repo-identity.ts`에 git common-dir 기반으로 root/worktree/subdirectory를 하나로 수렴시키는 `resolveCanonicalRepoIdentity`가 이미 있었지만, 진단용(read-only)이라 `project identity scan` CLI에서만 쓰였고 실제 저장 경로에는 연결되어 있지 않았습니다.

## 변경 내용

`git rev-parse --git-common-dir`로 해시 기준 경로를 결정합니다. 공유 `.git`을 소유한 checkout과 top level이 다른 경우 — 즉 worktree인 경우 — main checkout root로 해싱합니다.

**기존 해시는 하나도 이동하지 않습니다.** main checkout, 그 하위 디렉토리, non-git 경로는 모두 기존과 동일하게 자기 자신을 해싱합니다. (구현 중간 단계에서 하위 디렉토리까지 repo root로 수렴하는 문제가 있었고, 이는 요청 범위를 넘어 기존 store를 고아로 만들 수 있어 worktree로 한정했습니다. 회귀 테스트로 고정.)

부수 변경:
- `runGit` 헬퍼를 `git-utils.ts`로 추출해 `repo-identity.ts`와 공유 (중복 제거).
- `GIT_DIR`/`GIT_WORK_TREE`/`GIT_COMMON_DIR` 환경변수 제거 후 git 실행. 이 변수들은 `-C <dir>`보다 우선하므로, 상속된 값이 있으면 **다른 저장소**로 해석됩니다. 이제 이 로직이 메모리 *쓰기* 경로를 결정하므로 잘못된 프로젝트에 기록될 위험을 차단합니다.
- 경로별 memoize. `hashProjectPath`는 `sqlite-event-store.ts`의 행 단위 루프와 MCP handler/서버 API의 요청 단위 경로에서 호출되는데, 매 호출마다 동기 git 프로세스를 spawn하게 되므로 캐싱했습니다.

## 범위 — 기존 메모리는 병합하지 않음

이미 worktree별로 쌓인 store는 **그대로 남으며 자동 병합되지 않습니다.** 앞으로 생성되는 메모리만 main checkout store로 통합됩니다. 기존 store 병합은 되돌리기 어려운 작업이라 별도 마이그레이션으로 분리했습니다 (spec FR-B5의 write routing / explicit apply 단계).

## 검증

전체 스위트 통과: **164개 파일 / 975개 테스트**, `tsc --noEmit` 통과.

`tests/core/project-path.test.ts` 신규 — 실제 임시 저장소에 `git worktree add`로 검증:

| 대상 | 결과 |
|---|---|
| worktree | main checkout과 동일 해시 ✅ |
| main checkout root | 기존 해시 유지 ✅ |
| main의 하위 디렉토리 | 고유 해시 유지 ✅ |
| non-git 디렉토리 | 고유 해시 유지 ✅ |
| `GIT_DIR` 상속 시 | 무시하고 올바른 해시 ✅ |

새 테스트는 각 수정을 되돌렸을 때 실제로 실패하는지 확인해 vacuous test가 아님을 검증했습니다.

실제 저장소 확인 — worktree와 main repo가 동일 프로젝트로 수렴, 하위 디렉토리는 분리 유지:

```
this worktree:        73c3b2b0
main repo:            73c3b2b0   ← 수렴
main repo src/core:   f9460e73   ← 기존대로 분리
```

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)