### PR TITLE
fix(vectors): stop Lance version bloat and close the tool_observation embedding leak

### DIFF
--- a/src/core/engine/memory-ingest-service.ts
+++ b/src/core/engine/memory-ingest-service.ts
@@ -246,7 +246,12 @@ export class MemoryIngestService {
       }
 
       if (!result.isDuplicate) {
-        if (options.embeddingContent) {
+        // tool_observation is excluded from semantic embedding (see the V2
+        // vector_outbox skip in SQLiteEventStore.append()) — raw tool output,
+        // including full Agent/Task subagent responses, otherwise dominates
+        // and outranks actual prompts/answers in mem-search. This is the
+        // parallel legacy embedding_outbox path; it must skip the same way.
+        if (options.embeddingContent && options.operation !== 'tool_observation') {
           await this.eventStore.enqueueForEmbedding(result.eventId, options.embeddingContent);
         }
         try {

--- a/src/core/engine/memory-query-service.ts
+++ b/src/core/engine/memory-query-service.ts
@@ -43,6 +43,7 @@ interface QueryStore {
   getEvent(id: string): Promise<MemoryEvent | null>;
   getSessionEvents(sessionId: string): Promise<MemoryEvent[]>;
   getRecentEvents(limit: number): Promise<MemoryEvent[]>;
+  countEvents?(): Promise<number>;
 }
 
 interface QueryMaintenanceStore extends QueryStore {
@@ -179,12 +180,17 @@ export class MemoryQueryService {
     await this.initialize();
 
     const deps = this.getStatsDeps();
-    const recentEvents = await this.queryStore.getRecentEvents(10000);
+    // Counting via SQL, not by materializing rows: the old
+    // getRecentEvents(10000).length both capped the reported total at 10k and
+    // loaded every event body into memory to produce a single number.
+    const totalEvents = this.queryStore.countEvents
+      ? await this.queryStore.countEvents()
+      : (await this.queryStore.getRecentEvents(10000)).length;
     const vectorCount = await deps.vectorStore.count();
     const levelStats = await deps.graduation.getStats();
 
     return {
-      totalEvents: recentEvents.length,
+      totalEvents,
       vectorCount,
       levelStats
     };

--- a/src/core/vector-store.ts
+++ b/src/core/vector-store.ts
@@ -21,6 +21,18 @@ type LanceTable = lancedb.Table;
 const MAX_LANCE_COMMIT_ATTEMPTS = 3;
 const LANCE_COMMIT_RETRY_BASE_DELAY_MS = 20;
 
+/**
+ * Every Lance write is a new dataset version, and each version manifest embeds
+ * the full fragment list — so N un-pruned versions cost O(N^2) on disk. Without
+ * periodic pruning a busy project accumulates gigabytes of manifests for a few
+ * hundred megabytes of vectors. Optimize on a commit counter instead.
+ */
+const DEFAULT_OPTIMIZE_EVERY_N_COMMITS = 50;
+const DEFAULT_VERSION_RETENTION_MS = 60 * 60 * 1000;
+
+/** Lance parses the whole predicate string, so chunk oversized `id IN (...)` deletes. */
+const MAX_DELETE_PREDICATE_IDS = 200;
+
 type VectorRow = {
   id: string;
   eventId: string;
@@ -35,6 +47,7 @@ type VectorRow = {
 export class VectorStore {
   private db: lancedb.Connection | null = null;
   private readonly tableCache = new Map<string, LanceTable>();
+  private readonly commitsSinceOptimize = new Map<string, number>();
   private readonly defaultTableName = 'conversations';
 
   constructor(private dbPath: string) {}
@@ -250,13 +263,15 @@ export class VectorStore {
     rows: VectorRow[]
   ): Promise<void> {
     let table = initialTable;
+    const deletePredicates = buildIdDeletePredicates(rows.map(row => row.id));
 
     for (let attempt = 1; attempt <= MAX_LANCE_COMMIT_ATTEMPTS; attempt++) {
       try {
-        for (const row of rows) {
-          await table.delete(`id = ${toLanceSqlString(row.id)}`);
+        for (const predicate of deletePredicates) {
+          await table.delete(predicate);
         }
         await table.add(rows);
+        await this.maybeOptimize(tableName, table, deletePredicates.length + 1);
         return;
       } catch (error) {
         if (!isLanceCommitConflict(error) || attempt === MAX_LANCE_COMMIT_ATTEMPTS) {
@@ -268,6 +283,38 @@ export class VectorStore {
         table = await this.openTable(tableName);
       }
     }
+  }
+
+  /**
+   * Compact fragments and prune superseded versions across every table.
+   *
+   * Writers call this automatically via the commit counter; expose it so
+   * maintenance paths can reclaim space accumulated before that existed.
+   */
+  async optimizeAll(): Promise<void> {
+    await this.initialize();
+    if (!this.db) return;
+
+    for (const tableName of await this.db.tableNames()) {
+      const table = await this.getExistingTable(tableName);
+      if (!table) continue;
+      this.commitsSinceOptimize.set(tableName, 0);
+      await optimizeTable(table);
+    }
+  }
+
+  private async maybeOptimize(tableName: string, table: LanceTable, commits: number): Promise<void> {
+    const threshold = resolveOptimizeCommitInterval();
+    if (threshold <= 0) return;
+
+    const pending = (this.commitsSinceOptimize.get(tableName) ?? 0) + commits;
+    if (pending < threshold) {
+      this.commitsSinceOptimize.set(tableName, pending);
+      return;
+    }
+
+    this.commitsSinceOptimize.set(tableName, 0);
+    await optimizeTable(table);
   }
 
   private async getExistingTable(tableName: string): Promise<LanceTable | null> {
@@ -318,6 +365,52 @@ export class VectorStore {
       timestamp: record.timestamp,
       metadata: JSON.stringify(record.metadata || {})
     };
+  }
+}
+
+/**
+ * One `id IN (...)` delete per chunk instead of one delete per row: each Lance
+ * delete is its own commit, so per-row deletes made a 32-record batch cost 33
+ * versions instead of 2.
+ */
+function buildIdDeletePredicates(ids: string[]): string[] {
+  if (ids.length === 0) return [];
+  if (ids.length === 1) return [`id = ${toLanceSqlString(ids[0])}`];
+
+  const predicates: string[] = [];
+  for (let offset = 0; offset < ids.length; offset += MAX_DELETE_PREDICATE_IDS) {
+    const chunk = ids.slice(offset, offset + MAX_DELETE_PREDICATE_IDS);
+    predicates.push(`id IN (${chunk.map(toLanceSqlString).join(', ')})`);
+  }
+  return predicates;
+}
+
+function resolveOptimizeCommitInterval(): number {
+  const raw = process.env.CLAUDE_MEMORY_LANCE_OPTIMIZE_EVERY;
+  if (raw === undefined) return DEFAULT_OPTIMIZE_EVERY_N_COMMITS;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_OPTIMIZE_EVERY_N_COMMITS;
+}
+
+function resolveVersionRetentionMs(): number {
+  const raw = process.env.CLAUDE_MEMORY_LANCE_VERSION_RETENTION_MS;
+  if (raw === undefined) return DEFAULT_VERSION_RETENTION_MS;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_VERSION_RETENTION_MS;
+}
+
+/**
+ * Best-effort maintenance: a failed compaction must never fail the write that
+ * triggered it, and older lancedb builds have no `optimize` at all.
+ */
+async function optimizeTable(table: LanceTable): Promise<void> {
+  const optimize = (table as { optimize?: (options?: { cleanupOlderThan?: Date }) => Promise<unknown> }).optimize;
+  if (typeof optimize !== 'function') return;
+
+  try {
+    await optimize.call(table, { cleanupOlderThan: new Date(Date.now() - resolveVersionRetentionMs()) });
+  } catch {
+    // Compaction is opportunistic; retry on the next threshold crossing.
   }
 }
 

--- a/src/core/vector-worker.ts
+++ b/src/core/vector-worker.ts
@@ -495,46 +495,74 @@ export class VectorWorkerV2 {
       return 0;
     }
 
+    // Embed per job so one bad item can't poison the batch, but write the
+    // whole batch in a single upsert: every per-record upsert was its own pair
+    // of Lance commits, and un-pruned versions cost O(N^2) on disk.
+    const embedded: Array<{ job: OutboxJob; record: VectorRecord }> = [];
+    const skipped: OutboxJob[] = [];
     let successCount = 0;
 
     for (const job of jobs) {
       try {
-        await this.processJob(job);
+        const record = await this.buildRecord(job);
+        if (record) {
+          embedded.push({ job, record });
+        } else {
+          skipped.push(job);
+        }
+      } catch (error) {
+        await this.markJobFailed(job, error);
+      }
+    }
+
+    if (embedded.length > 0) {
+      try {
+        await this.vectorStore.upsertBatch(embedded.map(entry => entry.record));
+      } catch (error) {
+        for (const entry of embedded) {
+          await this.markJobFailed(entry.job, error);
+        }
+        embedded.length = 0;
+      }
+    }
+
+    for (const job of [...skipped, ...embedded.map(entry => entry.job)]) {
+      try {
         await this.outbox.markDone(job.jobId);
         successCount++;
       } catch (error) {
-        // Only try to mark as failed if not stopping (DB might be closed)
-        if (!this.stopping) {
-          try {
-            const errorMessage = error instanceof Error ? error.message : String(error);
-            await this.outbox.markFailed(job.jobId, errorMessage);
-          } catch {
-            // Database might be closed during shutdown, ignore
-          }
-        }
+        await this.markJobFailed(job, error);
       }
     }
 
     return successCount;
   }
 
+  private async markJobFailed(job: OutboxJob, error: unknown): Promise<void> {
+    // Only try to mark as failed if not stopping (DB might be closed)
+    if (this.stopping) return;
+    try {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      await this.outbox.markFailed(job.jobId, errorMessage);
+    } catch {
+      // Database might be closed during shutdown, ignore
+    }
+  }
+
   /**
-   * Process a single job
+   * Resolve and embed a single job. Returns null when the item no longer
+   * exists, which is a skip (marked done) rather than a failure.
    */
-  private async processJob(job: OutboxJob): Promise<void> {
-    // Get content
+  private async buildRecord(job: OutboxJob): Promise<VectorRecord | null> {
     const contentData = await this.contentProvider.getContent(job.itemKind, job.itemId);
 
     if (!contentData) {
-      // Item not found, mark as done (skip)
-      return;
+      return null;
     }
 
-    // Generate embedding
     const embedding = await this.embedder.embed(contentData.content);
 
-    // Upsert to vector store
-    const record: VectorRecord = {
+    return {
       id: `${job.itemKind}_${job.itemId}_${job.embeddingVersion}`,
       eventId: job.itemKind === 'event' ? job.itemId : '',
       sessionId: (contentData.metadata.sessionId as string) ?? '',
@@ -547,9 +575,6 @@ export class VectorWorkerV2 {
         embeddingVersion: job.embeddingVersion
       }
     };
-
-    // Use idempotent upsert (delete + add)
-    await this.vectorStore.upsertBatch([record]);
   }
 
   /**

--- a/src/extensions/mcp/handlers.ts
+++ b/src/extensions/mcp/handlers.ts
@@ -2499,18 +2499,23 @@ function formatMcpOutboxQueueStats(stats: McpOutboxStats['embedding']): string {
 
 async function handleMemStats(memoryService: MemoryService, args: Record<string, unknown>): Promise<ToolResult> {
   const stats = await memoryService.getStats();
-  const recentEvents = await memoryService.getRecentEvents(10000);
   const outboxStats = await readMcpOutboxStats(memoryService);
   const storageView = buildMcpStatsStorageView(optionalString(args.projectPath));
 
-  const uniqueSessions = new Set(recentEvents.map(e => e.sessionId));
+  // Aggregate in SQL. Deriving these by scanning 10k materialized events both
+  // silently capped every number at the scan limit and pulled the full event
+  // bodies into memory to compute three integers.
+  const [sessionCount, eventTypeCounts] = await Promise.all([
+    memoryService.getDistinctSessionCount(),
+    memoryService.getEventTypeCounts()
+  ]);
 
   const lines: string[] = [
     '## Memory Statistics',
     '',
     `- **Total Events**: ${stats.totalEvents}`,
     `- **Total Vectors**: ${stats.vectorCount}`,
-    `- **Sessions**: ${uniqueSessions.size}`,
+    `- **Sessions**: ${sessionCount}`,
     '',
     '### Storage View / Freshness',
     '',
@@ -2529,13 +2534,8 @@ async function handleMemStats(memoryService: MemoryService, args: Record<string,
     ''
   ];
 
-  const eventsByType = recentEvents.reduce((acc, e) => {
-    acc[e.eventType] = (acc[e.eventType] || 0) + 1;
-    return acc;
-  }, {} as Record<string, number>);
-
-  for (const [type, count] of Object.entries(eventsByType)) {
-    lines.push(`- ${type}: ${count}`);
+  for (const { eventType, count } of eventTypeCounts) {
+    lines.push(`- ${eventType}: ${count}`);
   }
 
   return {

--- a/tests/core/memory-ingest-service.test.ts
+++ b/tests/core/memory-ingest-service.test.ts
@@ -225,6 +225,28 @@ describe('MemoryIngestService ingest pipeline', () => {
     expect(store.enqueueForEmbedding).not.toHaveBeenCalled();
     expect(markdownMirror.append).not.toHaveBeenCalled();
   });
+
+  it('never enqueues tool_observation for embedding on a successful append, even though the legacy outbox path would otherwise embed every operation', async () => {
+    // SQLiteEventStore.append() already skips tool_observation for the V2
+    // vector_outbox (see the fix in append()/importEvents()); this is the
+    // parallel legacy embedding_outbox path storeToolObservation used to
+    // reach unconditionally via `embeddingContent`, which kept re-polluting
+    // semantic search with raw tool output (including full Agent/Task
+    // subagent responses) after every "fix".
+    const { service, store, markdownMirror, createToolEmbedding } = createService();
+
+    const result = await service.storeToolObservation('session-1', {
+      toolName: 'Agent',
+      success: true,
+      metadata: { turnId: 'turn-3' },
+      output: 'subagent review output'
+    } as ToolObservationPayload);
+
+    expect(result).toEqual({ success: true, eventId: 'event-1', isDuplicate: false });
+    expect(createToolEmbedding).toHaveBeenCalledOnce();
+    expect(store.enqueueForEmbedding).not.toHaveBeenCalled();
+    expect(markdownMirror.append).toHaveBeenCalledOnce();
+  });
 });
 
 describe('MemoryIngestService session summary generation', () => {

--- a/tests/core/memory-query-service.test.ts
+++ b/tests/core/memory-query-service.test.ts
@@ -61,7 +61,8 @@ function createService() {
     getEventsByTurn: vi.fn(async () => events),
     countSessionTurns: vi.fn(async () => 11),
     backfillTurnIds: vi.fn(async () => 13),
-    deleteSessionEvents: vi.fn(async () => 17)
+    deleteSessionEvents: vi.fn(async () => 17),
+    countEvents: vi.fn(async () => 31)
   };
   const vectorStore = {
     count: vi.fn(async () => 19)
@@ -118,15 +119,25 @@ describe('MemoryQueryService', () => {
     const { service, initialize, queryStore, vectorStore, graduation } = createService();
 
     await expect(service.getStats()).resolves.toEqual({
-      totalEvents: 1,
+      totalEvents: 31,
       vectorCount: 19,
       levelStats: [{ level: 'working', count: 23 }]
     });
 
     expect(initialize).toHaveBeenCalledOnce();
-    expect(queryStore.getRecentEvents).toHaveBeenCalledWith(10000);
+    // Counted in SQL, not by materializing a capped page of events.
+    expect(queryStore.countEvents).toHaveBeenCalledOnce();
+    expect(queryStore.getRecentEvents).not.toHaveBeenCalled();
     expect(vectorStore.count).toHaveBeenCalledOnce();
     expect(graduation.getStats).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to scanning recent events for the total when the store cannot count', async () => {
+    const { service, queryStore } = createService();
+    delete (queryStore as { countEvents?: unknown }).countEvents;
+
+    await expect(service.getStats()).resolves.toMatchObject({ totalEvents: 1 });
+    expect(queryStore.getRecentEvents).toHaveBeenCalledWith(10000);
   });
 
   it('keeps lightweight read methods usable with only the narrow query store', async () => {

--- a/tests/core/vector-outbox-v2.test.ts
+++ b/tests/core/vector-outbox-v2.test.ts
@@ -648,6 +648,114 @@ describe('VectorWorkerV2 runtime processing', () => {
       'session-runtime-1'
     ]);
   });
+
+  it('writes a claimed batch through a single upsert so each vector does not become its own Lance version', async () => {
+    const db = createDb();
+    const outbox = new VectorOutbox(db, { embeddingVersion: 'worker-v2' });
+    for (let i = 0; i < 5; i++) {
+      await outbox.enqueue('event', `event-batch-${i}`);
+    }
+    const upsertCalls: unknown[][] = [];
+    const contentProvider: ContentProvider = {
+      getContent: async (itemKind, itemId) => ({
+        content: `content-${itemId}`,
+        metadata: { itemKind, eventType: 'user_prompt', sessionId: 'session-batch' }
+      })
+    };
+    const embedder = { embed: async () => ({ vector: [0.1, 0.2, 0.3] }) };
+    const vectorStore = {
+      upsertBatch: async (records: unknown[]) => {
+        upsertCalls.push(records);
+      }
+    };
+    const worker = new VectorWorkerV2(
+      db,
+      vectorStore as never,
+      embedder as never,
+      { batchSize: 10, embeddingVersion: 'worker-v2' },
+      contentProvider
+    );
+
+    await expect(worker.processAll()).resolves.toBe(5);
+
+    expect(upsertCalls).toHaveLength(1);
+    expect(upsertCalls[0]).toHaveLength(5);
+    expect(db.prepare("SELECT COUNT(*) as count FROM vector_outbox WHERE status = 'done'").get())
+      .toEqual({ count: 5 });
+  });
+
+  it('fails only the job whose embedding threw and still batches the rest', async () => {
+    const db = createDb();
+    const outbox = new VectorOutbox(db, { embeddingVersion: 'worker-v2' });
+    await outbox.enqueue('event', 'event-ok-1');
+    const poisonJobId = await outbox.enqueue('event', 'event-poison');
+    await outbox.enqueue('event', 'event-ok-2');
+    const upsertCalls: unknown[][] = [];
+    const contentProvider: ContentProvider = {
+      getContent: async (itemKind, itemId) => ({
+        content: `content-${itemId}`,
+        metadata: { itemKind, eventType: 'user_prompt', sessionId: 'session-batch' }
+      })
+    };
+    const embedder = {
+      embed: async (content: string) => {
+        if (content.includes('event-poison')) throw new Error('embedding blew up');
+        return { vector: [0.1, 0.2, 0.3] };
+      }
+    };
+    const vectorStore = {
+      upsertBatch: async (records: unknown[]) => {
+        upsertCalls.push(records);
+      }
+    };
+    const worker = new VectorWorkerV2(
+      db,
+      vectorStore as never,
+      embedder as never,
+      { batchSize: 10, embeddingVersion: 'worker-v2' },
+      contentProvider
+    );
+
+    await expect(worker.processBatch()).resolves.toBe(2);
+
+    expect(upsertCalls).toHaveLength(1);
+    expect(upsertCalls[0]).toHaveLength(2);
+    const rows = db.prepare('SELECT job_id, status FROM vector_outbox ORDER BY job_id').all() as Array<{ job_id: string; status: string }>;
+    expect(rows.find(row => row.job_id === poisonJobId)?.status).not.toBe('done');
+    expect(rows.filter(row => row.status === 'done')).toHaveLength(2);
+  });
+
+  it('marks the whole batch retryable when the single batched vector write fails', async () => {
+    const db = createDb();
+    const outbox = new VectorOutbox(db, { embeddingVersion: 'worker-v2' });
+    for (let i = 0; i < 3; i++) {
+      await outbox.enqueue('event', `event-write-fail-${i}`);
+    }
+    const contentProvider: ContentProvider = {
+      getContent: async (itemKind, itemId) => ({
+        content: `content-${itemId}`,
+        metadata: { itemKind, eventType: 'user_prompt', sessionId: 'session-batch' }
+      })
+    };
+    const embedder = { embed: async () => ({ vector: [0.1, 0.2, 0.3] }) };
+    const vectorStore = {
+      upsertBatch: async () => {
+        throw new Error('lance write failed');
+      }
+    };
+    const worker = new VectorWorkerV2(
+      db,
+      vectorStore as never,
+      embedder as never,
+      { batchSize: 10, embeddingVersion: 'worker-v2' },
+      contentProvider
+    );
+
+    await expect(worker.processBatch()).resolves.toBe(0);
+
+    const rows = db.prepare('SELECT status FROM vector_outbox').all() as Array<{ status: string }>;
+    expect(rows.every(row => row.status !== 'done')).toBe(true);
+  });
 });
 
 describe('DefaultContentProvider perspective observation support', () => {

--- a/tests/core/vector-store-v2.test.ts
+++ b/tests/core/vector-store-v2.test.ts
@@ -1,8 +1,13 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { VectorRecord } from '../../src/core/types.js';
 
 const mocks = vi.hoisted(() => {
-  const tables = new Map<string, { add: ReturnType<typeof vi.fn>; delete: ReturnType<typeof vi.fn>; countRows: ReturnType<typeof vi.fn> }>();
+  const tables = new Map<string, {
+    add: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+    countRows: ReturnType<typeof vi.fn>;
+    optimize: ReturnType<typeof vi.fn>;
+  }>();
 
   const makeTable = (name: string) => {
     const existing = tables.get(name);
@@ -10,7 +15,8 @@ const mocks = vi.hoisted(() => {
     const table = {
       add: vi.fn().mockResolvedValue(undefined),
       delete: vi.fn().mockResolvedValue(undefined),
-      countRows: vi.fn().mockResolvedValue(0)
+      countRows: vi.fn().mockResolvedValue(0),
+      optimize: vi.fn().mockResolvedValue({})
     };
     tables.set(name, table);
     return table;
@@ -114,7 +120,7 @@ describe('VectorStore V2 upsert', () => {
     expect(mocks.db.openTable).not.toHaveBeenCalledWith('conversations');
   });
 
-  it('batch upsert groups records by inferred versioned table and deletes each id before adding', async () => {
+  it('batch upsert groups records by inferred versioned table and deletes every id in one commit before adding', async () => {
     mocks.db.tableNames.mockResolvedValue(['entry_vectors_v1', 'task_title_vectors_v1']);
     const entryTable = mocks.makeTable('entry_vectors_v1');
     const taskTable = mocks.makeTable('task_title_vectors_v1');
@@ -128,8 +134,8 @@ describe('VectorStore V2 upsert', () => {
 
     expect(mocks.db.openTable).toHaveBeenCalledWith('entry_vectors_v1');
     expect(mocks.db.openTable).toHaveBeenCalledWith('task_title_vectors_v1');
-    expect(entryTable.delete).toHaveBeenCalledWith("id = 'entry-1'");
-    expect(entryTable.delete).toHaveBeenCalledWith("id = 'entry-2'");
+    expect(entryTable.delete).toHaveBeenCalledTimes(1);
+    expect(entryTable.delete).toHaveBeenCalledWith("id IN ('entry-1', 'entry-2')");
     expect(entryTable.add).toHaveBeenCalledWith([
       expect.objectContaining({ id: 'entry-1' }),
       expect.objectContaining({ id: 'entry-2' })
@@ -194,5 +200,74 @@ describe('VectorStore V2 upsert', () => {
 
     await expect(store.deleteEventEverywhere('event-1')).resolves.toBeUndefined();
     expect(taskTable.delete).not.toHaveBeenCalled();
+  });
+});
+
+describe('VectorStore version pruning', () => {
+  beforeEach(() => {
+    mocks.tables.clear();
+    mocks.db.tableNames.mockReset().mockResolvedValue(['conversations']);
+    mocks.db.openTable.mockClear();
+    mocks.db.createTable.mockClear();
+    mocks.connect.mockReset().mockResolvedValue(mocks.db);
+    delete process.env.CLAUDE_MEMORY_LANCE_OPTIMIZE_EVERY;
+    delete process.env.CLAUDE_MEMORY_LANCE_VERSION_RETENTION_MS;
+  });
+
+  afterEach(() => {
+    delete process.env.CLAUDE_MEMORY_LANCE_OPTIMIZE_EVERY;
+    delete process.env.CLAUDE_MEMORY_LANCE_VERSION_RETENTION_MS;
+  });
+
+  it('prunes superseded versions once the accumulated commit count crosses the threshold', async () => {
+    process.env.CLAUDE_MEMORY_LANCE_OPTIMIZE_EVERY = '4';
+    const table = mocks.makeTable('conversations');
+    const store = new VectorStore('/tmp/cml-vectors');
+
+    // Each upsert is 2 commits (one batched delete + one add).
+    await store.upsert(record({ id: 'a' }));
+    expect(table.optimize).not.toHaveBeenCalled();
+
+    await store.upsert(record({ id: 'b' }));
+    expect(table.optimize).toHaveBeenCalledTimes(1);
+    expect(table.optimize).toHaveBeenCalledWith({ cleanupOlderThan: expect.any(Date) });
+
+    // Counter resets, so the next crossing needs another 4 commits.
+    await store.upsert(record({ id: 'c' }));
+    expect(table.optimize).toHaveBeenCalledTimes(1);
+  });
+
+  it('never prunes when the interval is disabled', async () => {
+    process.env.CLAUDE_MEMORY_LANCE_OPTIMIZE_EVERY = '0';
+    const table = mocks.makeTable('conversations');
+    const store = new VectorStore('/tmp/cml-vectors');
+
+    for (let i = 0; i < 10; i++) {
+      await store.upsert(record({ id: `id-${i}` }));
+    }
+
+    expect(table.optimize).not.toHaveBeenCalled();
+  });
+
+  it('keeps the write successful when pruning fails', async () => {
+    process.env.CLAUDE_MEMORY_LANCE_OPTIMIZE_EVERY = '1';
+    const table = mocks.makeTable('conversations');
+    table.optimize.mockRejectedValue(new Error('optimize unavailable'));
+    const store = new VectorStore('/tmp/cml-vectors');
+
+    await expect(store.upsert(record())).resolves.toBeUndefined();
+    expect(table.add).toHaveBeenCalledTimes(1);
+  });
+
+  it('optimizeAll prunes every table so pre-existing version bloat can be reclaimed', async () => {
+    mocks.db.tableNames.mockResolvedValue(['conversations', 'event_vectors_v1']);
+    const legacyTable = mocks.makeTable('conversations');
+    const eventTable = mocks.makeTable('event_vectors_v1');
+    const store = new VectorStore('/tmp/cml-vectors');
+
+    await store.optimizeAll();
+
+    expect(legacyTable.optimize).toHaveBeenCalledTimes(1);
+    expect(eventTable.optimize).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/extensions/mcp-project-aware-tools.test.ts
+++ b/tests/extensions/mcp-project-aware-tools.test.ts
@@ -9,7 +9,9 @@ const mocks = vi.hoisted(() => {
       getRecentEvents: vi.fn(),
       getSessionHistory: vi.fn(),
       getOutboxStats: vi.fn(),
-      getStats: vi.fn()
+      getStats: vi.fn(),
+      getDistinctSessionCount: vi.fn(),
+      getEventTypeCounts: vi.fn()
     };
   }
 
@@ -43,6 +45,8 @@ function resetService(service: typeof mocks.defaultService) {
     vector: { pending: 0, processing: 0, failed: 0, total: 0, stuckProcessing: 0, oldestProcessingAgeMs: null }
   });
   service.getStats.mockReset().mockResolvedValue({ totalEvents: 0, vectorCount: 0 });
+  service.getDistinctSessionCount.mockReset().mockResolvedValue(0);
+  service.getEventTypeCounts.mockReset().mockResolvedValue([]);
 }
 
 describe('MCP project-aware memory tools', () => {
@@ -428,15 +432,10 @@ describe('MCP project-aware memory tools', () => {
       vectorCount: 3,
       levelStats: [{ level: 'working', count: 7 }]
     });
-    mocks.projectService.getRecentEvents.mockResolvedValue([
-      {
-        id: 'event-stats-1',
-        sessionId: 'session-stats-a',
-        eventType: 'user_prompt',
-        timestamp: new Date('2026-05-05T01:00:00.000Z'),
-        content: 'stats event',
-        metadata: {}
-      }
+    mocks.projectService.getDistinctSessionCount.mockResolvedValue(4);
+    mocks.projectService.getEventTypeCounts.mockResolvedValue([
+      { eventType: 'tool_observation', count: 5 },
+      { eventType: 'user_prompt', count: 2 }
     ]);
     mocks.projectService.getOutboxStats.mockResolvedValue({
       embedding: { pending: 2, processing: 1, failed: 2, retryableFailed: 1, quarantinedFailed: 1, total: 5, stuckProcessing: 1, oldestProcessingAgeMs: 600000 },
@@ -460,6 +459,12 @@ describe('MCP project-aware memory tools', () => {
     expect(text).toContain('MCP/CLI parity');
     expect(text).toContain('restart');
     expect(text).not.toContain('/repo/app');
+    // Aggregated in SQL, not by scanning a capped page of materialized events.
+    expect(text).toContain('**Total Events**: 7');
+    expect(text).toContain('**Sessions**: 4');
+    expect(text).toContain('- tool_observation: 5');
+    expect(text).toContain('- user_prompt: 2');
+    expect(mocks.projectService.getRecentEvents).not.toHaveBeenCalled();
   });
 
   it('falls back to the global memory service when projectPath is absent', async () => {


### PR DESCRIPTION
## Summary

Two related fixes found while auditing memory usage on `aplus-dev-studio-desktop` (7.7GB vector store on a 208MB event DB, and semantic search returning raw tool output instead of actual answers).

**1. Lance version bloat (`8fc9605`)**
- `VectorOutboxWorker` upserted one record at a time and `VectorStore` issued one delete commit per row — a 32-job batch cost ~65 Lance versions instead of 2. Since every version manifest embeds the full fragment list, this is O(N²) on disk.
- Jobs now embed individually (so one bad item can't poison a batch) but write through a single batched upsert with one `id IN (...)` delete.
- `VectorStore` now prunes on a commit counter (`CLAUDE_MEMORY_LANCE_OPTIMIZE_EVERY`, default 50) and exposes `optimizeAll()` to reclaim bloat accumulated before this existed.
- Also fixed `mem-stats`, which derived Total Events/Sessions/Events-by-Type by materializing 10,000 full event rows — silently capping every number at the scan limit and loading full event bodies to produce three integers. Now aggregates in SQL.

**2. tool_observation still leaking into semantic search (`496dd92`)**
- `bb74141` excluded `tool_observation` from the V2 `vector_outbox` embedding path in `SQLiteEventStore.append()`/`importEvents()`, but `MemoryIngestService.storeToolObservation()` still built `embeddingContent` unconditionally and `ingestEvent()` enqueued it through the parallel legacy `enqueueForEmbedding()` path regardless of operation type.
- Every `tool_observation` — including full Agent/Task subagent responses, which the PostToolUse hook always stores in full — kept getting embedded and re-polluting `mem-search` after the "fix" landed.
- Confirmed live: on `aplus-dev-studio-desktop`, 8,662 of 13,055 embedded vectors (66%) were `tool_observation`, and a semantic search for "browser cookie import host scoped" returned `tool_observation` as its top 3 hits instead of the actual `agent_response`.
- `ingestEvent()` now skips `enqueueForEmbedding` for `tool_observation` the same way `append()` already does.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 995/995 passed (added regression tests for batched Lance deletes, commit-counter pruning, `optimizeAll()`, batched V2 outbox writes, partial-batch-failure isolation, and the legacy embedding-outbox skip for `tool_observation`)
- [x] Verified against the real store: ran `repair prune-tool-observation-vectors --apply` + `optimize()` on `aplus-dev-studio-desktop`'s live project store — 7.7GB → 169MB, semantic search relevance visibly restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)