### PR TITLE
feat(maintenance): self-heal already-polluted tool_observation vectors on session start

### DIFF
--- a/src/adapters/claude/hooks/session-start.ts
+++ b/src/adapters/claude/hooks/session-start.ts
@@ -7,6 +7,7 @@ import { randomUUID } from 'crypto';
 import { getLightweightMemoryService } from '../../../services/memory-service.js';
 import { registerSession } from '../../../core/registry/session-registry.js';
 import { ensureDaemonRunning } from './semantic-daemon-client.js';
+import { spawnToolObservationVectorAutoHealIfNeeded } from './tool-observation-vector-auto-heal-client.js';
 import { readStdin } from './hook-runtime.js';
 import { formatClaudeContextHookOutput, isHookEvaluationMode } from './hook-output.js';
 import type { SessionStartInput, SessionStartOutput } from '../../../core/types.js';
@@ -28,6 +29,13 @@ export async function main(): Promise<string> {
   // can process any pending embedding_outbox items immediately.
   ensureDaemonRunning().catch(() => {
     // Ignore - daemon will start on first prompt if needed
+  });
+
+  // Self-heal stores that embedded tool_observation vectors before the
+  // ingest-side fix existed. Cheap no-op once healed; the real cleanup (if
+  // needed) runs detached so a large backlog can't block this hook.
+  spawnToolObservationVectorAutoHealIfNeeded(input.cwd).catch(() => {
+    // Best-effort; next session's cheap check will retry.
   });
 
   // Use lightweight service to avoid starting background workers in hook process

--- a/src/adapters/claude/hooks/tool-observation-vector-auto-heal-client.ts
+++ b/src/adapters/claude/hooks/tool-observation-vector-auto-heal-client.ts
@@ -1,0 +1,52 @@
+/**
+ * SessionStart-side trigger for the one-time tool_observation vector cleanup.
+ *
+ * The check is a single indexed SQLite read against a readonly connection, so
+ * it's cheap enough for every session once healed. The actual cleanup (prune
+ * + Lance compaction) can take a long time on a large backlog, so it must
+ * never run inside this hook process: it's spawned detached, mirroring
+ * ensureDaemonRunning's pattern, so a slow migration can't block the hook's
+ * response or get cut short by the hook's own watchdog/close().
+ */
+
+import { spawn } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { getProjectStoragePath } from '../../../core/registry/project-path.js';
+import { SQLiteEventStore } from '../../../core/sqlite-event-store.js';
+import { needsToolObservationVectorAutoHeal } from '../../../core/operations/tool-observation-vector-auto-heal.js';
+
+function getCliScriptPath(): string {
+  return path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'cli', 'index.js');
+}
+
+/** Best-effort: any failure here must never affect SessionStart's own output. */
+export async function spawnToolObservationVectorAutoHealIfNeeded(projectPath: string): Promise<void> {
+  const storagePath = getProjectStoragePath(projectPath);
+  const dbPath = path.join(storagePath, 'events.sqlite');
+  if (!fs.existsSync(dbPath)) return;
+
+  let store: SQLiteEventStore | undefined;
+  try {
+    store = new SQLiteEventStore(dbPath, { readonly: true });
+    if (!(await needsToolObservationVectorAutoHeal(store))) return;
+  } catch {
+    return;
+  } finally {
+    await store?.close().catch(() => undefined);
+  }
+
+  const cliScriptPath = getCliScriptPath();
+  if (!fs.existsSync(cliScriptPath)) return;
+
+  try {
+    const child = spawn(
+      process.execPath,
+      [cliScriptPath, 'repair', 'auto-heal-tool-observation-vectors', '--project', projectPath],
+      { detached: true, stdio: 'ignore', env: process.env }
+    );
+    child.unref();
+  } catch {
+    // Next session's cheap check will retry.
+  }
+}

