### PR TITLE
fix: tool_observation을 임베딩 인덱싱에서 제외 + 기존 벡터 정리 백필

### DIFF
--- a/src/apps/cli/index.ts
+++ b/src/apps/cli/index.ts
@@ -89,6 +89,12 @@ import {
   resolveLegacyProjectScopeRepairOptions
 } from './repair-command.js';
 import {
+  formatPruneToolObservationVectorsResult,
+  resolvePruneToolObservationVectorsOptions
+} from './prune-tool-observation-vectors-command.js';
+import { pruneToolObservationVectors } from '../../core/operations/tool-observation-vector-backfill.js';
+import { VectorStore } from '../../core/vector-store.js';
+import {
   formatRetentionAuditReport,
   resolveRetentionAuditOptions
 } from './retention-audit-command.js';
@@ -1370,6 +1376,43 @@ repairCommand
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       console.error(`Repair failed: ${message}`);
+      process.exit(1);
+    }
+  });
+
+repairCommand
+  .command('prune-tool-observation-vectors')
+  .description('Delete already-embedded tool_observation vectors from LanceDB (dry-run by default)')
+  .option('-p, --project <path>', 'Project path (defaults to cwd)')
+  .option('--apply', 'Delete vectors and remove their outbox rows (default is dry-run preview)')
+  .action(async (options) => {
+    try {
+      const pruneOptions = resolvePruneToolObservationVectorsOptions(options);
+      const storagePath = getProjectStoragePath(pruneOptions.projectPath);
+      const dbPath = path.join(storagePath, 'events.sqlite');
+
+      if (pruneOptions.dryRun && !fs.existsSync(dbPath)) {
+        console.log(formatPruneToolObservationVectorsResult({
+          dryRun: true,
+          scanned: 0,
+          vectorsDeleted: 0,
+          outboxRowsRemoved: 0,
+          sampleEventIds: []
+        }));
+        return;
+      }
+
+      const store = new SQLiteEventStore(dbPath, { readonly: pruneOptions.dryRun });
+      const vectorStore = new VectorStore(path.join(storagePath, 'vectors'));
+      try {
+        const result = await pruneToolObservationVectors(store, vectorStore, { dryRun: pruneOptions.dryRun });
+        console.log(formatPruneToolObservationVectorsResult(result));
+      } finally {
+        await store.close().catch(() => undefined);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`Prune tool_observation vectors failed: ${message}`);
       process.exit(1);
     }
   });

--- a/src/apps/cli/prune-tool-observation-vectors-command.ts
+++ b/src/apps/cli/prune-tool-observation-vectors-command.ts
@@ -1,0 +1,47 @@
+import type { ToolObservationVectorPruneResult } from '../../core/operations/tool-observation-vector-backfill.js';
+
+export interface PruneToolObservationVectorsCommandOptions {
+  project?: string;
+  apply?: boolean;
+}
+
+export interface ResolvedPruneToolObservationVectorsOptions {
+  projectPath: string;
+  dryRun: boolean;
+}
+
+export function resolvePruneToolObservationVectorsOptions(
+  options: PruneToolObservationVectorsCommandOptions,
+  cwd: string = process.cwd()
+): ResolvedPruneToolObservationVectorsOptions {
+  if (options.project !== undefined && options.project.trim().length === 0) {
+    throw new Error('prune tool-observation-vectors --project must not be empty');
+  }
+  return {
+    projectPath: options.project ?? cwd,
+    dryRun: options.apply !== true
+  };
+}
+
+export function formatPruneToolObservationVectorsResult(result: ToolObservationVectorPruneResult): string {
+  const lines = [
+    'Prune tool_observation vectors',
+    `Mode: ${result.dryRun ? 'dry-run' : 'apply'}`,
+    `Scanned: ${result.scanned}`,
+    `Vectors deleted: ${result.vectorsDeleted}`,
+    `Outbox rows removed: ${result.outboxRowsRemoved}`
+  ];
+
+  if (result.sampleEventIds.length > 0) {
+    lines.push('Sample event IDs:');
+    for (const eventId of result.sampleEventIds) {
+      lines.push(`- ${eventId}`);
+    }
+  }
+
+  if (result.dryRun) {
+    lines.push('Dry-run only. Re-run with --apply to delete these vectors from LanceDB.');
+  }
+
+  return lines.join('\n');
+}

