### PR TITLE
fix(retrieval): exclude tool_observation from the default keyword lane

### DIFF
--- a/src/adapters/claude/hooks/user-prompt-submit.ts
+++ b/src/adapters/claude/hooks/user-prompt-submit.ts
@@ -481,7 +481,13 @@ export async function main(): Promise<string> {
       if (shouldUseKeywordFallback) {
         let usedFallbackFloor = false;
         const allKeywordResults = await memoryService.keywordSearch(retrievalQuery, {
-          topK: MAX_EPISODE_SEED_CANDIDATES
+          topK: MAX_EPISODE_SEED_CANDIDATES,
+          // Episode seeding intentionally accepts tool_observation matches:
+          // a tool call from the same turn is often the strongest anchor for
+          // finding that turn's answer (selectHookEpisodeSeeds handles the
+          // type-aware ranking). This opt-in preserves that behavior now that
+          // keywordSearch excludes tool_observation by default.
+          includeToolObservations: true
         });
         let results = allKeywordResults.filter((result) => result.score >= minScore);
 

--- a/src/core/engine/memory-query-service.ts
+++ b/src/core/engine/memory-query-service.ts
@@ -38,7 +38,7 @@ export interface MemoryStats {
 }
 
 interface QueryStore {
-  keywordSearch(query: string, topK: number): Promise<RankedKeywordResult[]>;
+  keywordSearch(query: string, topK: number, options?: { includeToolObservations?: boolean }): Promise<RankedKeywordResult[]>;
   searchGraduatedEvidence?(query: string, limit: number): Promise<GraduatedEvidenceResult[]>;
   getEvent(id: string): Promise<MemoryEvent | null>;
   getSessionEvents(sessionId: string): Promise<MemoryEvent[]>;
@@ -86,11 +86,13 @@ export class MemoryQueryService {
 
   async keywordSearch(
     query: string,
-    options?: { topK?: number; minScore?: number }
+    options?: { topK?: number; minScore?: number; includeToolObservations?: boolean }
   ): Promise<Array<{ event: MemoryEvent; score: number }>> {
     await this.initialize();
 
-    const results = await this.queryStore.keywordSearch(query, options?.topK ?? 10);
+    const results = await this.queryStore.keywordSearch(query, options?.topK ?? 10, {
+      includeToolObservations: options?.includeToolObservations
+    });
     if (results.length === 0) return [];
 
     // FTS5/BM25 ranks are ordered ascending: the smallest value is the best.

--- a/src/core/retriever.ts
+++ b/src/core/retriever.ts
@@ -826,6 +826,9 @@ export class Retriever {
     const recent = await this.eventStore.getRecentEvents(input.limit * 4);
     const tokens = this.tokenize(query);
     const filtered = recent
+      // Match the FTS lane's default: raw tool output outnumbers answer-type
+      // events several-fold and would crowd them out of the limit window.
+      .filter((e) => e.eventType !== 'tool_observation')
       .filter((e) => (input.sessionId ? e.sessionId === input.sessionId : true))
       .map((e) => ({ e, overlap: this.keywordOverlap(tokens, this.tokenize(e.content)) }))
       .filter((r) => r.overlap > 0)

--- a/src/core/sqlite-event-store.ts
+++ b/src/core/sqlite-event-store.ts
@@ -2987,8 +2987,21 @@ export class SQLiteEventStore {
    * Fast keyword search using FTS5
    * Returns events matching the search query, ranked by relevance
    */
-  async keywordSearch(query: string, limit: number = 10): Promise<Array<{event: MemoryEvent; rank: number}>> {
+  async keywordSearch(
+    query: string,
+    limit: number = 10,
+    options?: { includeToolObservations?: boolean }
+  ): Promise<Array<{event: MemoryEvent; rank: number}>> {
     await this.initialize();
+
+    // tool_observation events typically outnumber prompts/answers several-fold
+    // (they are kept as events but excluded from embedding), so an unfiltered
+    // FTS query returns mostly raw tool output and crowds answer-type events
+    // out of the limit window. Excluded by default to mirror the embedding
+    // policy; callers that intentionally want tool evidence (episode seeding,
+    // explicit eventType filters) opt in.
+    const includeToolObservations = options?.includeToolObservations === true;
+    const toolObservationSql = includeToolObservations ? '' : `AND e.event_type != 'tool_observation'`;
 
     // Escape special FTS5 characters and prepare search terms
     const searchTerms = query
@@ -3010,6 +3023,7 @@ export class SQLiteEventStore {
          JOIN events e ON e.id = fts.event_id
          WHERE events_fts MATCH ?
            AND ${notActiveQuarantinedSql('e.metadata')}
+           ${toolObservationSql}
          ORDER BY fts.rank
          LIMIT ?`,
         [searchTerms, limit]
@@ -3028,6 +3042,7 @@ export class SQLiteEventStore {
         `SELECT *, 0 as rank FROM events
          WHERE content LIKE ?
            AND ${notActiveQuarantinedSql()}
+           ${includeToolObservations ? '' : `AND event_type != 'tool_observation'`}
          ORDER BY timestamp DESC
          LIMIT ?`,
         [likePattern, limit]

--- a/src/extensions/mcp/handlers.ts
+++ b/src/extensions/mcp/handlers.ts
@@ -1129,6 +1129,17 @@ async function retrieveMcpMemories(
   options: McpMemoryRetrievalOptions
 ): Promise<McpMemoryRetrievalResult> {
   const fetchTopK = Math.max(options.topK, options.fetchTopK ?? options.topK);
+
+  // Explicit tool_observation queries need their own lane: those events are
+  // excluded from both embedding (no semantic hits) and the default keyword
+  // lane, so the hybrid path can no longer return them at all.
+  if (options.eventType === 'tool_observation') {
+    const candidates = options.sessionId
+      ? rankSessionKeywordMatches(query, await memoryService.getSessionHistory(options.sessionId), fetchTopK)
+      : await memoryService.keywordSearch(query, { topK: fetchTopK, includeToolObservations: true });
+    return { memories: selectMcpMemoryResults(candidates, options.topK, options.eventType) };
+  }
+
   try {
     const retrieveOptions = {
       topK: fetchTopK,

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -281,7 +281,7 @@ export class MemoryService {
    */
   async keywordSearch(
     query: string,
-    options?: { topK?: number; minScore?: number }
+    options?: { topK?: number; minScore?: number; includeToolObservations?: boolean }
   ): Promise<Array<{event: MemoryEvent; score: number}>> {
     return this.queryService.keywordSearch(query, options);
   }

--- a/tests/core/keyword-search-tool-observation-noise.test.ts
+++ b/tests/core/keyword-search-tool-observation-noise.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Regression: tool_observation events are kept in SQLite (only their
+ * embeddings are excluded), so on real projects they outnumber answer-type
+ * events several-fold. An unfiltered FTS keyword lane therefore returned
+ * mostly raw tool output — reproducing the exact "mem-search returns tool
+ * noise" symptom the embedding exclusion was supposed to fix, through a
+ * different lane.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+import { SQLiteEventStore } from '../../src/core/sqlite-event-store.js';
+
+describe('keywordSearch tool_observation noise', () => {
+  let tempDir: string;
+  let store: SQLiteEventStore;
+
+  beforeEach(async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-memory-layer-test-'));
+    store = new SQLiteEventStore(path.join(tempDir, 'events.sqlite'));
+    await store.initialize();
+
+    // Realistic ratio: many tool observations that all mention the topic,
+    // one actual answer and one prompt about it.
+    for (let i = 0; i < 8; i++) {
+      await store.append({
+        eventType: 'tool_observation',
+        sessionId: 'session-1',
+        timestamp: new Date(Date.now() - 1000 - i),
+        content: JSON.stringify({ toolName: 'Bash', toolOutput: `grep browser cookie import scope run ${i}` })
+      });
+    }
+    await store.append({
+      eventType: 'user_prompt',
+      sessionId: 'session-1',
+      timestamp: new Date(),
+      content: 'how is the browser cookie import scoped per host?'
+    });
+    await store.append({
+      eventType: 'agent_response',
+      sessionId: 'session-1',
+      timestamp: new Date(),
+      content: 'The browser cookie import is scoped per host via the partition audit.'
+    });
+  });
+
+  afterEach(() => {
+    try { store.close(); } catch { /* already closed */ }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('excludes tool_observation from FTS results by default so answers are not crowded out', async () => {
+    const results = await store.keywordSearch('browser cookie import', 5);
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every((r) => r.event.eventType !== 'tool_observation')).toBe(true);
+    expect(results.map((r) => r.event.eventType)).toEqual(
+      expect.arrayContaining(['agent_response', 'user_prompt'])
+    );
+  });
+
+  it('returns tool_observation matches when explicitly opted in', async () => {
+    const results = await store.keywordSearch('browser cookie import', 20, { includeToolObservations: true });
+
+    const types = new Set(results.map((r) => r.event.eventType));
+    expect(types.has('tool_observation')).toBe(true);
+    expect(types.has('agent_response')).toBe(true);
+  });
+
+  it('applies the same default exclusion on the LIKE fallback when FTS is unavailable', async () => {
+    // Force the FTS path to fail so keywordSearch falls back to LIKE.
+    const db = store.getDatabase();
+    db.exec('DROP TRIGGER IF EXISTS events_fts_insert; DROP TRIGGER IF EXISTS events_fts_delete; DROP TRIGGER IF EXISTS events_fts_update; DROP TABLE IF EXISTS events_fts;');
+
+    const results = await store.keywordSearch('browser cookie import', 5);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every((r) => r.event.eventType !== 'tool_observation')).toBe(true);
+
+    const optedIn = await store.keywordSearch('browser cookie import', 20, { includeToolObservations: true });
+    expect(optedIn.some((r) => r.event.eventType === 'tool_observation')).toBe(true);
+  });
+});

--- a/tests/core/memory-query-service.test.ts
+++ b/tests/core/memory-query-service.test.ts
@@ -155,7 +155,7 @@ describe('MemoryQueryService', () => {
     await expect(service.getRecentEvents(2)).resolves.toBe(events);
 
     expect(initialize).toHaveBeenCalledTimes(3);
-    expect(queryStore.keywordSearch).toHaveBeenCalledWith('query', 3);
+    expect(queryStore.keywordSearch).toHaveBeenCalledWith('query', 3, { includeToolObservations: undefined });
     expect(queryStore.getSessionEvents).toHaveBeenCalledWith('session-1');
     expect(queryStore.getRecentEvents).toHaveBeenCalledWith(2);
   });

--- a/tests/extensions/mcp-project-aware-tools.test.ts
+++ b/tests/extensions/mcp-project-aware-tools.test.ts
@@ -180,6 +180,40 @@ describe('MCP project-aware memory tools', () => {
     expect(text).not.toContain('user prompt result should be filtered out');
   });
 
+  it('routes explicit tool_observation mem-search through the opted-in keyword lane instead of the hybrid path', async () => {
+    // tool_observation is excluded from embedding and from the default
+    // keyword lane, so the hybrid path can never return it; the handler must
+    // use the explicit keyword opt-in or eventType filtering silently returns
+    // nothing.
+    mocks.projectService.keywordSearch.mockResolvedValue([
+      {
+        score: 0.7,
+        event: {
+          id: 'event-tool-1',
+          sessionId: 'session-tools',
+          eventType: 'tool_observation',
+          timestamp: new Date('2026-05-05T00:00:00.000Z'),
+          content: '{"toolName":"Bash","toolOutput":"explicit tool evidence stays reachable"}',
+          metadata: {}
+        }
+      }
+    ]);
+
+    const result = await handleToolCall('mem-search', {
+      query: 'tool evidence',
+      projectPath: '/repo/app',
+      eventType: 'tool_observation'
+    });
+
+    const text = String(result.content[0]?.text ?? '');
+    expect(result.isError).not.toBe(true);
+    expect(mocks.projectService.retrieveMemories).not.toHaveBeenCalled();
+    expect(mocks.projectService.keywordSearch).toHaveBeenCalledWith('tool evidence', expect.objectContaining({
+      includeToolObservations: true
+    }));
+    expect(text).toContain('explicit tool evidence stays reachable');
+  });
+
   it('normalizes invalid mem-search topK values before retrieval', async () => {
     mocks.projectService.retrieveMemories.mockResolvedValue({ memories: [] });
 


### PR DESCRIPTION
## Why

Post-deploy verification of v1.1.2 on `aplus-dev-studio-desktop` showed the embedding-side fixes all working (auto-heal ran itself, 11,191 stale vectors removed, zero new tool_observation embeddings) — yet `mem-search` still returned five `tool_observation` results as its top hits.

Root cause is a different lane with the same symptom:
- `tool_observation` events are intentionally kept in SQLite (only embeddings are excluded), and on a real project they are **83% of the corpus** (11,365 of 13,768 events)
- the FTS keyword lane (`SQLiteEventStore.keywordSearch`) searched them unfiltered, so they crowd answer-type events out of the limit window
- the retriever then assigns **position-based scores** (`1 - idx*0.04` → 0.96, 0.92, …) to keyword results, making low-quality tool matches look like strong semantic hits ranked above actual answers

## What

`keywordSearch` now excludes `tool_observation` **by default**, mirroring the embedding policy — at the FTS query, the LIKE fallback, and the retriever's non-FTS overlap fallback. Two callers intentionally opt in via the new `includeToolObservations` option:

- **user-prompt-submit episode seeding** — a tool call from the same turn is often the strongest anchor for finding that turn's answer (`selectHookEpisodeSeeds` already does type-aware ranking downstream)
- **mem-search with explicit `eventType: 'tool_observation'`** — gets a dedicated keyword lane in the MCP handler, since the hybrid path can no longer return those events at all (no embeddings + default keyword exclusion would otherwise make the filter silently return nothing)

## Verification against real data

Same query, same real project store (`aplus-dev-studio-desktop`):

| | before | after |
|---|---|---|
| hybrid top-5 | 5× `tool_observation` (0.92, 0.89, …) | top-1 = actual `agent_response` review summary (0.89) |
| keyword lane default | mostly tool output | only `user_prompt`/`agent_response` |
| `eventType: 'tool_observation'` | worked (via pollution) | still works (explicit opt-in lane) |

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1010/1010 passed (new: real-store FTS/LIKE-fallback exclusion + opt-in tests, MCP handler explicit-lane test)
- [x] `npx eslint` on changed files — no errors
- [x] End-to-end verified against the real project store with the built `dist/` output (table above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)