--- a/src/apps/cli/auto-heal-tool-observation-vectors-command.ts
+++ b/src/apps/cli/auto-heal-tool-observation-vectors-command.ts
@@ -1,0 +1,49 @@
+import type { ToolObservationVectorPruneResult } from '../../core/operations/tool-observation-vector-backfill.js';
+
+export interface AutoHealToolObservationVectorsCommandOptions {
+  project?: string;
+  lockPath?: string;
+}
+
+export interface ResolvedAutoHealToolObservationVectorsOptions {
+  projectPath: string;
+  lockPath?: string;
+}
+
+export function resolveAutoHealToolObservationVectorsOptions(
+  options: AutoHealToolObservationVectorsCommandOptions,
+  cwd: string = process.cwd()
+): ResolvedAutoHealToolObservationVectorsOptions {
+  if (options.project !== undefined && options.project.trim().length === 0) {
+    throw new Error('auto-heal-tool-observation-vectors --project must not be empty');
+  }
+  return {
+    projectPath: options.project ?? cwd,
+    lockPath: options.lockPath
+  };
+}
+
+export type AutoHealToolObservationVectorsOutcome =
+  | { status: 'already-healed' }
+  | { status: 'lock-busy' }
+  | { status: 'no-store' }
+  | { status: 'healed'; result: ToolObservationVectorPruneResult };
+
+export function formatAutoHealToolObservationVectorsResult(
+  outcome: AutoHealToolObservationVectorsOutcome
+): string {
+  switch (outcome.status) {
+    case 'already-healed':
+      return 'Auto-heal tool_observation vectors: already healed, nothing to do.';
+    case 'lock-busy':
+      return 'Auto-heal tool_observation vectors: another process is already healing this project, skipping.';
+    case 'no-store':
+      return 'Auto-heal tool_observation vectors: no store found for this project, nothing to do.';
+    case 'healed':
+      return [
+        'Auto-heal tool_observation vectors: done.',
+        `Vectors deleted: ${outcome.result.vectorsDeleted}`,
+        `Outbox rows removed: ${outcome.result.outboxRowsRemoved}`
+      ].join('\n');
+  }
+}

--- a/src/apps/cli/index.ts
+++ b/src/apps/cli/index.ts
@@ -93,6 +93,14 @@ import {
   resolvePruneToolObservationVectorsOptions
 } from './prune-tool-observation-vectors-command.js';
 import { pruneToolObservationVectors } from '../../core/operations/tool-observation-vector-backfill.js';
+import {
+  formatAutoHealToolObservationVectorsResult,
+  resolveAutoHealToolObservationVectorsOptions
+} from './auto-heal-tool-observation-vectors-command.js';
+import {
+  needsToolObservationVectorAutoHeal,
+  runToolObservationVectorAutoHeal
+} from '../../core/operations/tool-observation-vector-auto-heal.js';
 import { VectorStore } from '../../core/vector-store.js';
 import {
   formatRetentionAuditReport,
@@ -1414,6 +1422,60 @@ repairCommand
       const message = error instanceof Error ? error.message : String(error);
       console.error(`Prune tool_observation vectors failed: ${message}`);
       process.exit(1);
+    }
+  });
+
+/**
+ * Internal command: SessionStart spawns this detached (see session-start.ts)
+ * so the one-time tool_observation vector cleanup runs out-of-process,
+ * isolated from the hook's own DB handles and 30s watchdog. Also safe and
+ * idempotent to run manually — the flag check makes repeat invocations a
+ * fast no-op once healed.
+ */
+repairCommand
+  .command('auto-heal-tool-observation-vectors')
+  .description('Internal: self-triggered one-time cleanup of already-embedded tool_observation vectors')
+  .option('-p, --project <path>', 'Project path (defaults to cwd)')
+  .option('--lock-path <path>', 'Override auto-heal lock path (advanced)')
+  .action(async (options) => {
+    let store: SQLiteEventStore | undefined;
+    let workerLock: WorkerLock | undefined;
+
+    try {
+      const healOptions = resolveAutoHealToolObservationVectorsOptions(options);
+      const storagePath = getProjectStoragePath(healOptions.projectPath);
+      const dbPath = path.join(storagePath, 'events.sqlite');
+
+      if (!fs.existsSync(dbPath)) {
+        console.log(formatAutoHealToolObservationVectorsResult({ status: 'no-store' }));
+        return;
+      }
+
+      const lockPath = healOptions.lockPath ?? path.join(storagePath, 'auto-heal.lock');
+      workerLock = new WorkerLock(lockPath);
+      const lockResult = workerLock.acquire();
+      if (!lockResult.acquired) {
+        console.log(formatAutoHealToolObservationVectorsResult({ status: 'lock-busy' }));
+        workerLock = undefined;
+        return;
+      }
+
+      store = new SQLiteEventStore(dbPath);
+      if (!(await needsToolObservationVectorAutoHeal(store))) {
+        console.log(formatAutoHealToolObservationVectorsResult({ status: 'already-healed' }));
+        return;
+      }
+
+      const vectorStore = new VectorStore(path.join(storagePath, 'vectors'));
+      const result = await runToolObservationVectorAutoHeal(store, vectorStore);
+      console.log(formatAutoHealToolObservationVectorsResult({ status: 'healed', result }));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`Auto-heal tool_observation vectors failed: ${message}`);
+      process.exitCode = 1;
+    } finally {
+      if (store) await store.close().catch(() => undefined);
+      if (workerLock) workerLock.release();
     }
   });
 

