### PR TITLE
실제로 참고한 메모리를 답변에 표시하도록 요청

### DIFF
--- a/scripts/evaluate-memory-field.ts
+++ b/scripts/evaluate-memory-field.ts
@@ -316,6 +316,11 @@ async function evaluateCases(
         const context = parsed.hookSpecificOutput?.additionalContext ?? '';
         executions[index] = {
           caseId: item.caseId,
+          // Scraped back out of the prompt text that formatMemoryContext()
+          // builds in src/adapters/claude/hooks/user-prompt-submit.ts. That
+          // marker is a contract between the two files: changing its shape
+          // there, or adding any other `[event:...]`-looking text to the
+          // injected block, silently zeroes hit/top1 here instead of failing.
           selectedEventIds: Array.from(context.matchAll(/\[event:([a-f0-9-]+)\]/giu), (match) => match[1] ?? '').filter(Boolean),
           hasContext: context.trim().length > 0,
           latencyMs: Number((performance.now() - started).toFixed(1))

--- a/src/adapters/claude/hooks/user-prompt-submit.ts
+++ b/src/adapters/claude/hooks/user-prompt-submit.ts
@@ -111,7 +111,7 @@ function evidenceAnchorPriority(term: string): number {
   return Math.min(1, term.length / 20);
 }
 
-function formatMemoryContext(items: Array<{ type: string; content: string; id?: string; memoryLevel?: string }>, query: string): string {
+export function formatMemoryContext(items: Array<{ type: string; content: string; id?: string; memoryLevel?: string }>, query: string): string {
   if (items.length === 0) return '';
   const lines = items.map((m) => {
     const preview = selectEvidencePreview(m.content, query);
@@ -119,7 +119,12 @@ function formatMemoryContext(items: Array<{ type: string; content: string; id?: 
     const level = m.memoryLevel && m.memoryLevel !== 'L0' ? ` ${m.memoryLevel}` : '';
     return `- [${m.type}${level}] ${preview}${sourceRef}`;
   });
-  return `## Memory evidence for this question\n\n${lines.join('\n\n')}\n\nUse this only as evidence. Distinguish confirmed outcomes from requests or tool attempts.`;
+  // The self-report line is what makes memory reuse visible to the user in the
+  // chat itself. It asks for a short human-readable label rather than an id:
+  // a raw id means nothing to a reader, and an echoed id token would also be
+  // indistinguishable from the evidence markers that the field evaluation
+  // harness scrapes back out of this same text.
+  return `## Memory evidence for this question\n\n${lines.join('\n\n')}\n\nUse this only as evidence. Distinguish confirmed outcomes from requests or tool attempts.\n\nIf your answer actually relies on one or more of the memories above, end your reply with a single line naming them in a few words each, prefixed with the 📎 emoji (for example: "📎 Recalled: preview port binding decision"). Write that line in the language of the conversation. If no memory above actually informed your answer, omit the line entirely — never cite a memory merely because it was shown to you.`;
 }
 
 async function expandEpisodeEvidence(

--- a/tests/adapters/claude-hook-adherence.test.ts
+++ b/tests/adapters/claude-hook-adherence.test.ts
@@ -157,7 +157,10 @@ describe('formatMemoryContext', () => {
   // Mirrors the scraper in scripts/evaluate-memory-field.ts, which recovers the
   // injected event ids from this text to score retrieval. Any marker the
   // instruction text adds would be counted as a selected memory for every case.
-  const EVAL_EVENT_MARKER = /\[event:([a-f0-9-]+)\]/giu;
+  // Built per call: a shared /g regex carries lastIndex between assertions.
+  function scrapeEventIds(context: string): string[] {
+    return Array.from(context.matchAll(/\[event:([a-f0-9-]+)\]/giu), (match) => match[1] ?? '');
+  }
 
   it('marks each memory with its event id for the evaluation harness', () => {
     const context = formatMemoryContext(
@@ -168,8 +171,7 @@ describe('formatMemoryContext', () => {
       'PR 167'
     );
 
-    const scraped = Array.from(context.matchAll(EVAL_EVENT_MARKER), (match) => match[1]);
-    expect(scraped).toEqual([
+    expect(scrapeEventIds(context)).toEqual([
       '3cf7e0c0-5dbe-4d91-90ed-524254e6bd4f',
       '70958fdb-14fe-4385-a8ad-24cbaa4ffc60'
     ]);
@@ -179,20 +181,22 @@ describe('formatMemoryContext', () => {
     const context = formatMemoryContext([{ type: 'lesson', content: '아이디 없는 근거' }], '질문');
 
     expect(context).toContain('아이디 없는 근거');
-    expect(Array.from(context.matchAll(EVAL_EVENT_MARKER))).toHaveLength(0);
+    expect(scrapeEventIds(context)).toEqual([]);
   });
 
   it('asks the model to self-report the memories it actually relied on', () => {
     const context = formatMemoryContext(
-      [{ type: 'lesson', content: '어떤 메모리 내용', id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' }],
-      '질문'
+      [{ type: 'lesson', content: 'some recalled decision', id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' }],
+      'question'
     );
 
     expect(context).toContain('📎');
-    expect(context).toContain('actually relies');
-    // Must stay language-neutral: this plugin ships to non-Korean users too.
-    expect(context).toContain('language of the conversation');
     expect(context).toMatch(/omit the line/i);
+    // The instruction must carry no hardcoded natural language of its own: this
+    // plugin ships to non-Korean users, so the label has to follow the
+    // conversation. Asserting on the absence of Hangul pins the actual
+    // invariant rather than one particular English phrasing of it.
+    expect(context).not.toMatch(/[가-힣]/);
   });
 
   it('returns an empty string when there is nothing to inject', () => {

--- a/tests/adapters/claude-hook-adherence.test.ts
+++ b/tests/adapters/claude-hook-adherence.test.ts
@@ -5,7 +5,8 @@ import {
   shouldRunMemorySearch,
   shouldRunAdherenceCheck,
   type AdherenceState,
-  selectEvidencePreview
+  selectEvidencePreview,
+  formatMemoryContext
 } from '../../src/adapters/claude/hooks/user-prompt-submit.js';
 
 function adherenceState(overrides: Partial<AdherenceState> = {}): AdherenceState {
@@ -149,5 +150,52 @@ describe('Claude user prompt adherence trigger heuristics', () => {
   it('does not classify whitespace-only prompt normalization as query rewrite', () => {
     expect(getRetrievalQueryRewriteKind('  상태 확인만 해줘  ', '상태 확인만 해줘')).toBe('none');
     expect(getRetrievalQueryRewriteKind('그거 계속', 'Previous user: 이전\nCurrent user: 그거 계속')).toBe('follow-up-context');
+  });
+});
+
+describe('formatMemoryContext', () => {
+  // Mirrors the scraper in scripts/evaluate-memory-field.ts, which recovers the
+  // injected event ids from this text to score retrieval. Any marker the
+  // instruction text adds would be counted as a selected memory for every case.
+  const EVAL_EVENT_MARKER = /\[event:([a-f0-9-]+)\]/giu;
+
+  it('marks each memory with its event id for the evaluation harness', () => {
+    const context = formatMemoryContext(
+      [
+        { type: 'lesson', content: 'PR 167 리뷰에서 null 처리 위험 발견', id: '3cf7e0c0-5dbe-4d91-90ed-524254e6bd4f' },
+        { type: 'agent_response', content: '두 번째 근거', id: '70958fdb-14fe-4385-a8ad-24cbaa4ffc60' }
+      ],
+      'PR 167'
+    );
+
+    const scraped = Array.from(context.matchAll(EVAL_EVENT_MARKER), (match) => match[1]);
+    expect(scraped).toEqual([
+      '3cf7e0c0-5dbe-4d91-90ed-524254e6bd4f',
+      '70958fdb-14fe-4385-a8ad-24cbaa4ffc60'
+    ]);
+  });
+
+  it('adds no phantom event marker when a memory carries no id', () => {
+    const context = formatMemoryContext([{ type: 'lesson', content: '아이디 없는 근거' }], '질문');
+
+    expect(context).toContain('아이디 없는 근거');
+    expect(Array.from(context.matchAll(EVAL_EVENT_MARKER))).toHaveLength(0);
+  });
+
+  it('asks the model to self-report the memories it actually relied on', () => {
+    const context = formatMemoryContext(
+      [{ type: 'lesson', content: '어떤 메모리 내용', id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' }],
+      '질문'
+    );
+
+    expect(context).toContain('📎');
+    expect(context).toContain('actually relies');
+    // Must stay language-neutral: this plugin ships to non-Korean users too.
+    expect(context).toContain('language of the conversation');
+    expect(context).toMatch(/omit the line/i);
+  });
+
+  it('returns an empty string when there is nothing to inject', () => {
+    expect(formatMemoryContext([], '질문')).toBe('');
   });
 });


### PR DESCRIPTION
## 배경

주입된 메모리 중 **무엇이 실제로 답변에 쓰였는지** 사용자가 대화창에서 알 수 없었다.

기존에도 추적 수단은 있었지만 둘 다 이 목적에는 맞지 않았다:
- `recordRetrieval()` — "주입됨"만 기록. 모델이 실제로 참고했는지는 모름
- `evaluateSessionHelpfulness()` — 세션 종료 후 사후 추정. 해당 턴에서 보이는 신호가 없음

## 변경

`formatMemoryContext()`가 만드는 주입 블록 끝에 자기보고 지시를 추가했다. 실제로 근거로 삼은 메모리가 있으면 📎 한 줄로 밝히고, 없으면 생략한다.

```
📎 Recalled: preview port binding decision
```

### 설계 판단

- **id가 아니라 짧은 사람이 읽을 수 있는 라벨을 요청한다.** 독자에게 해시 id는 의미가 없다. 더 중요한 건, id 토큰을 답변에 되돌려 쓰게 하면 `scripts/evaluate-memory-field.ts`가 **같은 텍스트에서 긁어가는** `[event:...]` 마커와 구분되지 않는다는 점이다. 초안에서 실제로 `[event:uuid]`를 `[mem:xxxxxx]`로 바꿨다가, 평가 하네스의 `selectedEventIds`가 항상 비게 되어 hit/top1이 조용히 0으로 떨어지는 걸 발견하고 되돌렸다 (`src/core/memory-field-evaluation.ts:291`).
- **지시문은 대화 언어를 따르게 한다.** 이 플러그인은 한국어 사용자 전용이 아니므로 라벨 문구를 하드코딩하지 않았다.

## 테스트

`formatMemoryContext`를 export하고 회귀 테스트 4개를 추가했다. 핵심은 평가 하네스가 의존하는 `[event:...]` 마커 계약을 고정하는 것:

- 각 메모리가 정확히 자기 event id로 마킹되는지 (하네스 정규식을 그대로 사용)
- id 없는 메모리가 **팬텀 마커**를 만들지 않는지 — 지시문 자체가 `[event:...]`를 포함하면 모든 케이스에 가짜 선택 id가 섞인다
- 자기보고 지시가 언어 중립적인지
- 주입할 게 없으면 빈 문자열

`[event:]`를 `[mem:]`로 바꿔 넣고 첫 번째 테스트가 실제로 실패하는 것을 확인했다.

## 검증

| 항목 | 결과 |
|------|------|
| `npx tsc --noEmit` | 통과 |
| `npx vitest run` (origin/main 최신 기준) | **170 파일 / 1014 테스트 전부 통과** |

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)