--- a/src/core/operations/index.ts
+++ b/src/core/operations/index.ts
@@ -24,3 +24,4 @@ export * from './perspective-deriver.js';
 export * from './perspective-query-agent.js';
 export * from './perspective-consolidator.js';
 export * from './perspective-session-actor-backfill.js';
+export * from './tool-observation-vector-backfill.js';

--- a/src/core/operations/tool-observation-vector-backfill.ts
+++ b/src/core/operations/tool-observation-vector-backfill.ts
@@ -1,0 +1,56 @@
+/**
+ * Backfill: prune tool_observation vectors that were embedded before the
+ * append()/importEvents() vector-outbox exclusion existed. The exclusion
+ * only stops *new* tool_observation events from being queued for embedding;
+ * this operation cleans up ones already embedded into LanceDB.
+ */
+
+export interface ToolObservationVectorPruneStore {
+  listEventIdsByType(eventType: string): Promise<string[]>;
+  removeVectorOutboxRowsForEventIds(eventIds: string[]): Promise<number>;
+}
+
+export interface ToolObservationVectorPruneVectorStore {
+  deleteEventEverywhere(eventId: string): Promise<void>;
+}
+
+export interface ToolObservationVectorPruneOptions {
+  dryRun?: boolean;
+}
+
+export interface ToolObservationVectorPruneResult {
+  dryRun: boolean;
+  scanned: number;
+  vectorsDeleted: number;
+  outboxRowsRemoved: number;
+  sampleEventIds: string[];
+}
+
+const SAMPLE_LIMIT = 20;
+
+export async function pruneToolObservationVectors(
+  store: ToolObservationVectorPruneStore,
+  vectorStore: ToolObservationVectorPruneVectorStore,
+  options: ToolObservationVectorPruneOptions = {}
+): Promise<ToolObservationVectorPruneResult> {
+  const dryRun = options.dryRun === true;
+  const eventIds = await store.listEventIdsByType('tool_observation');
+  const sampleEventIds = eventIds.slice(0, SAMPLE_LIMIT);
+
+  if (dryRun || eventIds.length === 0) {
+    return { dryRun, scanned: eventIds.length, vectorsDeleted: 0, outboxRowsRemoved: 0, sampleEventIds };
+  }
+
+  for (const eventId of eventIds) {
+    await vectorStore.deleteEventEverywhere(eventId);
+  }
+  const outboxRowsRemoved = await store.removeVectorOutboxRowsForEventIds(eventIds);
+
+  return {
+    dryRun,
+    scanned: eventIds.length,
+    vectorsDeleted: eventIds.length,
+    outboxRowsRemoved,
+    sampleEventIds
+  };
+}

--- a/src/core/sqlite-event-store.ts
+++ b/src/core/sqlite-event-store.ts
@@ -286,13 +286,14 @@ export class SQLiteEventStore {
     return new VectorOutbox(this.db, option ?? {});
   }
 