--- a/src/core/operations/tool-observation-vector-auto-heal.ts
+++ b/src/core/operations/tool-observation-vector-auto-heal.ts
@@ -1,0 +1,68 @@
+/**
+ * One-time, self-triggering cleanup for stores that were embedding
+ * tool_observation vectors before the ingest-side fix landed. Users should
+ * never have to know this migration exists or run a command for it — it is
+ * gated on a persisted flag so it runs at most once per project store, and
+ * the caller (SessionStart hook) is expected to invoke it out-of-process so a
+ * large backlog cannot block or crash an interactive hook.
+ */
+
+import { pruneToolObservationVectors } from './tool-observation-vector-backfill.js';
+import type {
+  ToolObservationVectorPruneStore,
+  ToolObservationVectorPruneVectorStore,
+  ToolObservationVectorPruneResult
+} from './tool-observation-vector-backfill.js';
+
+export const TOOL_OBSERVATION_VECTOR_AUTO_HEAL_KEY = 'maintenance:tool_observation_vector_prune_v1';
+
+export interface ToolObservationVectorAutoHealFlagStore {
+  getEndlessConfig(key: string): Promise<unknown | null>;
+  setEndlessConfig(key: string, value: unknown): Promise<void>;
+}
+
+export interface ToolObservationVectorAutoHealStore
+  extends ToolObservationVectorPruneStore, ToolObservationVectorAutoHealFlagStore {}
+
+export interface ToolObservationVectorAutoHealVectorStore extends ToolObservationVectorPruneVectorStore {
+  optimizeAll(): Promise<void>;
+}
+
+export interface ToolObservationVectorAutoHealRecord {
+  completedAt: string;
+  vectorsDeleted: number;
+  outboxRowsRemoved: number;
+}
+
+/** Cheap check safe to call from an interactive hook: a single indexed read. */
+export async function needsToolObservationVectorAutoHeal(
+  store: ToolObservationVectorAutoHealFlagStore
+): Promise<boolean> {
+  const flag = await store.getEndlessConfig(TOOL_OBSERVATION_VECTOR_AUTO_HEAL_KEY);
+  return flag === null;
+}
+
+/**
+ * Deletes already-embedded tool_observation vectors, compacts the Lance
+ * tables to reclaim the versions that deletion itself creates (deletes are
+ * not covered by VectorStore's write-path commit-counter pruning), and
+ * stamps the flag so this never runs again for this store. Intended to run
+ * out-of-process (see spawnToolObservationVectorAutoHealIfNeeded); safe to
+ * call redundantly since the flag check is authoritative once set.
+ */
+export async function runToolObservationVectorAutoHeal(
+  store: ToolObservationVectorAutoHealStore,
+  vectorStore: ToolObservationVectorAutoHealVectorStore
+): Promise<ToolObservationVectorPruneResult> {
+  const result = await pruneToolObservationVectors(store, vectorStore, { dryRun: false });
+  await vectorStore.optimizeAll();
+
+  const record: ToolObservationVectorAutoHealRecord = {
+    completedAt: new Date().toISOString(),
+    vectorsDeleted: result.vectorsDeleted,
+    outboxRowsRemoved: result.outboxRowsRemoved
+  };
+  await store.setEndlessConfig(TOOL_OBSERVATION_VECTOR_AUTO_HEAL_KEY, record);
+
+  return result;
+}

--- a/tests/adapters/tool-observation-vector-auto-heal-client.test.ts
+++ b/tests/adapters/tool-observation-vector-auto-heal-client.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const spawnedChild = { unref: vi.fn() };
+  return {
+    existsSync: vi.fn(() => true),
+    spawn: vi.fn(() => spawnedChild),
+    spawnedChild,
+    getProjectStoragePath: vi.fn((projectPath: string) => `/storage/${projectPath.replace(/\//g, '_')}`),
+    needsToolObservationVectorAutoHeal: vi.fn(async () => true),
+    storeClose: vi.fn(async () => {}),
+    storeConstructed: [] as Array<{ dbPath: string; options: unknown }>
+  };
+});
+
+vi.mock('fs', () => ({ existsSync: mocks.existsSync }));
+vi.mock('child_process', () => ({ spawn: mocks.spawn }));
+vi.mock('../../src/core/registry/project-path.js', () => ({
+  getProjectStoragePath: mocks.getProjectStoragePath
+}));
+vi.mock('../../src/core/operations/tool-observation-vector-auto-heal.js', () => ({
+  needsToolObservationVectorAutoHeal: mocks.needsToolObservationVectorAutoHeal
+}));
+vi.mock('../../src/core/sqlite-event-store.js', () => ({
+  SQLiteEventStore: class {
+    constructor(dbPath: string, options: unknown) {
+      mocks.storeConstructed.push({ dbPath, options });
+    }
+    close = mocks.storeClose;
+  }
+}));
+
+const { spawnToolObservationVectorAutoHealIfNeeded } = await import(
+  '../../src/adapters/claude/hooks/tool-observation-vector-auto-heal-client.js'
+);
+
+describe('spawnToolObservationVectorAutoHealIfNeeded', () => {
+  beforeEach(() => {
+    mocks.existsSync.mockReset().mockReturnValue(true);
+    mocks.spawn.mockClear();
+    mocks.spawnedChild.unref.mockClear();
+    mocks.getProjectStoragePath.mockClear();
+    mocks.needsToolObservationVectorAutoHeal.mockReset().mockResolvedValue(true);
+    mocks.storeClose.mockClear();
+    mocks.storeConstructed.length = 0;
+  });
+
+  it('does nothing when the project has no store yet', async () => {
+    mocks.existsSync.mockReturnValue(false);
+
+    await spawnToolObservationVectorAutoHealIfNeeded('/repo/app');
+
+    expect(mocks.spawn).not.toHaveBeenCalled();
+    expect(mocks.storeConstructed).toEqual([]);
+  });
+
+  it('opens the store readonly for the check and closes it without spawning when already healed', async () => {
+    mocks.needsToolObservationVectorAutoHeal.mockResolvedValue(false);
+
+    await spawnToolObservationVectorAutoHealIfNeeded('/repo/app');
+
+    expect(mocks.storeConstructed).toEqual([
+      { dbPath: expect.stringContaining('events.sqlite'), options: { readonly: true } }
+    ]);
+    expect(mocks.storeClose).toHaveBeenCalledOnce();
+    expect(mocks.spawn).not.toHaveBeenCalled();
+  });
+
+  it('spawns the CLI detached with the project path when healing is needed', async () => {
+    await spawnToolObservationVectorAutoHealIfNeeded('/repo/app');
+
+    expect(mocks.storeClose).toHaveBeenCalledOnce();
+    expect(mocks.spawn).toHaveBeenCalledTimes(1);
+    const [command, args, options] = mocks.spawn.mock.calls[0];
+    expect(command).toBe(process.execPath);
+    expect(args).toEqual(expect.arrayContaining([
+      'repair', 'auto-heal-tool-observation-vectors', '--project', '/repo/app'
+    ]));
+    expect(options).toMatchObject({ detached: true, stdio: 'ignore' });
+    expect(mocks.spawnedChild.unref).toHaveBeenCalledOnce();
+  });
+
+  it('never throws when the readonly check itself throws', async () => {
+    mocks.needsToolObservationVectorAutoHeal.mockRejectedValue(new Error('db locked'));
+
+    await expect(spawnToolObservationVectorAutoHealIfNeeded('/repo/app')).resolves.toBeUndefined();
+    expect(mocks.spawn).not.toHaveBeenCalled();
+  });
+});