-  private enqueueVectorOutboxEventSync(eventId: string): void {
+  private enqueueVectorOutboxEventSync(eventId: string, eventType: string): void {
     if (!this.vectorOutbox) return;
+    if (eventType === 'tool_observation') return;
     this.vectorOutbox.enqueueSync('event', eventId);
   }
 
-  private async enqueueVectorOutboxEvent(eventId: string): Promise<void> {
-    this.enqueueVectorOutboxEventSync(eventId);
+  private async enqueueVectorOutboxEvent(eventId: string, eventType: string): Promise<void> {
+    this.enqueueVectorOutboxEventSync(eventId, eventType);
   }
 
   /**
@@ -1026,7 +1027,7 @@ export class SQLiteEventStore {
 
     if (existing) {
       try {
-        await this.enqueueVectorOutboxEvent(existing.event_id);
+        await this.enqueueVectorOutboxEvent(existing.event_id, input.eventType);
       } catch (error) {
         return {
           success: false,
@@ -1076,7 +1077,7 @@ export class SQLiteEventStore {
         );
         insertDedup.run(dedupeKey, id);
         insertLevel.run(id);
-        this.enqueueVectorOutboxEventSync(id);
+        this.enqueueVectorOutboxEventSync(id, input.eventType);
       });
 
       transaction();
@@ -1425,7 +1426,7 @@ export class SQLiteEventStore {
 
         insertDedup.run(dedupeKey, ev.id);
         insertLevel.run(ev.id);
-        this.enqueueVectorOutboxEventSync(ev.id);
+        this.enqueueVectorOutboxEventSync(ev.id, ev.eventType);
         inserted++;
         insertedEvents.push(ev);
       }
@@ -1766,6 +1767,34 @@ export class SQLiteEventStore {
     return result;
   }
 
+
+  /**
+   * List event IDs for a given event type (used by maintenance/backfill tooling).
+   */
+  async listEventIdsByType(eventType: string): Promise<string[]> {
+    await this.initialize();
+    const rows = sqliteAll<{ id: string }>(
+      this.db,
+      `SELECT id FROM events WHERE event_type = ? ORDER BY timestamp ASC`,
+      [eventType]
+    );
+    return rows.map((row) => row.id);
+  }
+
+  /**
+   * Remove vector_outbox rows for the given event ids (item_kind = 'event').
+   * Used after pruning already-embedded vectors so the outbox stops reporting
+   * them as done work.
+   */
+  async removeVectorOutboxRowsForEventIds(eventIds: string[]): Promise<number> {
+    if (eventIds.length === 0) return 0;
+    await this.initialize();
+    const placeholders = eventIds.map(() => '?').join(', ');
+    const result = this.db.prepare(
+      `DELETE FROM vector_outbox WHERE item_kind = 'event' AND item_id IN (${placeholders})`
+    ).run(...eventIds);
+    return Number(result.changes ?? 0);
+  }
 
   /**
    * Repair legacy imported events that predate canonical project scope metadata.

--- a/src/core/vector-store.ts
+++ b/src/core/vector-store.ts
@@ -112,7 +112,7 @@ export class VectorStore {
 
     // Apply session filter if specified
     if (sessionId) {
-      query = query.where(`sessionId = ${toLanceSqlString(sessionId)}`);
+      query = query.where(toLanceColumnEquals('sessionId', sessionId));
     }
 
     const results = await query.toArray();
@@ -149,7 +149,28 @@ export class VectorStore {
     await this.initialize();
     const table = await this.getExistingTable(this.defaultTableName);
     if (!table) return;
-    await table.delete(`eventId = ${toLanceSqlString(eventId)}`);
+    await table.delete(toLanceColumnEquals('eventId', eventId));
+  }
+
+  /**
+   * Delete a vector by event ID from every table that could hold it: the
+   * legacy conversations table plus every `event_vectors_<embeddingVersion>`
+   * table (there can be more than one after an embedding model migration).
+   */
+  async deleteEventEverywhere(eventId: string): Promise<void> {
+    await this.initialize();
+    if (!this.db) return;
+
+    const tableNames = await this.db.tableNames();
+    const targetTables = tableNames.filter(
+      (name) => name === this.defaultTableName || name.startsWith('event_vectors_')
+    );
+
+    for (const tableName of targetTables) {
+      const table = await this.getExistingTable(tableName);
+      if (!table) continue;
+      await table.delete(toLanceColumnEquals('eventId', eventId));
+    }
   }
 
   /**
@@ -193,7 +214,7 @@ export class VectorStore {
 
     const results = await table
       .search([])
-      .where(`eventId = ${toLanceSqlString(eventId)}`)
+      .where(toLanceColumnEquals('eventId', eventId))
       .limit(1)
       .toArray();
 
@@ -310,6 +331,15 @@ function slugifyTablePart(value: string): string {
 
 function toLanceSqlString(value: string): string {
   return `'${value.replace(/'/g, "''")}'`;
+}
+
+/**
+ * Lance's predicate parser lowercases unquoted identifiers, so camelCase
+ * columns (eventId, sessionId) silently fail to match the schema unless
+ * backtick-quoted (double quotes parse without error but never match either).
+ */
+function toLanceColumnEquals(column: string, value: string): string {
+  return `\`${column}\` = ${toLanceSqlString(value)}`;
 }
 
 function isAlreadyExistsError(error: unknown): boolean {

--- a/tests/apps/prune-tool-observation-vectors-command.test.ts
+++ b/tests/apps/prune-tool-observation-vectors-command.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatPruneToolObservationVectorsResult,
+  resolvePruneToolObservationVectorsOptions
+} from '../../src/apps/cli/prune-tool-observation-vectors-command.js';
+
+describe('prune tool-observation-vectors CLI helpers', () => {
+  it('defaults to cwd and dry-run, rejects empty --project', () => {
+    expect(resolvePruneToolObservationVectorsOptions({}, '/repo/current')).toEqual({
+      projectPath: '/repo/current',
+      dryRun: true
+    });
+    expect(resolvePruneToolObservationVectorsOptions({ project: '/repo/selected' }, '/repo/current')).toEqual({
+      projectPath: '/repo/selected',
+      dryRun: true
+    });
+    expect(resolvePruneToolObservationVectorsOptions({ apply: true }, '/repo/current')).toEqual({
+      projectPath: '/repo/current',
+      dryRun: false
+    });
+    expect(() => resolvePruneToolObservationVectorsOptions({ project: '   ' }, '/repo/current')).toThrow(
+      '--project must not be empty'
+    );
+  });
+
+  it('formats a dry-run report with samples and the re-run hint', () => {
+    const output = formatPruneToolObservationVectorsResult({
+      dryRun: true,
+      scanned: 3,
+      vectorsDeleted: 0,
+      outboxRowsRemoved: 0,
+      sampleEventIds: ['event-1', 'event-2']
+    });
+
+    expect(output).toContain('Mode: dry-run');
+    expect(output).toContain('Scanned: 3');
+    expect(output).toContain('Vectors deleted: 0');
+    expect(output).toContain('- event-1');
+    expect(output).toContain('- event-2');
+    expect(output).toContain('Re-run with --apply');
+  });
+
+  it('formats an apply report without the dry-run hint', () => {
+    const output = formatPruneToolObservationVectorsResult({
+      dryRun: false,
+      scanned: 3,
+      vectorsDeleted: 3,
+      outboxRowsRemoved: 3,
+      sampleEventIds: []
+    });
+
+    expect(output).toContain('Mode: apply');
+    expect(output).toContain('Vectors deleted: 3');
+    expect(output).toContain('Outbox rows removed: 3');
+    expect(output).not.toContain('Re-run with --apply');
+    expect(output).not.toContain('Sample event IDs:');
+  });
+});

--- a/tests/core/tool-observation-vector-backfill.test.ts
+++ b/tests/core/tool-observation-vector-backfill.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+import { pruneToolObservationVectors } from '../../src/core/operations/tool-observation-vector-backfill.js';
+
+function makeStore(eventIds: string[]) {
+  return {
+    listEventIdsByType: vi.fn().mockResolvedValue(eventIds),
+    removeVectorOutboxRowsForEventIds: vi.fn().mockResolvedValue(eventIds.length)
+  };
+}
+
+function makeVectorStore() {
+  return {
+    deleteEventEverywhere: vi.fn().mockResolvedValue(undefined)
+  };
+}
+
+describe('pruneToolObservationVectors', () => {
+  it('dry-run reports counts without deleting anything', async () => {
+    const store = makeStore(['tool-1', 'tool-2']);
+    const vectorStore = makeVectorStore();
+
+    const result = await pruneToolObservationVectors(store, vectorStore, { dryRun: true });
+
+    expect(result).toEqual({
+      dryRun: true,
+      scanned: 2,
+      vectorsDeleted: 0,
+      outboxRowsRemoved: 0,
+      sampleEventIds: ['tool-1', 'tool-2']
+    });
+    expect(vectorStore.deleteEventEverywhere).not.toHaveBeenCalled();
+    expect(store.removeVectorOutboxRowsForEventIds).not.toHaveBeenCalled();
+  });
+
+  it('apply mode deletes every tool_observation vector and removes their outbox rows', async () => {
+    const store = makeStore(['tool-1', 'tool-2', 'tool-3']);
+    const vectorStore = makeVectorStore();
+
+    const result = await pruneToolObservationVectors(store, vectorStore, { dryRun: false });
+
+    expect(vectorStore.deleteEventEverywhere).toHaveBeenCalledTimes(3);
+    expect(vectorStore.deleteEventEverywhere).toHaveBeenNthCalledWith(1, 'tool-1');
+    expect(vectorStore.deleteEventEverywhere).toHaveBeenNthCalledWith(2, 'tool-2');
+    expect(vectorStore.deleteEventEverywhere).toHaveBeenNthCalledWith(3, 'tool-3');
+    expect(store.removeVectorOutboxRowsForEventIds).toHaveBeenCalledWith(['tool-1', 'tool-2', 'tool-3']);
+    expect(result).toEqual({
+      dryRun: false,
+      scanned: 3,
+      vectorsDeleted: 3,
+      outboxRowsRemoved: 3,
+      sampleEventIds: ['tool-1', 'tool-2', 'tool-3']
+    });
+  });
+
+  it('apply mode is a no-op when there is nothing to prune', async () => {
+    const store = makeStore([]);
+    const vectorStore = makeVectorStore();
+
+    const result = await pruneToolObservationVectors(store, vectorStore, { dryRun: false });
+
+    expect(vectorStore.deleteEventEverywhere).not.toHaveBeenCalled();
+    expect(store.removeVectorOutboxRowsForEventIds).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      dryRun: false,
+      scanned: 0,
+      vectorsDeleted: 0,
+      outboxRowsRemoved: 0,
+      sampleEventIds: []
+    });
+  });
+
+  it('caps the reported sample at 20 event ids even when more are scanned', async () => {
+    const eventIds = Array.from({ length: 25 }, (_, i) => `tool-${i}`);
+    const store = makeStore(eventIds);
+    const vectorStore = makeVectorStore();
+
+    const result = await pruneToolObservationVectors(store, vectorStore, { dryRun: true });
+
+    expect(result.scanned).toBe(25);
+    expect(result.sampleEventIds).toHaveLength(20);
+    expect(result.sampleEventIds).toEqual(eventIds.slice(0, 20));
+  });
+});