--- a/tests/apps/auto-heal-tool-observation-vectors-command.test.ts
+++ b/tests/apps/auto-heal-tool-observation-vectors-command.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatAutoHealToolObservationVectorsResult,
+  resolveAutoHealToolObservationVectorsOptions
+} from '../../src/apps/cli/auto-heal-tool-observation-vectors-command.js';
+
+describe('auto-heal tool-observation-vectors CLI helpers', () => {
+  it('defaults project path to cwd, rejects empty --project', () => {
+    expect(resolveAutoHealToolObservationVectorsOptions({}, '/repo/current')).toEqual({
+      projectPath: '/repo/current',
+      lockPath: undefined
+    });
+    expect(resolveAutoHealToolObservationVectorsOptions({ project: '/repo/selected' }, '/repo/current')).toEqual({
+      projectPath: '/repo/selected',
+      lockPath: undefined
+    });
+    expect(() => resolveAutoHealToolObservationVectorsOptions({ project: '  ' }, '/repo/current')).toThrow(
+      '--project must not be empty'
+    );
+  });
+
+  it('passes through an explicit lock path override', () => {
+    expect(resolveAutoHealToolObservationVectorsOptions(
+      { project: '/repo/selected', lockPath: '/tmp/custom.lock' },
+      '/repo/current'
+    )).toEqual({
+      projectPath: '/repo/selected',
+      lockPath: '/tmp/custom.lock'
+    });
+  });
+
+  it('formats each outcome distinctly', () => {
+    expect(formatAutoHealToolObservationVectorsResult({ status: 'already-healed' }))
+      .toContain('already healed');
+    expect(formatAutoHealToolObservationVectorsResult({ status: 'lock-busy' }))
+      .toContain('another process');
+    expect(formatAutoHealToolObservationVectorsResult({ status: 'no-store' }))
+      .toContain('no store found');
+    const healed = formatAutoHealToolObservationVectorsResult({
+      status: 'healed',
+      result: { dryRun: false, scanned: 5, vectorsDeleted: 5, outboxRowsRemoved: 5, sampleEventIds: [] }
+    });
+    expect(healed).toContain('Vectors deleted: 5');
+    expect(healed).toContain('Outbox rows removed: 5');
+  });
+});