--- a/tests/core/vector-outbox-v2.test.ts
+++ b/tests/core/vector-outbox-v2.test.ts
@@ -166,6 +166,79 @@ describe('automatic vector_outbox enqueue boundaries', () => {
     }
   });
 
+  it('never enqueues tool_observation events for embedding, from append() or duplicates', async () => {
+    const dbPath = createTempDbPath();
+    const store = new SQLiteEventStore(dbPath, {
+      vectorOutbox: { embeddingVersion: 'auto-tool-observation-v1' }
+    });
+
+    try {
+      await store.initialize();
+      const first = await store.append({
+        eventType: 'tool_observation',
+        sessionId: 'session-tool-observation',
+        timestamp: new Date('2026-05-25T00:00:00.000Z'),
+        content: 'tool observation content that must never be embedded'
+      });
+      const duplicate = await store.append({
+        eventType: 'tool_observation',
+        sessionId: 'session-tool-observation',
+        timestamp: new Date('2026-05-25T00:00:01.000Z'),
+        content: 'tool observation content that must never be embedded'
+      });
+
+      expect(first).toMatchObject({ success: true, isDuplicate: false });
+      expect(duplicate).toMatchObject({ success: true, isDuplicate: true });
+      expect(readOutboxRows(store.getDatabase() as Database.Database)).toEqual([]);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('listEventIdsByType and removeVectorOutboxRowsForEventIds support pruning already-embedded tool_observation vectors', async () => {
+    const dbPath = createTempDbPath();
+    // Simulate events embedded before the tool_observation exclusion existed:
+    // enqueue rows directly rather than through append(), which now skips them.
+    const store = new SQLiteEventStore(dbPath, {
+      vectorOutbox: { embeddingVersion: 'legacy-v1' }
+    });
+
+    try {
+      await store.initialize();
+      const toolEvent = await store.append({
+        eventType: 'tool_observation',
+        sessionId: 'session-legacy-tool',
+        timestamp: new Date('2026-05-25T00:00:00.000Z'),
+        content: 'legacy tool observation embedded before the exclusion fix'
+      });
+      const promptEvent = await store.append({
+        eventType: 'user_prompt',
+        sessionId: 'session-legacy-tool',
+        timestamp: new Date('2026-05-25T00:00:01.000Z'),
+        content: 'user prompt should be unaffected'
+      });
+      if (!toolEvent.success || !promptEvent.success) throw new Error('append failed');
+
+      const db = store.getDatabase() as Database.Database;
+      const outbox = new VectorOutbox(db, { embeddingVersion: 'legacy-v1' });
+      outbox.enqueueSync('event', toolEvent.eventId);
+      outbox.enqueueSync('event', promptEvent.eventId);
+
+      const toolObservationIds = await store.listEventIdsByType('tool_observation');
+      expect(toolObservationIds).toEqual([toolEvent.eventId]);
+
+      const removed = await store.removeVectorOutboxRowsForEventIds(toolObservationIds);
+      expect(removed).toBe(1);
+
+      const rows = readOutboxRows(db);
+      expect(rows).toEqual([
+        { item_kind: 'event', item_id: promptEvent.eventId, embedding_version: 'legacy-v1', status: 'pending' }
+      ]);
+    } finally {
+      await store.close();
+    }
+  });
+
   it('enqueues only newly imported events and skips imported duplicates', async () => {
     const dbPath = createTempDbPath();
     const store = new SQLiteEventStore(dbPath, {
@@ -209,8 +282,7 @@ describe('automatic vector_outbox enqueue boundaries', () => {
       const rows = readOutboxRows(store.getDatabase() as Database.Database);
       expect(rows).toEqual([
         { item_kind: 'event', item_id: eventA.id, embedding_version: 'auto-import-v1', status: 'pending' },
-        { item_kind: 'event', item_id: eventB.id, embedding_version: 'auto-import-v1', status: 'pending' },
-        { item_kind: 'event', item_id: eventC.id, embedding_version: 'auto-import-v1', status: 'pending' }
+        { item_kind: 'event', item_id: eventB.id, embedding_version: 'auto-import-v1', status: 'pending' }
       ]);
       expectPrivateSentinelsAbsent(rows, [
         'PRIVATE_IMPORT_EVENT_A_SENTINEL',

--- a/tests/core/vector-store-v2.test.ts
+++ b/tests/core/vector-store-v2.test.ts
@@ -165,4 +165,34 @@ describe('VectorStore V2 upsert', () => {
     expect(table.delete).toHaveBeenCalledTimes(1);
     expect(table.add).not.toHaveBeenCalled();
   });
+
+  it('deleteEventEverywhere removes the event from the legacy table and every event_vectors_* table, but not unrelated tables', async () => {
+    mocks.db.tableNames.mockResolvedValue([
+      'conversations',
+      'event_vectors_v1',
+      'event_vectors_minilm_l6_v2_0',
+      'task_title_vectors_v1'
+    ]);
+    const legacyTable = mocks.makeTable('conversations');
+    const eventTableV1 = mocks.makeTable('event_vectors_v1');
+    const eventTableV2 = mocks.makeTable('event_vectors_minilm_l6_v2_0');
+    const taskTable = mocks.makeTable('task_title_vectors_v1');
+    const store = new VectorStore('/tmp/cml-vectors');
+
+    await store.deleteEventEverywhere("tool-event-'1");
+
+    expect(legacyTable.delete).toHaveBeenCalledWith("`eventId` = 'tool-event-''1'");
+    expect(eventTableV1.delete).toHaveBeenCalledWith("`eventId` = 'tool-event-''1'");
+    expect(eventTableV2.delete).toHaveBeenCalledWith("`eventId` = 'tool-event-''1'");
+    expect(taskTable.delete).not.toHaveBeenCalled();
+  });
+
+  it('deleteEventEverywhere is a no-op when no matching tables exist', async () => {
+    mocks.db.tableNames.mockResolvedValue(['task_title_vectors_v1']);
+    const taskTable = mocks.makeTable('task_title_vectors_v1');
+    const store = new VectorStore('/tmp/cml-vectors');
+
+    await expect(store.deleteEventEverywhere('event-1')).resolves.toBeUndefined();
+    expect(taskTable.delete).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- 시맨틱 검색 결과에 tool 호출 원본(Bash/grep 등)이 섞여 정확도가 떨어지던 문제 수정: `append()`/`importEvents()`가 `tool_observation` 이벤트를 벡터 아웃박스(임베딩 큐)에 아예 넣지 않도록 변경
- 이미 임베딩되어 LanceDB에 남아있는 과거 `tool_observation` 벡터를 정리할 수 있는 `repair prune-tool-observation-vectors` CLI 명령 추가 (dry-run 기본, `--apply`로 실제 삭제)
- 실제 LanceDB로 스모크 테스트하는 과정에서 `VectorStore.delete()`/`exists()`/`search()`의 `sessionId` 필터가 이미 조용히 깨져 있던 버그 발견 및 수정: Lance predicate 파서가 unquoted camelCase 컬럼(`eventId` 등)을 소문자로 바꿔버려 매칭이 안 되고, 더블쿼트로도 안 고쳐지고 백틱 quoting만 동작함 — 공용 `toLanceColumnEquals()` 헬퍼로 수정 (신규 prune 기능이 실제 삭제 동작에 의존하기 때문에 필요했음)

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] `npx vitest run` — 166 files / 986 tests 전부 통과
- [x] 실제 LanceDB(mock 아님)로 append → 임베딩 시뮬레이션 → dry-run → apply → 벡터 실제 삭제 확인하는 스모크 테스트 수행

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)