--- a/tests/core/tool-observation-vector-auto-heal.test.ts
+++ b/tests/core/tool-observation-vector-auto-heal.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  TOOL_OBSERVATION_VECTOR_AUTO_HEAL_KEY,
+  needsToolObservationVectorAutoHeal,
+  runToolObservationVectorAutoHeal
+} from '../../src/core/operations/tool-observation-vector-auto-heal.js';
+
+function createStore(overrides: { flag?: unknown; eventIds?: string[] } = {}) {
+  const config = new Map<string, unknown>();
+  if (overrides.flag !== undefined) config.set(TOOL_OBSERVATION_VECTOR_AUTO_HEAL_KEY, overrides.flag);
+
+  return {
+    listEventIdsByType: vi.fn(async () => overrides.eventIds ?? ['event-1', 'event-2']),
+    removeVectorOutboxRowsForEventIds: vi.fn(async (ids: string[]) => ids.length),
+    getEndlessConfig: vi.fn(async (key: string) => config.get(key) ?? null),
+    setEndlessConfig: vi.fn(async (key: string, value: unknown) => {
+      config.set(key, value);
+    })
+  };
+}
+
+function createVectorStore() {
+  return {
+    deleteEventEverywhere: vi.fn(async () => {}),
+    optimizeAll: vi.fn(async () => {})
+  };
+}
+
+describe('needsToolObservationVectorAutoHeal', () => {
+  it('is true when the flag was never set', async () => {
+    const store = createStore();
+    await expect(needsToolObservationVectorAutoHeal(store)).resolves.toBe(true);
+  });
+
+  it('is false once the flag is stamped, regardless of its content', async () => {
+    const store = createStore({ flag: { completedAt: '2026-01-01T00:00:00.000Z', vectorsDeleted: 0, outboxRowsRemoved: 0 } });
+    await expect(needsToolObservationVectorAutoHeal(store)).resolves.toBe(false);
+  });
+});
+
+describe('runToolObservationVectorAutoHeal', () => {
+  it('prunes, compacts the Lance tables, and stamps the flag with a timestamped record', async () => {
+    const store = createStore({ eventIds: ['event-1', 'event-2', 'event-3'] });
+    const vectorStore = createVectorStore();
+
+    const result = await runToolObservationVectorAutoHeal(store, vectorStore);
+
+    expect(result).toEqual({
+      dryRun: false,
+      scanned: 3,
+      vectorsDeleted: 3,
+      outboxRowsRemoved: 3,
+      sampleEventIds: ['event-1', 'event-2', 'event-3']
+    });
+    expect(vectorStore.deleteEventEverywhere).toHaveBeenCalledTimes(3);
+    // optimizeAll must run after the deletes, since it exists specifically to
+    // reclaim the Lance versions those per-event deletes create.
+    expect(vectorStore.optimizeAll).toHaveBeenCalledTimes(1);
+    const deleteOrder = vectorStore.deleteEventEverywhere.mock.invocationCallOrder[2];
+    const optimizeOrder = vectorStore.optimizeAll.mock.invocationCallOrder[0];
+    expect(optimizeOrder).toBeGreaterThan(deleteOrder);
+
+    expect(store.setEndlessConfig).toHaveBeenCalledWith(
+      TOOL_OBSERVATION_VECTOR_AUTO_HEAL_KEY,
+      expect.objectContaining({
+        completedAt: expect.any(String),
+        vectorsDeleted: 3,
+        outboxRowsRemoved: 3
+      })
+    );
+    await expect(needsToolObservationVectorAutoHeal(store)).resolves.toBe(false);
+  });
+
+  it('still stamps the flag on a store with nothing to prune, so it never runs again', async () => {
+    const store = createStore({ eventIds: [] });
+    const vectorStore = createVectorStore();
+
+    const result = await runToolObservationVectorAutoHeal(store, vectorStore);
+
+    expect(result).toEqual({ dryRun: false, scanned: 0, vectorsDeleted: 0, outboxRowsRemoved: 0, sampleEventIds: [] });
+    expect(vectorStore.optimizeAll).toHaveBeenCalledTimes(1);
+    expect(store.setEndlessConfig).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Why

`496dd92` closed the ingest-side leak that kept embedding `tool_observation` (including full Agent/Task subagent output) into semantic search — but that fix only stops *new* pollution. Any project store that was already contaminated needs someone to know that `repair prune-tool-observation-vectors --apply` exists and run it, per project, by hand. There's no signal anywhere telling a user this is needed.

## What

`SessionStart` now self-heals with zero user action:

1. Cheap check — one indexed SQLite read against `endless_config` (readonly connection). No-op once healed; negligible cost every session after that.
2. If unhealed, spawns `repair auto-heal-tool-observation-vectors` **detached** (same pattern as the existing semantic-daemon auto-start) so a large backlog can't block the interactive hook or get cut short by its `close()`/watchdog.
3. That command: prunes already-embedded `tool_observation` vectors, then runs `VectorStore.optimizeAll()` to reclaim the Lance versions the per-event deletes themselves create (`deleteEventEverywhere` isn't covered by the write-path commit-counter pruning added in `8fc9605`), then stamps the flag so it never runs again for that store.
4. A file lock (existing `WorkerLock`) guards against two sessions racing the same project.

## Verification

Ran the actual compiled `dist/hooks/session-start.js` against a scratch project store seeded with 5 `tool_observation` vectors mixed with 1 real `user_prompt` vector (simulating pre-fix contamination):

- **First session**: hook returns immediately (fast, unblocked); the detached heal completes in the background — `tool_observation` vectors go 5 → 0, the `user_prompt` vector survives untouched, flag gets stamped with a timestamped record.
- **Second session**: 0.12s total, no process spawned — confirmed no-op once healed.
- Real project store (`aplus-dev-studio-desktop`) confirmed untouched by the test.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1006/1006 passed (added: operation-level tests for flag-gating and prune→optimize→stamp ordering, CLI helper tests, hook-trigger wiring tests covering no-store/already-healed/needs-heal/never-throws)
- [x] `npx eslint` on all new/changed files — clean
- [x] End-to-end verified against the real built `dist/` output (see above), not just mocked unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)