### PR TITLE
fix(memory): raise memory grounding by fixing what gets injected, summarized and recalled

### DIFF
--- a/specs/memory-grounding-remediation/baseline-6ab6d837.md
+++ b/specs/memory-grounding-remediation/baseline-6ab6d837.md
@@ -1,0 +1,215 @@
+# Baseline — projectHash 6ab6d837 (aplus-dev-studio-desktop)
+
+채취 시각: 2026-08-01 (변경 전). 재측정 시 동일 쿼리를 사용할 것 — spec.md §2.
+
+## 타입별 실사용률 (grounding)
+
+```
+event_type        evaluated  grounded  pct 
+----------------  ---------  --------  ----
+agent_response    1642       196       11.9
+tool_observation  452        1         0.2 
+session_summary   225        2         0.9 
+user_prompt       102        5         4.9 
+
+evaluated_total  grounded_total  pct
+---------------  --------------  ---
+2421             204             8.4
+```
+
+## 저장 구성
+
+```
+event_type        stored
+----------------  ------
+tool_observation  13609 
+agent_response    1581  
+user_prompt       838   
+session_summary   518   
+
+tool             n   
+---------------  ----
+Bash             7132
+Edit             5007
+Write            904 
+Agent            291 
+AskUserQuestion  137 
+TaskUpdate       80  
+```
+
+## F1 대상: tool_observation 누수 경로
+
+```
+k                               traces
+------------------------------  ------
+answer_only                     878   
+tool+answer (intent path)       188   
+tool_only (gate fallback leak)  131   
+```
+
+---
+
+## F1 배포 시각 (측정 분기점)
+
+- **배포 UTC**: `2026-07-31T15:48:03Z`
+- 배포 내용: tool_observation 질의 조건부 페널티, 게이트 fallback 제거, intent 정규식 축소 + anchor 검증
+- 빌드: `/Users/justin/workspace/claude-memory-layer/dist/hooks/` (전역 훅이 참조하는 경로)
+
+### F1 이후 재측정 쿼리
+
+```sql
+SELECT e.event_type, COUNT(*) evaluated,
+  SUM(CASE WHEN h.content_overlap_score>=0.3 THEN 1 ELSE 0 END) grounded,
+  ROUND(100.0*SUM(CASE WHEN h.content_overlap_score>=0.3 THEN 1 ELSE 0 END)/COUNT(*),1) pct
+FROM memory_helpfulness h JOIN events e ON e.id=h.event_id
+WHERE h.content_overlap_score IS NOT NULL
+  AND h.created_at >= '2026-07-31T15:48:03Z'
+GROUP BY e.event_type ORDER BY evaluated DESC;
+```
+
+기대: `tool_observation`의 `evaluated`가 거의 0에 수렴하고, `agent_response`의 `evaluated`가
+늘어야 한다(슬롯이 답변 근거로 이전됐다는 증거). 유의미한 판단에는 세션이 몇 번 쌓여야 한다.
+
+---
+
+## F2-a 배포 시각 (측정 분기점)
+
+- **배포 UTC**: `2026-07-31T16:07:32Z`
+- 배포 내용: 규칙 기반 목차형 session_summary(`isPromptOnlySessionSummary`)를 semantic/keyword 레인
+  (`rankHookCandidates`)에서도 제외. 기존엔 graduated 레인(`scoreGraduatedEvidence`)에만 연결돼 있었음.
+- 빌드: `/Users/justin/workspace/claude-memory-layer/dist/hooks/`
+
+### F2-a 이후 재측정 쿼리
+
+```sql
+SELECT e.event_type, COUNT(*) evaluated,
+  SUM(CASE WHEN h.content_overlap_score>=0.3 THEN 1 ELSE 0 END) grounded,
+  ROUND(100.0*SUM(CASE WHEN h.content_overlap_score>=0.3 THEN 1 ELSE 0 END)/COUNT(*),1) pct
+FROM memory_helpfulness h JOIN events e ON e.id=h.event_id
+WHERE h.content_overlap_score IS NOT NULL
+  AND h.created_at >= '2026-07-31T16:07:32Z'
+GROUP BY e.event_type ORDER BY evaluated DESC;
+```
+
+기대: `session_summary`의 `evaluated`가 급감(오염된 요약이 주입에서 빠짐). F2-b(LLM 요약)
+배포 전까지는 session_summary가 아예 거의 주입되지 않는 것이 정상 — 지금 저장된 518건이
+전부 목차형이기 때문.
+
+---
+
+## F2-b 배포 시각 (측정 분기점)
+
+- **배포 UTC**: `2026-08-01T01:31:52Z`
+- 배포 내용: 규칙 기반 요약 생성기 → LLM(claude CLI) 요약으로 교체.
+  Stop 훅은 데몬에 `summarize`를 요청만 하고 즉시 반환(논블로킹), 데몬이 백그라운드에서 생성.
+
+### ✅ 배포 절차: 수동 재시작 불필요 (자동화 완료)
+
+`semantic-daemon`은 long-lived 프로세스라 원래는 **빌드만 해서는 새 코드가 적용되지 않았다.**
+E2E 검증 중 실제로 이 문제를 만났다 — 구버전 데몬이 `summarize` 요청을
+`invalid request`로 거부했고, Stop 훅은 이를 삼켜서(try/catch) **아무 오류 없이 요약만 누락**됐다.
+`npm install` 업그레이드도 `dist/`만 교체할 뿐 데몬을 재시작하지 않아 동일한 문제가 있었다
+(postinstall·install 커맨드 모두 데몬을 건드리지 않고, `ensureDaemonRunning()`은 연결만 확인).
+idle 타임아웃(10분)이 있으나 **연결마다 리셋**되므로 작업 중에는 무기한 유지될 수 있었다.
+
+이제 데몬이 기동 시 자기 스크립트의 fingerprint(mtime:size)를 기록하고, 연결 수립 시 현재 값과
+비교해 다르면 **응답하지 않고 소켓을 끊은 뒤 스스로 종료**한다. 모든 클라이언트가 이미
+연결 오류 시 `ensureDaemonRunning()` 후 재시도하므로, 재시도가 새 빌드 데몬으로 자동으로 넘어간다.
+따라서 `npm run build` / `npm install` 후 **추가 조치가 필요 없다.**
+
+검증(실측): 재빌드만 하고 `pkill` 없이 Stop 훅 실행 → 데몬 PID 9954 → 16273 자동 교체,
+요약 정상 생성(`generated=llm`). fingerprint를 읽을 수 없으면 stale로 판정하지 않아
+(모든 요청 거부 방지) 안전 측으로 동작한다.
+
+### E2E 검증 결과 (실제 훅 전체 경로)
+
+생성된 요약:
+```
+- 제약: 현재 빌드가 arm64 전용이라 intel mac에서는 업데이트 채널이 비어있음
+- 제약: intel 호환성을 위해 universal 빌드로 전환하거나 x64 타깃을 따로 배포해야 함
+```
+metadata: `generated=llm, provider=claude, model=claude-haiku-4-5-20251001`
+
+- Stop 훅 즉시 반환 확인(논블로킹)
+- **재귀 없음 확인**: 프로젝트 저장소 수 67 → 68(테스트 프로젝트 1개만). 재귀였다면 다수 생성.
+
+### F2-b 이후 확인 쿼리
+
+```sql
+-- 새로 생성되는 요약이 LLM 산출물인지
+SELECT json_extract(metadata,'$.generated') gen, COUNT(*)
+FROM events WHERE event_type='session_summary' GROUP BY gen;
+```
+
+기대: `llm`이 증가. 기존 518건(`rule-based`)은 F2-a로 주입이 이미 차단돼 있어 무해.
+
+---
+
+## F3 배포 시각 (측정 분기점)
+
+- **배포 UTC**: `2026-08-01T02:01:38Z`
+
+### F3-a: lesson 주입 레인 신설 (핵심)
+
+착수 전 확인한 사실: **lesson 은 주입 경로에 전혀 연결돼 있지 않았다.**
+`memory_lessons` 는 events 테이블 밖에 있어 semantic/keyword 검색에 잡히지 않고,
+MCP 도구로 에이전트가 직접 호출해야만 보였다. 즉 후보 탐지만 고쳤다면
+**"만들지만 안 쓰임"** 이라는 이 spec 이 막으려던 실패를 그대로 반복했을 것이다.
+
+- `MemoryQueryService.listProjectLessons()` 신설 → `MemoryService` 로 노출
+- `scoreLessonEvidence()` — graduated 레인과 같은 결정론적 lexical 스코어링
+  (curated 라는 이유로 정확한 증거를 이기지 않도록 confidence 는 작은 tie-breaker)
+- 게이트에서 lesson 을 answer evidence 로 인정, `evidenceUtilityBonus('lesson') = 0.16` (최고)
+
+### F3-b: 후보 탐지 결함 2건 수정
+
+| 결함 | 수정 |
+|---|---|
+| `ORDER BY timestamp ASC LIMIT 2000` → **가장 오래된** 구간만 스캔 (207세션 중 32개) | 최신 구간을 스캔하도록 변경 |
+| 세션에 `error/failed/blocked` 토큰이 하나라도 있으면 통째 탈락 (**실측 93.7% 세션이 해당**) | "실패 후 복구했는가"(마지막 성공이 마지막 실패 이후)로 대체 |
+
+실측 개선: 적격 세션 0 → 9, 후보 0건 → **1건**(3개 세션 근거, 신뢰도 0.85).
+가장 배울 가치가 큰 "오류를 만나 해결한 세션"이 정확히 배제되던 문제가 해소됐다.
+
+### E2E 검증
+
+실제 lesson 저장 후 훅 실행:
+- 관련 질의 → `- [lesson] preview 포트 충돌 복구 절차` + 적용 시점/절차 3단계/주의사항 **전문 주입**
+- 무관한 질의 → 주입 없음 (오주입 없음)
+
+### F3 이후 확인 쿼리
+
+```sql
+-- lesson 이 실제로 주입되고 사용되는지 (F3 이전에는 구조적으로 0이었음)
+SELECT COUNT(*) injected,
+  SUM(CASE WHEN content_overlap_score>=0.3 THEN 1 ELSE 0 END) grounded
+FROM memory_helpfulness
+WHERE created_at >= '2026-08-01T02:01:38Z' AND event_id IN (SELECT lesson_id FROM memory_lessons);
+```
+
+주의: lesson 은 event 가 아니므로 `memory_helpfulness.event_id` 에 lesson_id 가 기록된다.
+집계 시 events 조인이 아니라 위처럼 lesson 테이블과 대조해야 한다.
+
+---
+
+## ⚠️ 측정 교란 요인 — 같은 기간에 배포된 다른 변경들
+
+이 spec 의 F1~F3 만으로 전후 차이를 귀속하면 **F1 효과를 과대평가하게 된다.**
+baseline 채취(2026-08-01) 전후로 `main` 에 tool_observation 노이즈를 겨냥한 별개 작업이 머지됐다.
+
+| PR | 내용 | 층 |
+|---|---|---|
+| #37 / #38 | tool_observation 을 벡터 임베딩에서 제외 | 임베딩 |
+| #39 | 이미 오염된 tool_observation 벡터 self-heal | 저장소 |
+| #40 | keywordSearch 기본 레인에서 tool_observation 제외 (`includeToolObservations` opt-in) | 검색 |
+| **F1 (본 spec)** | 주입 슬롯 경쟁·게이트 fallback 차단 | **주입 정책** |
+
+네 층이 같은 증상을 각각 다른 지점에서 막는다. 특히 **#40 이 검색 단계에서 이미 걸러내므로,
+F1 배포 후 tool_observation 주입이 0 에 수렴하더라도 그 공은 F1 단독이 아니다.**
+F1 이 여전히 유효한 범위는 (a) episode seeding 이 `includeToolObservations: true` 로
+의도적으로 끌어오는 tool 근거, (b) semantic/graduated 레인을 통해 들어오는 경우,
+(c) 게이트 fallback 이라는 마지막 방어선이다.
+
+**해석 규칙**: tool_observation 지표 개선은 #37~#40 과 F1 의 합작으로 보고,
+F1 단독 효과를 주장하지 말 것. 반면 `session_summary`(F2) 와 `lesson`(F3) 지표는
+다른 PR 이 건드리지 않았으므로 본 spec 에 귀속 가능하다.

--- a/specs/memory-grounding-remediation/spec.md
+++ b/specs/memory-grounding-remediation/spec.md
@@ -1,0 +1,294 @@
+# Spec: Memory Grounding Remediation
+
+> 마지막 갱신: 2026-08-01
+> 상태: 초안 (미착수)
+> 선행 spec: `specs/memory-utilization-improvements/` (2026-03-04) — **본 문서가 그 실패 원인을 규명하고 대체한다**
+
+## 0. 왜 세 번째로 다시 쓰는가
+
+같은 문제를 이미 두 번 고쳤는데 지표가 움직이지 않았다. 근본 원인은 코드가 아니라 **목표 지표 선택**이었다.
+
+`specs/memory-utilization-improvements/spec.md`(2026-03-04)의 성공 기준:
+
+| 선행 spec의 목표 | 성격 | 결과 |
+|---|---|---|
+| Retrieval trace 기록률 > 95% | 프록시 | ✅ 달성 |
+| 세션 요약 생성률 > 80% | 프록시 | ✅ 달성 (518건) |
+| Tool observation 저장 비율 < 30% | 프록시 | ❌ 미달 (여전히 82%) |
+| 메모리 Graduation L1+ > 10% | 프록시 | ⚠️ 5.2% |
+
+전부 **"만들어졌는가"를 재는 프록시 지표**다. "**쓸모가 있었는가**"를 재는 지표가 목표에 없었다.
+그 결과 IMP-03(세션 요약)은 spec대로 정확히 구현됐지만 — spec이 정의한 템플릿
+(`"[날짜] [N]턴 세션. 주요 작업: ... 사용 툴: ..."`)이 **목차이지 지식이 아니었기 때문에**,
+생성률 100%를 달성하고도 실사용률은 0.9%다. **스펙을 충족하면서 동시에 무용한 결과**가 나왔다.
+
+지금은 `memory_helpfulness.content_overlap_score`라는 **결과 지표**가 존재한다(주입된 메모리가
+실제 응답에 반영됐는지 측정). 본 spec은 이 지표 하나만을 목표로 삼는다.
+
+## 1. 현재 측정값 (aplus-dev-studio-desktop, projectHash `6ab6d837`, 2026-08-01)
+
+주입된 메모리 중 실제로 답변에 사용된 비율 (`content_overlap_score >= 0.3`):
+
+| 이벤트 타입 | 저장량 | 주입 평가 | 실사용 | **실사용률** |
+|---|---|---|---|---|
+| tool_observation | 13,609 (82%) | 452 | 1 | **0.2%** |
+| session_summary | 518 | 225 | 2 | **0.9%** |
+| user_prompt | 838 | 102 | 5 | 4.9% |
+| agent_response | 1,581 | 1,642 | 196 | 11.9% |
+| **전체** | 16,546 | 2,421 | 204 | **8.4%** |
+
+주입 슬롯의 91.6%가 토큰만 쓰고 버려진다.
+
+### 검증된/기각된 가설
+
+- ✅ **tool_observation은 IMP-02 필터 적용 후에도 82%다.** Read/Grep/Glob은 이미 제외됨에도
+  Bash 7,132 + Edit 5,007 = 전체 관측의 89%가 남는다. IMP-02는 "Edit/Write는 항상 저장(코드 변경 추적 필요)"으로
+  설계했으나, **코드 변경은 git이 이미 추적하며 모델은 그걸 git에게 묻지 메모리에게 묻지 않는다.**
+  저장 가치 모델 자체가 틀렸다.
+- ✅ **fallback 누수 확인.** tool_observation을 포함한 trace 319건 중 **131건은 답변 근거가 하나도 없는
+  상태에서 tool만 주입**됐다(`applyAnswerabilityGate` 최종 fallback 경로).
+- ❌ **"같은 세션 메모리는 이미 컨텍스트에 있으니 중복"** — 기각. 동일 세션 9.4% vs 타 세션 7.9%로
+  오히려 동일 세션이 근소 우위. 컴팩션 이후에는 컨텍스트에 없기 때문으로 추정. **이 가설 기반 최적화는 하지 않는다.**
+
+## 2. 성공 기준 (본 spec)
+
+측정은 전부 아래 단일 쿼리로 한다. 변경 전 baseline을 기록하고, 변경 후 동일 쿼리로 비교한다.
+
+```sql
+SELECT e.event_type, COUNT(*) evaluated,
+  SUM(CASE WHEN h.content_overlap_score >= 0.3 THEN 1 ELSE 0 END) grounded,
+  ROUND(100.0*SUM(CASE WHEN h.content_overlap_score >= 0.3 THEN 1 ELSE 0 END)/COUNT(*),1) pct
+FROM memory_helpfulness h JOIN events e ON e.id = h.event_id
+WHERE h.content_overlap_score IS NOT NULL
+  AND h.created_at >= :since        -- 변경 배포 시점
+GROUP BY e.event_type;
+```
+
+| 지표 | 현재 | 목표 |
+|---|---|---|
+| 전체 실사용률 | 8.4% | **> 25%** |
+| tool_observation 주입 건수 | 452 | **< 20** |
+| session_summary 실사용률 | 0.9% | **> 10%** |
+| 주입당 평균 토큰 (낭비 대리지표) | — | 감소 |
+
+**프록시 지표는 성공 기준에 넣지 않는다.** 생성률·저장률·trace 기록률은 관측만 하고 목표로 삼지 않는다.
+
+---
+
+## F1. tool_observation을 주입 경로에서 차단
+
+**우선순위: P0** — 효과가 가장 크고 범위가 가장 명확하다.
+
+### 문제
+
+두 개의 누수 경로가 있다.
+
+1. **랭킹 슬롯 점유**: `evidenceUtilityBonus('tool_observation') = +0.03` (prompt-injection-policy.ts:208).
+   tool 관측이 상위 5슬롯을 차지한 뒤 게이트를 통과한다.
+2. **게이트 최종 fallback**: `applyAnswerabilityGate` (같은 파일 196–197행) —
+   답변 근거가 하나도 없으면 **질의 의도와 무관하게 tool 관측 전체를 반환**한다. 확인된 누수 131 trace.
+
+```typescript
+// 현재 (196-197행)
+const toolEvidence = candidates.filter((c) => c.type === 'tool_observation');
+if (toolEvidence.length > 0) return toolEvidence;   // ← 무조건 누수
+```
+
+추가로 `hasToolEvidenceIntent`(201행)의 정규식이 `command|log|명령|로그`처럼 흔한 단어를 잡아
+너무 느슨하다 (tool+answer 188 trace).
+
+### 설계
+
+1. **`evidenceUtilityBonus`를 질의 조건부로 변경.** tool_observation에만 적용:
+   질의에 tool 의도가 있으면 현행 `+0.03` 유지, 없으면 **`-0.15`**.
+   ⚠️ **일괄 페널티는 안 된다** — 아래 "검토된 대안"에 산술 근거.
+2. `applyAnswerabilityGate` 최종 fallback 제거. 답변 근거가 없으면
+   `isContinuationQuery` 경로만 남기고 **빈 배열 반환**(= 주입 안 함). 근거 없는 주입보다 무주입이 낫다.
+3. `hasToolEvidenceIntent` 강화: 흔한 단어(`command`, `log`, `명령`, `로그`) 제거하고,
+   **질의의 identifier anchor가 해당 관측 내용에 실제로 등장할 때만** tool 근거를 허용.
+   1번과 3번이 같은 판정을 공유하므로 헬퍼로 추출한다.
+
+### 검토된 대안 — 기각: tool_observation 일괄 페널티
+
+착수 전 산술 검증에서 **기존 테스트를 깨뜨리는 것이 확인됐다**
+(`tests/adapters/claude-hook-prompt-injection-policy.test.ts:292`,
+"kubectl 출력을 알려줘" → `[answer, tool]` 기대).
+
+| 후보 | 현행 유효점수 | 일괄 `-0.15` 적용 시 |
+|---|---|---|
+| answer (0.86, +0.10) | 0.96 | 0.96 |
+| tool (0.89) | 0.92 | **0.74** |
+| tail (0.68) | 0.71 | 0.53 |
+
+현행은 `0.96→0.92` 격차 0.04 < `scoreCliffGap`(0.08)이라 tool이 살아남아 게이트에서 의도 판정을 받는다.
+일괄 페널티 시 격차가 0.22가 되어 **`applyScoreCliff`가 게이트 이전에 tool을 잘라낸다.**
+정당한 tool 질의가 회귀한다. → 질의 조건부 방식으로 확정.
+
+### 변경 파일
+
+- `src/adapters/claude/hooks/prompt-injection-policy.ts` — `evidenceUtilityBonus`(질의 인자 추가),
+  `rankHookCandidates`(인자 전달), `applyAnswerabilityGate`, `hasToolEvidenceIntent`
+- `tests/adapters/claude-hook-prompt-injection-policy.test.ts` — fallback 제거에 대한 케이스 추가
+
+### 리스크
+
+- `evidenceUtilityBonus`에 query 인자를 추가하면 `rankHookCandidates`의 시그니처가 전파된다(순수 함수라 범위는 좁음).
+- fallback 제거로 "근거 없음 → 무주입"이 되면 체감상 메모리가 조용해진다.
+  **이는 의도된 동작**이며, §2 실사용률로 정당성을 확인한다.
+- "그 명령어 뭐였지?" 류 질의 회귀 → 3번(anchor 검증)으로 방어하고 위 테스트로 고정.
+
+### 검증
+
+배포 후 §2 쿼리에서 `tool_observation`의 `evaluated`가 20 미만으로 떨어지는지. 동시에
+`agent_response`의 `evaluated`가 늘어야 한다(슬롯이 답변 근거로 이전됐다는 증거).
+
+---
+
+## F2. session_summary — 목차 대신 결과를 저장
+
+**우선순위: P1**
+
+### 문제
+
+요약 생성기 2개가 모두 **메타데이터 목차**를 만든다. 결과(무엇이 결정됐고 무엇이 실패했는지)가 없다.
+
+```typescript
+// src/core/derive/summary-deriver.ts (Stop hook 경로)
+// → "[2026-07-28] 1턴 세션. 주요 작업: <첫 프롬프트 120자>. 사용 툴: Bash, Edit"
+
+// src/adapters/claude/transcript/turn-reconstructor.ts (session-end 경로)
+// → "Session with 13 user prompts and 29 responses. Topics discussed: - <프롬프트 100자>"
+```
+
+부수 문제: `firstPromptPreview(prompts[0])`는 **세션 첫 프롬프트**만 쓴다. 긴 세션일수록
+첫 프롬프트만 남아 요약끼리 near-duplicate가 된다 (518건 중 고유 prefix 435건, 16% 중복).
+
+이 무용한 형식을 탐지하는 `isPromptOnlySessionSummary`(prompt-injection-policy.ts:280)는 **이미 존재하며
+두 형식을 모두 정확히 매칭한다.** 그런데 `scoreGraduatedEvidence` 한 곳에서만 호출되고,
+semantic/keyword 레인과 `evidenceUtilityBonus(+0.12, 전 타입 중 최고)`에는 연결돼 있지 않다.
+
+### 설계 — 2단계
+
+**F2-a (즉시, 저위험): 차단만.**
+`isPromptOnlySessionSummary`를 `rankHookCandidates`와 `evidenceUtilityBonus`에도 연결.
+목차형 요약은 유틸리티 보너스 0 + 랭킹에서 제외. 기존 518건의 오염된 요약이 즉시 주입에서 빠진다.
+
+**F2-b (근본): LLM 요약으로 생성기 교체.** — ✅ **결정됨 (2026-08-01): claude/codex CLI 호출**
+
+요약이 담아야 할 것은 목차가 아니라 **결과**다: 무엇을 결정했는가 / 무엇이 실패했고 왜인가 /
+어떤 제약이 확인됐는가. 규칙 기반으로는 "왜"를 뽑을 수 없으므로 LLM을 호출한다.
+
+#### 🔴 최대 위험: 훅 재귀 — 실측으로 해결됨
+
+Stop hook에서 `claude`를 그냥 spawn하면 **자식 세션이 전역 훅을 다시 실행**한다
+(`~/.claude/settings.json`의 SessionStart/Stop/…). 자식의 Stop hook이 또 요약을 만들려고
+`claude`를 spawn → **무한 재귀**. 기존 선례인 `src/apps/server/api/chat.ts:286`은
+`env: { ...process.env }`로 전체 환경을 상속하며 **훅 차단 장치가 없다** — 그대로 복사하면 안 된다.
+
+**실측 결과 (2026-08-01, 대조군 포함):**
+
+| 호출 | 신규 project 저장소 | 판정 |
+|---|---|---|
+| `claude -p` (플래그 없음) | 67 → **68** | 훅 실행됨 |
+| `claude -p --setting-sources project` | 67 → **67** | **훅 미실행** |
+
+→ **`--setting-sources project`를 필수로 사용한다.** 메모리 훅은 user 레벨 설정에 있으므로
+`user`를 로드 대상에서 빼면 실행되지 않는다.
+
+`--bare`도 훅을 차단하지만 **채택하지 않는다**: "OAuth and keychain are never read"라
+`ANTHROPIC_API_KEY`가 필요한데 현재 환경에 **미설정**이다. `--setting-sources`는 OAuth 인증이
+유지됨을 실측 확인했다(exit 0, 정상 응답).
+
+#### 설계
+
+- **호출 형태**: `claude -p --setting-sources project --model <소형모델>`, 프롬프트는 stdin.
+  실패 분류(auth/not-found/timeout)는 `chat.ts:220-236`의 `classifyProviderFailure` 패턴을 재사용.
+- **입력**: 세션의 user_prompt + agent_response (tool_observation 제외 — 노이즈이고 토큰만 먹는다).
+  프롬프트는 "결정/실패 원인/확인된 제약"만 뽑도록 지시하고, 없으면 빈 출력을 허용한다.
+- **동기/비동기**: Stop hook을 LLM 지연으로 블로킹하면 안 된다.
+  기존 `embedding_outbox` 아웃박스 패턴을 따라 **요약 작업을 큐에 넣고 백그라운드에서 처리**한다
+  (요약은 다음 세션을 위한 것이므로 지연 허용).
+- **폴백**: LLM 호출 실패 시 현행 규칙 기반 요약으로 되돌리지 **않는다**(그게 오염원이다).
+  요약 없이 두고 재시도 큐에 남긴다.
+- **codex 대안**: `codex`도 설치돼 있다. 동일 인터페이스로 교체 가능하도록 provider를 추상화하되,
+  기본은 claude로 한다.
+
+#### 미해결 (구현 시 결정)
+
+- 모델 선택 및 세션당 비용 상한
+- 아웃박스 재시도 정책 (임베딩 아웃박스 정책 재사용 여부)
+- 기존 오염된 요약 518건의 소급 재생성 여부 (F2-a로 주입은 이미 차단되므로 급하지 않음)
+
+### 변경 파일
+
+- F2-a: `src/adapters/claude/hooks/prompt-injection-policy.ts`
+- F2-b: `src/core/derive/summary-deriver.ts`, `src/adapters/claude/transcript/turn-reconstructor.ts`
+  (두 생성기를 하나로 통합하는 것도 함께 검토 — 현재 이원화 자체가 결함)
+
+### 검증
+
+F2-a 후 `session_summary`의 `evaluated`가 급감해야 한다(= 오염된 요약이 주입에서 빠짐).
+F2-b 후에는 `evaluated`가 회복하면서 `pct > 10%`.
+
+---
+
+## F3. 지식 추출 레인 신설
+
+**우선순위: P2** — 가장 근본적이지만 데이터 근거가 가장 약하고 설계 자유도가 크다.
+
+### 문제
+
+현재 저장되는 모든 것은 **원시 전사(transcript)**다: 프롬프트, 응답, 툴 JSON, 그리고 메타데이터 요약.
+"무엇이 결정됐다 / 무엇이 제약이다 / 이 접근은 실패했다"를 담는 레인이 **하나도 없다.**
+`memory_lessons` 테이블이 정확히 그 용도로 존재하지만 **0건**이다.
+
+그 결과 유일하게 작동하는 게 `agent_response`(11.9%) — **Claude가 쓴 산문을 Claude에게 되먹이는 것**이다.
+주입의 66%가 여기서 나온다. 같은 문체·같은 주제라 검색 점수는 높지만 지식 추출이 아니라 메아리이고,
+세대를 거치며 "요약의 요약"으로 열화된다.
+
+> 근거의 한계를 명시한다: 이 열화가 실측된 것은 아니다. 관측된 사실은 (a) 주입의 66%가 자기 산문이고
+> (b) 그마저 11.9%만 실사용된다는 것. "열화"는 메커니즘 추론이다.
+
+### 설계 방향 (택일 아님, 조합 가능)
+
+1. **자동 후보 탐지 → 수동 승격.** 이미 `LessonCandidateService`가 존재하고,
+   금일 `mem-lesson-candidates` MCP 도구로 노출했다. 다만 현재 판정 기준이 엄격해
+   이 프로젝트에서 32세션 스캔 후보 0건 — **판정 기준과 스캔 범위(기본 가장 오래된 2,000건) 재조정 필요.**
+2. **Stop hook에서 결과 문장 추출.** agent_response에서 결정/원인/제약 문장만 뽑아
+   별도 이벤트 타입으로 저장. 규칙 기반의 한계는 F2-b와 동일한 트레이드오프.
+3. **provenance 기반 감쇠.** 주입된 메모리를 인용해 생성된 응답을 "파생"으로 표시
+   (`retrieval_traces`에 이미 연결 데이터 있음). 원본이 메아리보다 상위에 오도록.
+
+### 검증
+
+`memory_lessons` 건수 > 0, 그리고 lesson이 주입됐을 때의 실사용률을 별도 타입으로 §2 쿼리에서 추적.
+
+---
+
+## 3. 실행 순서
+
+```
+F1 (P0)  ──> 측정 ──> F2-a (P1, 저위험) ──> 측정 ──> [결정] F2-b / F3
+```
+
+각 단계마다 §2 쿼리로 전후 비교. **한 번에 하나씩 배포하고 측정한다** — 동시 배포하면
+어느 변경이 효과를 냈는지 귀속할 수 없고, 그게 지금까지 반복된 실패 패턴이다.
+
+F1과 F2-a는 모두 `prompt-injection-policy.ts` 한 파일이고 순수 함수라 테스트가 쉽다. 롤백은 환경변수가
+아니라 revert로 한다(현재 정책 임계값들은 env로 조정 가능하나, 보너스 상수는 하드코딩이므로).
+
+## 4. 범위 밖
+
+- 저장 단계에서 tool_observation을 줄이는 것(IMP-02 재시도): F1이 주입을 막으면 저장 비용은
+  디스크·임베딩 문제로 축소된다. 별건으로 다룬다.
+- 이미 저장된 13,609건의 소급 정리: 주입이 막히면 무해하다. retention 정책과 함께 별도 검토.
+- 다른 프로젝트로의 일반화: 본 spec은 `6ab6d837` 단일 프로젝트 데이터에 근거한다.
+  배포 전 최소 1개 프로젝트에서 baseline을 더 확인하는 것이 안전하다.
+
+## 5. 결정 필요 사항
+
+**D1. F2-b 요약 생성 방식** — ✅ **결정됨 (2026-08-01): (b) LLM 요약, claude/codex CLI 호출.**
+훅 재귀 위험은 `--setting-sources project`로 차단하며 실측 검증 완료 (F2-b 참조).
+
+**D2. F3 착수 여부** — 미결. F1+F2로 실사용률이 목표(25%)에 도달하면 F3는 불필요할 수 있다.
+F1·F2 측정 후 재판단하는 것을 권한다.

--- a/src/adapters/claude/hooks/prompt-injection-policy.ts
+++ b/src/adapters/claude/hooks/prompt-injection-policy.ts
@@ -1,4 +1,4 @@
-export type HookMemorySource = 'semantic' | 'keyword' | 'graduated' | 'episode' | 'unknown';
+export type HookMemorySource = 'semantic' | 'keyword' | 'graduated' | 'episode' | 'lesson' | 'unknown';
 
 export interface HookMemoryCandidate {
   type: string;
@@ -147,12 +147,21 @@ function rankHookCandidates(
     .filter(({ candidate }) => !query || (
       candidate.source === 'episode' && candidate.episodeLinked && candidate.episodeSeedAligned
     ) || hasQueryMemoryAlignment(query, candidate.content, 2))
+    // The rule-based session-summary generator emits a table of contents
+    // ("Session with N prompts. Topics discussed: ..."), not a result. The
+    // graduated lane already excludes this via scoreGraduatedEvidence; the
+    // semantic/keyword lanes must exclude it too or it keeps winning the
+    // evidenceUtilityBonus('session_summary') = 0.12 slot on session_summary's
+    // own high type bonus alone, with nothing answerable inside it.
+    .filter(({ candidate }) =>
+      candidate.type !== 'session_summary' || !isPromptOnlySessionSummary(candidate.content)
+    )
     .map(({ candidate, index }) => ({
       candidate,
       index,
       effectiveScore: Math.max(0,
         (candidate.score ?? 0)
-        + (query ? evidenceUtilityBonus(candidate.type) : 0)
+        + (query ? evidenceUtilityBonus(candidate.type, query) : 0)
         + (query ? graduatedEvidenceBonus(candidate) : 0)
         + (candidate.source === 'episode' && candidate.episodeLinked && candidate.episodeSeedStrongAligned
           ? 0.42
@@ -185,27 +194,55 @@ function applyScoreCliff(
 
 function applyAnswerabilityGate(candidates: HookMemoryCandidate[], query: string): HookMemoryCandidate[] {
   const answerEvidence = candidates.filter((candidate) =>
-    candidate.type === 'agent_response' || candidate.type === 'session_summary'
+    candidate.type === 'agent_response'
+    || candidate.type === 'session_summary'
+    || candidate.type === 'lesson'
   );
   if (answerEvidence.length > 0) {
     const toolEvidence = hasToolEvidenceIntent(query)
-      ? candidates.filter((candidate) => candidate.type === 'tool_observation')
+      ? candidates.filter((candidate) =>
+        candidate.type === 'tool_observation' && toolEvidenceMatchesQueryAnchors(candidate, query)
+      )
       : [];
     return [...answerEvidence, ...toolEvidence];
   }
-  const toolEvidence = candidates.filter((candidate) => candidate.type === 'tool_observation');
-  if (toolEvidence.length > 0) return toolEvidence;
+  // No tool-only fallback. Injecting raw tool attempts because nothing better
+  // survived ranking produced 131 traces whose memories were never used in an
+  // answer (grounding 0.2%). Abstaining is cheaper than unusable context.
   return isContinuationQuery(query) ? candidates : [];
 }
 
-function hasToolEvidenceIntent(query: string): boolean {
-  return /\b(?:kubectl|curl|sql|command|log|output|stack trace)\b|(?:명령|로그|출력|스택\s*트레이스)/iu.test(query);
+/**
+ * A tool observation may only accompany an answer when the query's distinctive
+ * identifiers actually occur in it. Queries without identifiers cannot be
+ * verified this way, so they keep the intent-only behaviour.
+ */
+function toolEvidenceMatchesQueryAnchors(candidate: HookMemoryCandidate, query: string): boolean {
+  const anchors = identifierAnchors(query);
+  if (anchors.length === 0) return true;
+  const lowered = candidate.content.toLowerCase();
+  return anchors.some((anchor) => lowered.includes(anchor.toLowerCase()));
 }
 
-function evidenceUtilityBonus(type: string): number {
+function hasToolEvidenceIntent(query: string): boolean {
+  // "command", "log", and "output" are deliberately absent: <task-notification>
+  // payloads embed <output-file>, which made nearly every notification look like
+  // a tool-evidence request. Retrieval queries are also enriched with the
+  // previous turn, so generic words match far beyond the current question.
+  return /\b(?:kubectl|curl|psql|sql|stderr|stdout|traceback|stack\s*trace|exit\s*code)\b|(?:명령어|스택\s*트레이스|종료\s*코드|터미널)/iu
+    .test(query);
+}
+
+function evidenceUtilityBonus(type: string, query: string): number {
+  // Lessons are human-reviewed runbooks rather than transcript, so they outrank
+  // every derived evidence type.
+  if (type === 'lesson') return 0.16;
   if (type === 'session_summary') return 0.12;
   if (type === 'agent_response') return 0.10;
-  if (type === 'tool_observation') return 0.03;
+  // Tool observations only earn a slot when the question actually asks for tool
+  // evidence; otherwise they are pushed below answer evidence instead of
+  // consuming the bounded injection budget.
+  if (type === 'tool_observation') return hasToolEvidenceIntent(query) ? 0.03 : -0.15;
   if (type === 'user_prompt') return -0.10;
   return 0;
 }
@@ -275,6 +312,66 @@ export function scoreGraduatedEvidence(query: string, candidate: HookMemoryCandi
     + levelPrior
     + accessPrior
   );
+}
+
+export interface LessonEvidenceInput {
+  lessonId: string;
+  name: string;
+  trigger?: string;
+  steps: string[];
+  failureModes?: string[];
+  confidence: number;
+}
+
+/**
+ * Render a curated lesson as injectable evidence, scored by query coverage.
+ *
+ * Lessons live outside the events table, so they reach the prompt only through
+ * this lane. The score stays lexical and deterministic for the same reason the
+ * graduated lane does: a reviewed runbook must not outrank exact evidence just
+ * for being curated, so confidence is only a small tie-breaker.
+ */
+export function scoreLessonEvidence(
+  query: string,
+  lesson: LessonEvidenceInput
+): HookMemoryCandidate | null {
+  const content = formatLessonContent(lesson);
+  if (!hasQueryMemoryAlignment(query, content, 2)) return null;
+
+  const queryTerms = meaningfulTerms(query);
+  const contentTerms = new Set(meaningfulTerms(content));
+  const overlap = queryTerms.filter((term) => contentTerms.has(term)).length;
+  if (overlap < Math.min(3, queryTerms.length)) return null;
+
+  const coverage = overlap / Math.max(1, Math.min(queryTerms.length, 8));
+  const anchors = identifierAnchors(query);
+  const lowered = content.toLowerCase();
+  const matchedAnchors = anchors.filter((anchor) => lowered.includes(anchor.toLowerCase())).length;
+  const anchorCoverage = anchors.length === 0 ? 0 : matchedAnchors / anchors.length;
+  if (anchors.length >= 2 && matchedAnchors < Math.ceil(anchors.length * 0.6)) return null;
+
+  const confidencePrior = Math.min(0.05, Math.max(0, lesson.confidence) * 0.05);
+  const score = Math.min(0.98, 0.5 + coverage * 0.28 + anchorCoverage * 0.12 + confidencePrior);
+
+  return {
+    id: lesson.lessonId,
+    type: 'lesson',
+    content,
+    score,
+    source: 'lesson'
+  };
+}
+
+function formatLessonContent(lesson: LessonEvidenceInput): string {
+  const parts = [lesson.name];
+  if (lesson.trigger) parts.push(`적용 시점: ${lesson.trigger}`);
+  if (lesson.steps.length > 0) {
+    parts.push(lesson.steps.slice(0, 8).map((step) => `- ${step}`).join('\n'));
+  }
+  if (lesson.failureModes && lesson.failureModes.length > 0) {
+    parts.push(`주의: ${lesson.failureModes.slice(0, 4).join(' / ')}`);
+  }
+  return parts.join('\n');
 }
 
 function isPromptOnlySessionSummary(content: string): boolean {
@@ -366,7 +463,12 @@ function thresholdFor(candidate: HookMemoryCandidate, policy: HookInjectionPolic
       ? policy.fallbackKeywordMinScore
       : policy.keywordMinScore;
   }
-  if (candidate.source === 'semantic' || candidate.source === 'graduated' || candidate.source === 'episode') {
+  if (
+    candidate.source === 'semantic'
+    || candidate.source === 'graduated'
+    || candidate.source === 'episode'
+    || candidate.source === 'lesson'
+  ) {
     return policy.semanticMinScore;
   }
   return policy.minScore;

--- a/src/adapters/claude/hooks/semantic-daemon-client.ts
+++ b/src/adapters/claude/hooks/semantic-daemon-client.ts
@@ -21,7 +21,7 @@ interface SemanticMemory {
 }
 
 interface SemanticDaemonRequest {
-  type: 'retrieve' | 'graduate';
+  type: 'retrieve' | 'graduate' | 'summarize';
   sessionId: string;
   prompt?: string;
   topK?: number;
@@ -89,6 +89,30 @@ export async function scheduleSemanticGraduation(
 ): Promise<void> {
   const payload: SemanticDaemonRequest = {
     type: 'graduate',
+    sessionId,
+    evaluation: process.env.CLAUDE_MEMORY_EVAL_MODE === 'true'
+  };
+
+  try {
+    await requestFromDaemon(payload, timeoutMs);
+  } catch (error) {
+    if (!isConnectionError(error)) throw error;
+    await ensureDaemonRunning();
+    await requestFromDaemon(payload, timeoutMs);
+  }
+}
+
+/**
+ * Ask the daemon to build this session's outcome-focused summary. The daemon
+ * acknowledges immediately and runs the LLM call in the background, so the Stop
+ * hook never waits on it.
+ */
+export async function scheduleSessionSummary(
+  sessionId: string,
+  timeoutMs: number = 500
+): Promise<void> {
+  const payload: SemanticDaemonRequest = {
+    type: 'summarize',
     sessionId,
     evaluation: process.env.CLAUDE_MEMORY_EVAL_MODE === 'true'
   };

--- a/src/adapters/claude/hooks/semantic-daemon.ts
+++ b/src/adapters/claude/hooks/semantic-daemon.ts
@@ -8,9 +8,10 @@ import { getSessionProject } from '../../../core/registry/session-registry.js';
 import { WorkerLock } from '../../../core/worker-lock.js';
 import { readNumberEnv } from './hook-runtime.js';
 import { AutoGraduationScheduler, isAutoGraduationEnabled } from './semantic-daemon-graduation.js';
+import { generateLlmSessionSummary, isLlmSummaryEnabled } from '../../llm/session-summary-llm.js';
 
 export interface SemanticDaemonRequest {
-  type?: 'retrieve' | 'graduate';
+  type?: 'retrieve' | 'graduate' | 'summarize';
   sessionId?: string;
   prompt?: string;
   topK?: number;
@@ -52,6 +53,38 @@ let idleTimer: NodeJS.Timeout | null = null;
 let shuttingDown = false;
 let processHandlersInstalled = false;
 
+/**
+ * Build fingerprint of the daemon script this process actually loaded.
+ *
+ * A daemon is long-lived, so `npm install`/`npm run build` replaces dist/ while
+ * the old code keeps serving from memory, and the client only checks whether
+ * *something* is listening. A stale daemon rejects request types it does not
+ * know ("invalid request"), and callers that swallow errors then lose work
+ * silently — observed with the `summarize` request after adding it. The idle
+ * timeout alone is not enough because every connection resets it, so a busy
+ * machine can keep a stale daemon alive indefinitely.
+ */
+function readDaemonScriptFingerprint(): string | null {
+  try {
+    const scriptPath = new URL(import.meta.url).pathname;
+    const stats = fs.statSync(scriptPath);
+    return `${stats.mtimeMs}:${stats.size}`;
+  } catch {
+    // Unreadable script: fall back to "never stale" rather than refusing work.
+    return null;
+  }
+}
+
+const startupScriptFingerprint = readDaemonScriptFingerprint();
+
+export function isDaemonBuildStale(
+  current: string | null = readDaemonScriptFingerprint(),
+  startup: string | null = startupScriptFingerprint
+): boolean {
+  if (startup === null || current === null) return false;
+  return current !== startup;
+}
+
 function scheduleIdleShutdown(): void {
   if (idleTimer) {
     clearTimeout(idleTimer);
@@ -77,7 +110,9 @@ export function isValidSemanticDaemonRequest(
   input: SemanticDaemonRequest
 ): boolean {
   if (typeof input.sessionId !== 'string' || input.sessionId.length === 0) return false;
-  if (input.type === 'graduate') return input.evaluation === undefined || typeof input.evaluation === 'boolean';
+  if (input.type === 'graduate' || input.type === 'summarize') {
+    return input.evaluation === undefined || typeof input.evaluation === 'boolean';
+  }
   return input.type === 'retrieve'
     && typeof input.prompt === 'string'
     && input.prompt.length > 0
@@ -152,6 +187,46 @@ function getProjectKeyForSession(sessionId: string): string {
   return getSessionProject(sessionId)?.projectHash || '__global__';
 }
 
+/**
+ * Generate the outcome-focused session summary outside the hook response path.
+ *
+ * The cached daemon service is read-only, so this builds a short-lived writable
+ * one exactly like the graduation path does.
+ */
+async function runSessionSummaryWithWriterLock(sessionId: string): Promise<void> {
+  if (!isLlmSummaryEnabled()) return;
+
+  const projectInfo = getSessionProject(sessionId);
+  const storagePath = projectInfo
+    ? getProjectStoragePath(projectInfo.projectPath)
+    : path.join(os.homedir(), '.claude-code', 'memory');
+  const writerLock = new WorkerLock(path.join(storagePath, 'summary-worker.lock'));
+  const lockResult = writerLock.acquire();
+  if (!lockResult.acquired) return;
+
+  const service = new MemoryService({
+    storagePath,
+    projectHash: projectInfo?.projectHash,
+    projectPath: projectInfo?.projectPath,
+    readOnly: false,
+    analyticsEnabled: false,
+    sharedStoreConfig: DISABLED_SHARED_STORE_CONFIG,
+    llmSummaryGenerator: (events) => generateLlmSessionSummary(events)
+  });
+
+  try {
+    await service.initialize();
+    await service.generateLlmSessionSummary(sessionId);
+  } catch (error) {
+    if (process.env.CLAUDE_MEMORY_DEBUG) {
+      console.error('[semantic-daemon] session summary failed:', error);
+    }
+  } finally {
+    await service.shutdown().catch(() => undefined);
+    writerLock.release();
+  }
+}
+
 export async function handleSemanticDaemonRequest(raw: string): Promise<SemanticDaemonResponse> {
   const input = parseSemanticDaemonRequest(raw);
   if (!isValidSemanticDaemonRequest(input)) {
@@ -160,6 +235,16 @@ export async function handleSemanticDaemonRequest(raw: string): Promise<Semantic
 
   try {
     const sessionId = input.sessionId!;
+    if (input.type === 'summarize') {
+      // Fire-and-forget: the LLM call is far slower than the Stop hook's
+      // response budget, so acknowledge immediately and summarize in the
+      // background. A failure leaves the session without a summary, which
+      // keeps it eligible for the session-start backfill to retry.
+      if (input.evaluation !== true) {
+        void runSessionSummaryWithWriterLock(sessionId).catch(() => undefined);
+      }
+      return { ok: true, memories: [] };
+    }
     if (input.type === 'graduate') {
       autoGraduationScheduler.schedule(
         getProjectKeyForSession(sessionId),
@@ -215,6 +300,16 @@ export async function handleSemanticDaemonRequest(raw: string): Promise<Semantic
 
 function createServer(): net.Server {
   return net.createServer({ allowHalfOpen: true }, (socket) => {
+    if (isDaemonBuildStale()) {
+      // Drop the connection instead of answering: every client already retries
+      // through ensureDaemonRunning() on a connection error, so refusing here
+      // makes the retry land on a daemon running the new build. Answering with
+      // an error object would instead surface as a normal failed request.
+      socket.destroy();
+      void shutdown(0).catch(() => process.exit(0));
+      return;
+    }
+
     scheduleIdleShutdown();
     socket.setEncoding('utf8');
 

--- a/src/adapters/claude/hooks/stop.ts
+++ b/src/adapters/claude/hooks/stop.ts
@@ -18,6 +18,8 @@ import { readTurnState, clearTurnState, writeLastAssistantSnippet } from '../../
 import type { StopInput, Config } from '../../../core/types.js';
 import { extractAssistantMessages } from '../transcript/turn-reconstructor.js';
 import { readStdin, readNumberEnv } from './hook-runtime.js';
+import { scheduleSessionSummary } from './semantic-daemon-client.js';
+import { isLlmSummaryEnabled } from '../../llm/session-summary-llm.js';
 
 // Default privacy config
 const DEFAULT_PRIVACY_CONFIG: Config['privacy'] = {
@@ -92,9 +94,18 @@ export async function main(): Promise<string> {
       // non-critical
     }
 
-    // Generate session summary from recent events (rule-based, no LLM needed)
+    // Session summary. The LLM path produces the decisions/failures/constraints
+    // a later session can actually reuse, but it is far too slow to run here, so
+    // the daemon is asked to build it in the background. A failed or skipped
+    // summary leaves the session without one, which keeps it eligible for the
+    // session-start backfill to retry. There is deliberately no rule-based
+    // fallback: that text grounds at 0.9% and is what this path replaces.
     try {
-      await memoryService.generateSessionSummary(input.session_id);
+      if (isLlmSummaryEnabled()) {
+        await scheduleSessionSummary(input.session_id);
+      } else {
+        await memoryService.generateSessionSummary(input.session_id);
+      }
     } catch {
       // non-critical
     }

--- a/src/adapters/claude/hooks/user-prompt-submit.ts
+++ b/src/adapters/claude/hooks/user-prompt-submit.ts
@@ -27,6 +27,7 @@ import {
   filterHookInjectableMemories,
   getHookInjectionPolicy,
   scoreGraduatedEvidence,
+  scoreLessonEvidence,
   selectHookEpisodeSeeds,
   summarizeHookInjectionConfidence,
   type HookMemoryCandidate
@@ -477,6 +478,23 @@ export async function main(): Promise<string> {
         mergedMemories.push({ ...candidate, score });
         if (candidate.id) existingGraduatedById.set(candidate.id, mergedMemories.length - 1);
       }
+
+      // Curated lesson lane. Lessons are not events, so no other lane can ever
+      // surface them; without this the lesson feature is write-only.
+      try {
+        const lessons = await memoryService.listProjectLessons(MAX_CANDIDATES);
+        for (const lesson of lessons) {
+          const candidate = scoreLessonEvidence(retrievalQuery, {
+            lessonId: String(lesson.lessonId ?? ''),
+            name: String(lesson.name ?? ''),
+            trigger: lesson.trigger ? String(lesson.trigger) : undefined,
+            steps: Array.isArray(lesson.steps) ? lesson.steps.map(String) : [],
+            failureModes: Array.isArray(lesson.failureModes) ? lesson.failureModes.map(String) : [],
+            confidence: Number(lesson.confidence ?? 0)
+          });
+          if (candidate) mergedMemories.push(candidate);
+        }
+      } catch { /* lesson lane is supplementary */ }
 
       const shouldUseKeywordFallback =
         RETRIEVAL_MODE === 'keyword' ||

--- a/src/adapters/llm/session-summary-llm.ts
+++ b/src/adapters/llm/session-summary-llm.ts
@@ -1,0 +1,267 @@
+/**
+ * LLM-backed session summary generation.
+ *
+ * The rule-based deriver emits a table of contents ("[date] N turn session.
+ * Main task: <first prompt>"), which measured a 0.9% grounding rate: there is
+ * no outcome inside it for a later answer to reuse. This module asks a local
+ * Claude/Codex CLI for the durable outcomes instead.
+ *
+ * Two hazards drive the implementation shape:
+ *
+ * 1. Hook recursion. A child `claude` run re-executes the user-level hooks in
+ *    ~/.claude/settings.json, whose Stop hook would request another summary,
+ *    which would spawn another child. `--setting-sources project` keeps the
+ *    user source (where the memory hooks live) out of the child, and running in
+ *    an empty scratch cwd keeps any *project* hooks and CLAUDE.md out too.
+ *    Verified empirically: without the flag a child run creates a new memory
+ *    project store, with it the store count is unchanged.
+ * 2. Blocking. The call is slow, so callers must run it off the hook response
+ *    path (the daemon schedules it).
+ */
+
+import { spawn } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+export type SummaryProviderName = 'claude' | 'codex';
+
+export interface SummarySourceEvent {
+  eventType: string;
+  content: string;
+}
+
+export interface LlmSummaryResult {
+  text: string;
+  metadata: {
+    generated: 'llm';
+    provider: SummaryProviderName;
+    model: string;
+    eventCount: number;
+  };
+}
+
+/** The model is told to emit this when a session holds nothing worth keeping. */
+export const NO_DURABLE_CONTENT = 'NO_DURABLE_CONTENT';
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_MODEL = 'claude-haiku-4-5-20251001';
+const MAX_EVENT_CHARS = 2_000;
+const MAX_EVENTS = 40;
+const MAX_OUTPUT_CHARS = 2_000;
+
+export class SummaryProviderError extends Error {
+  constructor(message: string, readonly code: string) {
+    super(message);
+    this.name = 'SummaryProviderError';
+  }
+}
+
+export function getSummaryProviderName(env: NodeJS.ProcessEnv = process.env): SummaryProviderName {
+  return env.CLAUDE_MEMORY_SUMMARY_PROVIDER === 'codex' ? 'codex' : 'claude';
+}
+
+export function getSummaryModel(env: NodeJS.ProcessEnv = process.env): string {
+  const configured = env.CLAUDE_MEMORY_SUMMARY_MODEL?.trim();
+  return configured && configured.length > 0 ? configured : DEFAULT_MODEL;
+}
+
+export function isLlmSummaryEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.CLAUDE_MEMORY_SUMMARY_MODE !== 'rule' && env.CLAUDE_MEMORY_SUMMARY_MODE !== 'off';
+}
+
+/**
+ * Only prompts and answers carry decisions. Tool observations are excluded on
+ * purpose: they are 82% of stored volume, ground at 0.2%, and would dominate
+ * the context window with content the summary must not describe anyway.
+ */
+export function buildSummaryPrompt(events: SummarySourceEvent[]): string | null {
+  const usable = events
+    .filter((event) => event.eventType === 'user_prompt' || event.eventType === 'agent_response')
+    .filter((event) => typeof event.content === 'string' && event.content.trim().length > 0)
+    .slice(-MAX_EVENTS);
+
+  if (usable.length < 2) return null;
+
+  const transcript = usable
+    .map((event) => {
+      const role = event.eventType === 'user_prompt' ? 'User' : 'Assistant';
+      const content = event.content.length > MAX_EVENT_CHARS
+        ? `${event.content.slice(0, MAX_EVENT_CHARS)}…`
+        : event.content;
+      return `[${role}] ${content.replace(/\r?\n/g, ' ')}`;
+    })
+    .join('\n');
+
+  return [
+    '다음은 한 개발 세션의 대화 기록이다. 다음 세션이 같은 것을 다시 알아내지 않아도 되도록,',
+    '아래 세 가지에 해당하는 내용만 추출해라.',
+    '',
+    '- 결정: 무엇을 하기로 했고, 왜 그렇게 정했는가',
+    '- 실패: 시도했으나 안 된 것과 그 원인',
+    '- 제약: 새로 확인된 사실, 한계, 함정',
+    '',
+    '규칙:',
+    '- 무엇을 "했다"는 나열(파일 수정, 명령 실행, 커밋)은 git이 이미 기록하므로 쓰지 마라.',
+    '- 위 세 가지에 해당하는 내용이 하나도 없으면 다른 말 없이 정확히 ' + NO_DURABLE_CONTENT + ' 만 출력해라.',
+    '- 최대 5줄. 각 줄은 "- " 로 시작. 머리말, 인사, 총평, 설명 금지.',
+    '- 추측하지 마라. 기록에 근거가 있는 것만 써라.',
+    '',
+    '--- 기록 시작 ---',
+    transcript,
+    '--- 기록 끝 ---'
+  ].join('\n');
+}
+
+function buildArgs(provider: SummaryProviderName, model: string): string[] {
+  if (provider === 'codex') {
+    return ['exec', '--skip-git-repo-check', '--model', model];
+  }
+  // --setting-sources project: never load the user-level memory hooks.
+  return ['-p', '--setting-sources', 'project', '--model', model];
+}
+
+export function classifySummaryFailure(detail: string): SummaryProviderError {
+  const lowered = detail.toLowerCase();
+  if (lowered.includes('enoent') || lowered.includes('not found')) {
+    return new SummaryProviderError('summary provider CLI was not found', 'provider-not-found');
+  }
+  if (lowered.includes('timed out') || lowered.includes('etimedout')) {
+    return new SummaryProviderError('summary provider timed out', 'provider-timeout');
+  }
+  if (lowered.includes('auth') || lowered.includes('credential') || lowered.includes('login')) {
+    return new SummaryProviderError('summary provider authentication failed', 'provider-auth');
+  }
+  return new SummaryProviderError('summary provider failed', 'provider-error');
+}
+
+/**
+ * Strip anything that is not one of the requested bullet lines so a chatty
+ * preamble cannot become the stored "summary".
+ */
+export function normalizeSummaryOutput(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  if (trimmed.includes(NO_DURABLE_CONTENT)) return null;
+
+  const bullets = trimmed
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => /^[-*•]\s+/.test(line))
+    .map((line) => `- ${line.replace(/^[-*•]\s+/, '').trim()}`)
+    .filter((line) => line.length > 2)
+    .slice(0, 5);
+
+  if (bullets.length === 0) return null;
+  const text = bullets.join('\n');
+  return text.length > MAX_OUTPUT_CHARS ? text.slice(0, MAX_OUTPUT_CHARS) : text;
+}
+
+/**
+ * A scratch cwd keeps project-level hooks and CLAUDE.md out of the child run.
+ * `--setting-sources project` alone would still load them when the child
+ * inherits a real project directory.
+ */
+function createScratchCwd(): string {
+  const dir = path.join(os.tmpdir(), 'cml-summary');
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function runProvider(
+  provider: SummaryProviderName,
+  model: string,
+  prompt: string,
+  timeoutMs: number
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let child;
+    try {
+      child = spawn(provider, buildArgs(provider, model), {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        cwd: createScratchCwd(),
+        env: {
+          ...process.env,
+          // Defence in depth: if a child hook ever does run, these keep it from
+          // recursing back into summary generation.
+          CLAUDE_MEMORY_SUMMARY_MODE: 'off',
+          CLAUDE_MEMORY_DISABLE_HOOKS: 'true'
+        }
+      });
+    } catch (error) {
+      reject(classifySummaryFailure(String(error)));
+      return;
+    }
+
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+
+    const settle = (error?: Error, value?: string) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (error) reject(error);
+      else resolve(value ?? '');
+    };
+
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM');
+      settle(classifySummaryFailure('timed out'));
+    }, timeoutMs);
+
+    child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
+    child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+    child.on('error', (error: NodeJS.ErrnoException) => {
+      settle(classifySummaryFailure(error.code === 'ENOENT' ? 'ENOENT not found' : String(error)));
+    });
+    child.on('close', (code) => {
+      if (code === 0) settle(undefined, stdout);
+      else settle(classifySummaryFailure(stderr || `exit code ${code}`));
+    });
+
+    child.stdin.write(prompt);
+    child.stdin.end();
+  });
+}
+
+/**
+ * Returns null when the session holds nothing durable. Callers must treat that
+ * as "store nothing" rather than falling back to the rule-based text, which is
+ * the content this module exists to stop producing.
+ */
+export async function generateLlmSessionSummary(
+  events: SummarySourceEvent[],
+  options: {
+    provider?: SummaryProviderName;
+    model?: string;
+    timeoutMs?: number;
+    env?: NodeJS.ProcessEnv;
+  } = {}
+): Promise<LlmSummaryResult | null> {
+  const env = options.env ?? process.env;
+  const prompt = buildSummaryPrompt(events);
+  if (!prompt) return null;
+
+  const provider = options.provider ?? getSummaryProviderName(env);
+  const model = options.model ?? getSummaryModel(env);
+  const configuredTimeout = Number(env.CLAUDE_MEMORY_SUMMARY_TIMEOUT_MS);
+  const timeoutMs = options.timeoutMs
+    ?? (Number.isFinite(configuredTimeout) && configuredTimeout > 0
+      ? configuredTimeout
+      : DEFAULT_TIMEOUT_MS);
+
+  const raw = await runProvider(provider, model, prompt, timeoutMs);
+  const text = normalizeSummaryOutput(raw);
+  if (!text) return null;
+
+  return {
+    text,
+    metadata: {
+      generated: 'llm',
+      provider,
+      model,
+      eventCount: events.length
+    }
+  };
+}

--- a/src/core/engine/memory-engine-services.ts
+++ b/src/core/engine/memory-engine-services.ts
@@ -23,7 +23,7 @@ import {
   createPerspectiveDeriver
 } from '../operations/index.js';
 import { VectorStore } from '../vector-store.js';
-import { MemoryIngestService } from './memory-ingest-service.js';
+import { MemoryIngestService, type LlmSummaryGenerator } from './memory-ingest-service.js';
 import { MemoryQueryService } from './memory-query-service.js';
 import {
   createRetrievalServices,
@@ -48,6 +48,7 @@ export interface MemoryEngineServicesOptions {
   memoryOperationsConfig?: MemoryOperationsConfig;
   sharedStore?: RetrievalDisclosureSharedStore;
   createToolObservationEmbedding: (payload: ToolObservationPayload) => string;
+  llmSummaryGenerator?: LlmSummaryGenerator;
   factories?: MemoryEngineServicesFactories;
 }
 
@@ -138,7 +139,8 @@ export function createMemoryEngineServices(options: MemoryEngineServicesOptions)
     createToolEmbedding: options.createToolObservationEmbedding,
     getProjectHash: options.getProjectHash,
     getProjectPath: options.getProjectPath,
-    perspectiveDeriver
+    perspectiveDeriver,
+    llmSummaryGenerator: options.llmSummaryGenerator
   });
   const queryService = new MemoryQueryService(
     () => sqliteStore.initialize(),

--- a/src/core/engine/memory-ingest-service.ts
+++ b/src/core/engine/memory-ingest-service.ts
@@ -48,7 +48,22 @@ export interface MemoryIngestServiceOptions {
   getProjectPath?: () => string | null;
   summaryDeriver?: SummaryDeriver;
   perspectiveDeriver?: PerspectiveDeriverLike;
+  /**
+   * Injected so core stays free of child-process/CLI concerns. Returns null
+   * when the session holds nothing durable, which must store nothing rather
+   * than fall back to the rule-based text.
+   */
+  llmSummaryGenerator?: LlmSummaryGenerator;
 }
+
+export interface LlmSummaryGenerated {
+  text: string;
+  metadata: Record<string, unknown>;
+}
+
+export type LlmSummaryGenerator = (
+  events: Array<{ eventType: string; content: string }>
+) => Promise<LlmSummaryGenerated | null>;
 
 /**
  * Thin-core ingest service for session lifecycle and event writes.
@@ -66,6 +81,7 @@ export class MemoryIngestService {
   private readonly getProjectPath: () => string | null;
   private readonly summaryDeriver: SummaryDeriver;
   private readonly perspectiveDeriver?: PerspectiveDeriverLike;
+  private readonly llmSummaryGenerator?: LlmSummaryGenerator;
   private readonly ingestInterceptors = new IngestInterceptorRegistry();
 
   constructor(options: MemoryIngestServiceOptions) {
@@ -77,6 +93,7 @@ export class MemoryIngestService {
     this.getProjectPath = options.getProjectPath ?? (() => null);
     this.summaryDeriver = options.summaryDeriver ?? createSummaryDeriver();
     this.perspectiveDeriver = options.perspectiveDeriver;
+    this.llmSummaryGenerator = options.llmSummaryGenerator;
   }
 
   registerIngestBefore(interceptor: IngestInterceptor): () => void {
@@ -194,6 +211,32 @@ export class MemoryIngestService {
     if (!summary) return;
 
     await this.storeSessionSummary(sessionId, summary.text, summary.metadata);
+  }
+
+  /**
+   * Generate an outcome-focused summary through the injected LLM generator.
+   *
+   * Slow by nature, so callers must keep it off any hook response path. On
+   * failure or when the session holds nothing durable this stores nothing: the
+   * session then still has no summary and stays eligible for a later backfill
+   * attempt. It deliberately does not fall back to the rule-based text, whose
+   * table-of-contents shape is the reason this path exists.
+   */
+  async generateLlmSessionSummary(sessionId: string): Promise<boolean> {
+    await this.initialize();
+    if (!this.llmSummaryGenerator) return false;
+
+    const events = await this.eventStore.getSessionEvents(sessionId);
+    if (events.length < 3) return false;
+    if (events.some((event) => event.eventType === 'session_summary')) return false;
+
+    const summary = await this.llmSummaryGenerator(
+      events.map((event) => ({ eventType: event.eventType, content: event.content }))
+    );
+    if (!summary) return false;
+
+    await this.storeSessionSummary(sessionId, summary.text, summary.metadata);
+    return true;
   }
 
   async storeToolObservation(

--- a/src/core/engine/memory-query-service.ts
+++ b/src/core/engine/memory-query-service.ts
@@ -1,5 +1,6 @@
 import type {
   MemoryEvent,
+  MemoryLesson,
   OutboxStats,
   OutboxStatsOptions,
   OutboxRecoveryOptions,
@@ -8,6 +9,8 @@ import type {
   ProjectScopeRepairResult
 } from '../types.js';
 import type { DerivationLiveness } from '../sqlite-event-store.js';
+import type { SQLiteDatabase } from '../sqlite-wrapper.js';
+import { LessonRepository } from '../operations/lesson-repository.js';
 
 interface RankedKeywordResult {
   event: MemoryEvent;
@@ -44,6 +47,8 @@ interface QueryStore {
   getSessionEvents(sessionId: string): Promise<MemoryEvent[]>;
   getRecentEvents(limit: number): Promise<MemoryEvent[]>;
   countEvents?(): Promise<number>;
+  /** Present on the SQLite store; lessons live outside the events table. */
+  getDatabase?(): SQLiteDatabase;
 }
 
 interface QueryMaintenanceStore extends QueryStore {
@@ -83,6 +88,25 @@ export class MemoryQueryService {
     private readonly queryStore: QueryStore,
     private readonly deps?: MemoryQueryServiceDeps
   ) {}
+
+  /**
+   * Curated lessons for prompt injection.
+   *
+   * Lessons are stored outside the events table, so they never appear in
+   * semantic or keyword retrieval. Without this lookup the whole lesson feature
+   * is write-only: an agent can save runbooks that nothing will ever surface.
+   */
+  async listProjectLessons(projectHash: string, limit = 25): Promise<MemoryLesson[]> {
+    await this.initialize();
+    const db = this.queryStore.getDatabase?.();
+    if (!db || !projectHash) return [];
+    try {
+      return await new LessonRepository(db).list({ projectHash, limit });
+    } catch {
+      // Lesson retrieval is supplementary: never fail a prompt over it.
+      return [];
+    }
+  }
 
   async keywordSearch(
     query: string,

--- a/src/core/engine/memory-service-composition.ts
+++ b/src/core/engine/memory-service-composition.ts
@@ -37,7 +37,8 @@ import {
   type MemoryRuntimeServicesDeps
 } from './memory-runtime-service.js';
 import type {
-  MemoryIngestService
+  MemoryIngestService,
+  LlmSummaryGenerator
 } from './memory-ingest-service.js';
 import type {
   MemoryQueryService
@@ -88,6 +89,7 @@ export interface MemoryServiceCompositionOptions {
   initialize: () => Promise<void>;
   getProjectHash: () => string | null;
   getProjectPath?: () => string | null;
+  llmSummaryGenerator?: LlmSummaryGenerator;
   factories?: MemoryServiceCompositionFactories;
 }
 
@@ -151,7 +153,8 @@ export function createMemoryServiceComposition(
       payload.toolName,
       payload.metadata || {},
       payload.success
-    )
+    ),
+    llmSummaryGenerator: options.llmSummaryGenerator
   });
 
   const endlessMemoryServices = (factories.createEndlessMemoryServices ?? defaultCreateEndlessMemoryServices)({

--- a/src/core/operations/lesson-candidate-service.ts
+++ b/src/core/operations/lesson-candidate-service.ts
@@ -66,6 +66,9 @@ interface SessionProfile {
   taskPatterns: Set<string>;
   successSignals: Set<ToolPattern>;
   hasFailureSignal: boolean;
+  /** Timestamps of the last failure/success signal, used to detect recovery. */
+  lastFailureTimestamp: string | null;
+  lastSuccessTimestamp: string | null;
   hasPrivacyConflict: boolean;
 }
 
@@ -247,6 +250,11 @@ function orderedTools(tools: Set<ToolPattern>): ToolPattern[] {
   return TOOL_ORDER.filter((tool) => tools.has(tool));
 }
 
+function maxTimestamp(current: string | null, candidate: string): string {
+  if (!current) return candidate;
+  return candidate.localeCompare(current) > 0 ? candidate : current;
+}
+
 function sortedStrings(values: Iterable<string>): string[] {
   return Array.from(new Set(Array.from(values))).sort((a, b) => a.localeCompare(b));
 }
@@ -274,13 +282,31 @@ function profileSignature(profile: SessionProfile): string | null {
   return `tools:${tools.join('+')}|files:${fileCategories.join('+') || 'none'}|task:${taskKey}`;
 }
 
+/**
+ * A session qualifies when its workflow demonstrably ended in success.
+ *
+ * This deliberately does not veto every session that ever logged a failure.
+ * The failure tokens (error/failed/blocked) appear somewhere in 93.7% of real
+ * sessions — often inside unrelated tool output — so a whole-session veto made
+ * nearly everything ineligible (measured: 120 of 121 sessions skipped). Worse,
+ * it excluded exactly the sessions worth learning from: the ones that hit a
+ * problem and then resolved it. What matters is recovery, so a failure only
+ * disqualifies a session when no success signal follows it.
+ */
 function hasEnoughSuccess(profile: SessionProfile): boolean {
-  if (profile.hasFailureSignal) return false;
   if (profile.successEventIds.length === 0) return false;
+  if (!hasRecoveredFromFailure(profile)) return false;
   const successTools = profile.successSignals;
   const testSignal = successTools.has('focused-test') || successTools.has('full-suite');
   const validationSignal = successTools.has('typecheck') || successTools.has('build') || successTools.has('static-privacy-scan');
   return successTools.has('verified-commit') || (testSignal && validationSignal);
+}
+
+function hasRecoveredFromFailure(profile: SessionProfile): boolean {
+  if (!profile.hasFailureSignal) return true;
+  if (!profile.lastSuccessTimestamp) return false;
+  if (!profile.lastFailureTimestamp) return true;
+  return profile.lastSuccessTimestamp.localeCompare(profile.lastFailureTimestamp) >= 0;
 }
 
 function confidenceForGroup(group: SessionProfile[], tools: ToolPattern[], fileCategories: string[], taskPatterns: string[]): number {
@@ -395,16 +421,25 @@ export class LessonCandidateService {
   }
 
   private buildSessionProfiles(input: ParsedLessonCandidateInput): SessionProfile[] {
+    // Take the newest events, then restore chronological order for profiling.
+    // Scanning `timestamp ASC LIMIT n` meant a long-lived project only ever
+    // inspected its oldest window: with the 2000-event default this project saw
+    // 32 of 207 sessions, all of them ancient. Recent work is what carries
+    // reusable patterns.
     const rows = sqliteAll<EventRow>(
       this.db,
       `SELECT id, event_type, session_id, timestamp, content, metadata
-       FROM events
-       WHERE (
-         json_extract(CASE WHEN json_valid(metadata) THEN metadata ELSE '{}' END, '$.scope.project.hash') = ?
-         OR json_extract(CASE WHEN json_valid(metadata) THEN metadata ELSE '{}' END, '$.projectHash') = ?
+       FROM (
+         SELECT id, event_type, session_id, timestamp, content, metadata
+         FROM events
+         WHERE (
+           json_extract(CASE WHEN json_valid(metadata) THEN metadata ELSE '{}' END, '$.scope.project.hash') = ?
+           OR json_extract(CASE WHEN json_valid(metadata) THEN metadata ELSE '{}' END, '$.projectHash') = ?
+         )
+         ORDER BY timestamp DESC
+         LIMIT ?
        )
-       ORDER BY timestamp ASC
-       LIMIT ?`,
+       ORDER BY timestamp ASC`,
       [input.projectHash, input.projectHash, input.eventLimit]
     );
     const profilesBySession = new Map<string, SessionProfile>();
@@ -420,6 +455,12 @@ export class LessonCandidateService {
 
       const tools = extractToolPatterns(row.content);
       const success = isSuccessSignal(row.content);
+      if (isFailureSignal(row.content)) {
+        profile.lastFailureTimestamp = maxTimestamp(profile.lastFailureTimestamp, row.timestamp);
+      }
+      if (success) {
+        profile.lastSuccessTimestamp = maxTimestamp(profile.lastSuccessTimestamp, row.timestamp);
+      }
       for (const tool of Array.from(tools)) {
         profile.tools.add(tool);
         if (success) profile.successSignals.add(tool);
@@ -446,6 +487,8 @@ export class LessonCandidateService {
         taskPatterns: new Set<string>(),
         successSignals: new Set<ToolPattern>(),
         hasFailureSignal: false,
+        lastFailureTimestamp: null,
+        lastSuccessTimestamp: null,
         hasPrivacyConflict: false
       };
       profilesBySession.set(row.session_id, profile);

--- a/src/extensions/mcp/handlers.ts
+++ b/src/extensions/mcp/handlers.ts
@@ -32,6 +32,7 @@ import {
   FacetRepository,
   FrontierService,
   GraphPathService,
+  LessonCandidateService,
   LessonRepository,
   LessonService,
   PerspectiveObservationRepository,
@@ -197,6 +198,7 @@ const MEMORY_OPERATION_TOOL_NAMES = new Set([
   'mem-checkpoint-list',
   'mem-retention-audit',
   'mem-graph-query',
+  'mem-lesson-candidates',
   'mem-lesson-list',
   'mem-lesson-save',
   'mem-actor-list',
@@ -239,6 +241,8 @@ async function handleMemoryOperationTool(name: string, args: Record<string, unkn
         return jsonResult(handleRetentionAudit(context, args));
       case 'mem-graph-query':
         return jsonResult(handleGraphQuery(context, args));
+      case 'mem-lesson-candidates':
+        return jsonResult(await handleLessonCandidates(context, args));
       case 'mem-lesson-list':
         return jsonResult(await handleLessonList(context, args));
       case 'mem-lesson-save':
@@ -496,6 +500,32 @@ async function handleLessonList(context: MemoryOperationContext, args: Record<st
       createdAt: isoDate(lesson.createdAt),
       updatedAt: isoDate(lesson.updatedAt)
     }))
+  };
+}
+
+async function handleLessonCandidates(context: MemoryOperationContext, args: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const result = await new LessonCandidateService(context.db).findCandidates({
+    projectHash: context.projectHash,
+    minSessions: typeof args.minSessions === 'number' ? args.minSessions : undefined,
+    limit: numberArg(args.limit, 25, 1, 100)
+  });
+  return {
+    operation: 'mem-lesson-candidates',
+    projectHash: context.projectHash,
+    scannedSessions: result.scannedSessions,
+    eligibleSessions: result.eligibleSessions,
+    count: result.candidates.length,
+    candidates: result.candidates.map((candidate) => ({
+      candidateId: sanitizeOperationString(candidate.candidateId, 120),
+      name: sanitizeOperationString(candidate.name, 240),
+      trigger: sanitizeOperationString(candidate.trigger, 500),
+      confidence: candidate.confidence,
+      steps: candidate.steps.slice(0, 10).map((step) => sanitizeOperationString(step, 500)),
+      failureModes: candidate.failureModes.slice(0, 10).map((mode) => sanitizeOperationString(mode, 300)),
+      sourceSessionIds: candidate.sourceSessionIds.slice(0, 10).map((id) => sanitizeOperationString(id, 120)),
+      sourceEventIds: candidate.sourceEventIds.slice(0, 10).map((id) => sanitizeOperationString(id, 120))
+    })),
+    note: 'Read-only detection. Review a candidate and call mem-lesson-save to promote it into a curated lesson.'
   };
 }
 

--- a/src/extensions/mcp/tools.ts
+++ b/src/extensions/mcp/tools.ts
@@ -606,6 +606,28 @@ export const tools: Tool[] = [
     }
   },
   {
+    name: 'mem-lesson-candidates',
+    description: 'Detect not-yet-saved reusable workflow patterns (rule-based, from repeated successful tool sequences across sessions) so they can be reviewed and promoted with mem-lesson-save. Read-only — does not write a lesson.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: requiredProjectPathProperty,
+        minSessions: {
+          type: 'number',
+          minimum: 2,
+          maximum: 10,
+          description: 'Minimum number of sessions sharing a pattern before it counts as a candidate (default: 2).'
+        },
+        limit: {
+          type: 'number',
+          maximum: 100,
+          description: 'Maximum candidates to return (default: 25, max: 100).'
+        }
+      },
+      required: ['projectPath']
+    }
+  },
+  {
     name: 'mem-lesson-save',
     description: 'Save a reviewed project-scoped lesson or rule as a curated memory. Rejects private or credential-like content and preserves compact provenance.',
     inputSchema: {

--- a/src/services/memory-service-config.ts
+++ b/src/services/memory-service-config.ts
@@ -2,6 +2,7 @@ import * as os from 'os';
 import * as path from 'path';
 
 import type { MemoryOperationsConfig, SharedStoreConfig } from '../core/types.js';
+import type { LlmSummaryGenerator } from '../core/engine/memory-ingest-service.js';
 
 export interface MemoryServiceConfig {
   storagePath: string;
@@ -15,6 +16,11 @@ export interface MemoryServiceConfig {
   embeddingOnly?: boolean;
   /** AgentMemory-inspired operations feature config (default: disabled). */
   operations?: MemoryOperationsConfig;
+  /**
+   * Outcome-focused session summary generator. Injected by the adapter layer
+   * (it shells out to a local CLI) so core and services stay platform-agnostic.
+   */
+  llmSummaryGenerator?: LlmSummaryGenerator;
 }
 
 const SHARED_STORAGE_PATH = path.join(os.homedir(), '.claude-code', 'memory', 'shared');

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -131,7 +131,8 @@ export class MemoryService {
       defaultSharedStoreConfig: DEFAULT_ENABLED_SHARED_STORE_CONFIG,
       initialize: () => this.initialize(),
       getProjectHash: () => this.projectHash,
-      getProjectPath: () => this.projectPath
+      getProjectPath: () => this.projectPath,
+      llmSummaryGenerator: config.llmSummaryGenerator
     });
 
     this.retrievalOrchestrator = composition.retrievalOrchestrator;
@@ -226,6 +227,15 @@ export class MemoryService {
    */
   async generateSessionSummary(sessionId: string): Promise<void> {
     return this.ingestService.generateSessionSummary(sessionId);
+  }
+
+  /**
+   * Generate an outcome-focused summary via the injected LLM generator.
+   * Slow: callers must keep this off any hook response path.
+   * Returns false when nothing durable was stored.
+   */
+  async generateLlmSessionSummary(sessionId: string): Promise<boolean> {
+    return this.ingestService.generateLlmSessionSummary(sessionId);
   }
 
   /**

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -11,6 +11,7 @@ import type { SharedMemoryServices } from '../extensions/shared-memory/index.js'
 import type {
   AppendResult,
   MemoryEvent,
+  MemoryLesson,
   ToolObservationPayload,
   MemoryMode,
   EndlessModeConfig,
@@ -227,6 +228,11 @@ export class MemoryService {
    */
   async generateSessionSummary(sessionId: string): Promise<void> {
     return this.ingestService.generateSessionSummary(sessionId);
+  }
+
+  /** Curated project lessons, for the prompt-injection lesson lane. */
+  async listProjectLessons(limit = 25): Promise<MemoryLesson[]> {
+    return this.queryService.listProjectLessons(this.projectHash ?? '', limit);
   }
 
   /**

--- a/tests/adapters/claude-hook-prompt-injection-policy.test.ts
+++ b/tests/adapters/claude-hook-prompt-injection-policy.test.ts
@@ -6,6 +6,7 @@ import {
   filterHookInjectableMemories,
   getHookInjectionPolicy,
   scoreGraduatedEvidence,
+  scoreLessonEvidence,
   selectHookEpisodeSeeds,
   summarizeHookInjectionConfidence,
   type HookMemoryCandidate
@@ -305,6 +306,30 @@ describe('Claude hook prompt injection policy', () => {
       .toEqual([answer, tool]);
   });
 
+  it('abstains instead of falling back to tool attempts when no answer evidence survives', () => {
+    const tool: HookMemoryCandidate = {
+      id: 'tool', type: 'tool_observation', content: 'Argo CD 배포 pod 상태를 출력했다', score: 0.92, source: 'semantic'
+    };
+    const tail: HookMemoryCandidate = {
+      id: 'tail', type: 'tool_observation', content: 'Argo CD 배포 pod 이전 상태', score: 0.88, source: 'semantic'
+    };
+    expect(filterHookInjectableMemories([tool, tail], getHookInjectionPolicy(), 'Argo CD 배포 pod 원인을 알려줘'))
+      .toEqual([]);
+  });
+
+  it('requires a query identifier anchor before attaching tool evidence to an answer', () => {
+    const answer: HookMemoryCandidate = {
+      id: 'answer', type: 'agent_response',
+      content: 'benimaru v1 pod 재기동 원인은 stderr 의 timestamp 불일치였다', score: 0.86, source: 'semantic'
+    };
+    const unrelatedTool: HookMemoryCandidate = {
+      id: 'tool', type: 'tool_observation',
+      content: 'benimaru v2 pod stderr 를 출력했다', score: 0.9, source: 'semantic'
+    };
+    expect(filterHookInjectableMemories([answer, unrelatedTool], getHookInjectionPolicy(), 'benimaru v1 pod stderr 원인'))
+      .toEqual([answer]);
+  });
+
   it('uses promoted answer evidence as a bounded prior rather than promoting raw requests', () => {
     const query = 'aiaas ssgshop benimaru v1 pod CrashLoopBackOff 직접 원인';
     const exact: HookMemoryCandidate = {
@@ -341,6 +366,25 @@ describe('Claude hook prompt injection policy', () => {
       id: 'summary', type: 'session_summary', source: 'graduated', memoryLevel: 'L2', accessCount: 5,
       content: 'Session with 1 user prompts and 0 responses. Topics discussed: PR 167 코드 리뷰 해줘'
     })).toBeNull();
+  });
+
+  it('rejects prompt-only generated summaries from the semantic/keyword lanes too', () => {
+    const tocSummary: HookMemoryCandidate = {
+      id: 'toc-en', type: 'session_summary', source: 'semantic', score: 0.95,
+      content: 'Session with 1 user prompts and 0 responses.\nTopics discussed:\n- PR 167 코드 리뷰 해줘'
+    };
+    const tocSummaryKo: HookMemoryCandidate = {
+      id: 'toc-ko', type: 'session_summary', source: 'keyword', score: 0.95,
+      content: '[2026-07-28] 1턴 세션. 주요 작업: PR 167 코드 리뷰 해줘. 사용 툴: Bash, Edit'
+    };
+    const answer: HookMemoryCandidate = {
+      id: 'answer', type: 'agent_response', source: 'semantic', score: 0.7,
+      content: 'PR 167 코드 리뷰 핵심 위험은 인증 우회 가능성이었다'
+    };
+    expect(filterHookInjectableMemories([tocSummary, answer], getHookInjectionPolicy(), 'PR 167 코드 리뷰 핵심 위험'))
+      .toEqual([answer]);
+    expect(filterHookInjectableMemories([tocSummaryKo, answer], getHookInjectionPolicy(), 'PR 167 코드 리뷰 핵심 위험'))
+      .toEqual([answer]);
   });
 
   it('uses a tighter score cliff for calibrated graduated evidence', () => {
@@ -396,5 +440,48 @@ describe('Claude hook prompt injection policy', () => {
       source: 'keyword'
     }));
     expect(filterHookInjectableMemories(hookCandidates, getHookInjectionPolicy())).toEqual([]);
+  });
+});
+
+describe('curated lesson injection lane', () => {
+  const lesson = {
+    lessonId: 'lesson-1',
+    name: 'preview 포트 충돌 복구 절차',
+    trigger: 'preview 서버가 EADDRINUSE 로 죽을 때',
+    steps: ['남은 preview 프로세스를 정리한다', '포트 바인딩을 확인한다'],
+    failureModes: ['프로세스를 죽이지 않고 재시도하면 같은 오류가 반복된다'],
+    confidence: 0.9
+  };
+
+  it('surfaces a lesson that covers the query', () => {
+    const candidate = scoreLessonEvidence('preview 서버 EADDRINUSE 포트 충돌 복구', lesson);
+    expect(candidate).not.toBeNull();
+    expect(candidate?.type).toBe('lesson');
+    expect(candidate?.source).toBe('lesson');
+    expect(candidate?.content).toContain('preview 포트 충돌 복구 절차');
+    expect(candidate?.content).toContain('남은 preview 프로세스를 정리한다');
+  });
+
+  it('abstains when the lesson does not cover the query', () => {
+    expect(scoreLessonEvidence('데스크탑 앱 자동 업데이트 서명 오류', lesson)).toBeNull();
+  });
+
+  it('treats a lesson as answer evidence so it is not dropped by the gate', () => {
+    const query = 'preview 서버 EADDRINUSE 포트 충돌 복구';
+    const candidate = scoreLessonEvidence(query, lesson)!;
+    expect(filterHookInjectableMemories([candidate], getHookInjectionPolicy(), query))
+      .toEqual([candidate]);
+  });
+
+  it('ranks a curated lesson above a same-scored transcript answer', () => {
+    const query = 'preview 서버 EADDRINUSE 포트 충돌 복구';
+    const lessonCandidate = scoreLessonEvidence(query, lesson)!;
+    const answer: HookMemoryCandidate = {
+      id: 'answer', type: 'agent_response', source: 'semantic',
+      score: lessonCandidate.score,
+      content: 'preview 서버 EADDRINUSE 포트 충돌은 남은 프로세스 때문이었다'
+    };
+    const result = filterHookInjectableMemories([answer, lessonCandidate], getHookInjectionPolicy(), query);
+    expect(result[0].type).toBe('lesson');
   });
 });

--- a/tests/adapters/claude/claude-semantic-daemon-adapter.test.ts
+++ b/tests/adapters/claude/claude-semantic-daemon-adapter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   handleSemanticDaemonRequest,
+  isDaemonBuildStale,
   isValidSemanticDaemonRequest,
   isVectorSessionFilterError,
   makeSemanticDaemonErrorResponse,
@@ -59,5 +60,29 @@ describe('Claude semantic daemon adapter', () => {
   it('formats daemon errors without leaking non-Error values', () => {
     expect(makeSemanticDaemonErrorResponse(new Error('boom'))).toEqual({ ok: false, error: 'boom' });
     expect(makeSemanticDaemonErrorResponse('boom')).toEqual({ ok: false, error: 'unknown daemon error' });
+  });
+});
+
+describe('Claude semantic daemon build staleness', () => {
+  it('treats an unchanged build fingerprint as fresh', () => {
+    expect(isDaemonBuildStale('123.5:4096', '123.5:4096')).toBe(false);
+  });
+
+  it('detects a rebuilt daemon script by mtime or size change', () => {
+    expect(isDaemonBuildStale('999.0:4096', '123.5:4096')).toBe(true);
+    expect(isDaemonBuildStale('123.5:8192', '123.5:4096')).toBe(true);
+  });
+
+  it('never reports stale when a fingerprint is unavailable', () => {
+    // An unreadable script must not make the daemon refuse all work.
+    expect(isDaemonBuildStale(null, '123.5:4096')).toBe(false);
+    expect(isDaemonBuildStale('123.5:4096', null)).toBe(false);
+    expect(isDaemonBuildStale(null, null)).toBe(false);
+  });
+
+  it('accepts summarize requests so a fresh build does not reject the new type', () => {
+    expect(isValidSemanticDaemonRequest({ type: 'summarize', sessionId: 'session-1' })).toBe(true);
+    expect(isValidSemanticDaemonRequest({ type: 'summarize', sessionId: 'session-1', evaluation: true })).toBe(true);
+    expect(isValidSemanticDaemonRequest({ type: 'summarize', sessionId: '' })).toBe(false);
   });
 });

--- a/tests/adapters/session-summary-llm.test.ts
+++ b/tests/adapters/session-summary-llm.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  NO_DURABLE_CONTENT,
+  buildSummaryPrompt,
+  classifySummaryFailure,
+  getSummaryProviderName,
+  isLlmSummaryEnabled,
+  normalizeSummaryOutput
+} from '../../src/adapters/llm/session-summary-llm.js';
+
+describe('session summary llm provider', () => {
+  it('excludes tool observations from the summary input', () => {
+    const prompt = buildSummaryPrompt([
+      { eventType: 'user_prompt', content: '자동 업데이트가 왜 안 보이지' },
+      { eventType: 'tool_observation', content: '{"toolName":"Bash","toolOutput":"npm run build ok"}' },
+      { eventType: 'agent_response', content: 'publish 설정 누락이 원인이었다' }
+    ]);
+
+    expect(prompt).toContain('자동 업데이트가 왜 안 보이지');
+    expect(prompt).toContain('publish 설정 누락이 원인이었다');
+    expect(prompt).not.toContain('toolName');
+    expect(prompt).not.toContain('npm run build ok');
+  });
+
+  it('abstains when a session has too little conversation to summarize', () => {
+    expect(buildSummaryPrompt([{ eventType: 'user_prompt', content: '안녕' }])).toBeNull();
+    expect(buildSummaryPrompt([
+      { eventType: 'tool_observation', content: 'a' },
+      { eventType: 'tool_observation', content: 'b' }
+    ])).toBeNull();
+  });
+
+  it('treats the no-durable-content marker as "store nothing"', () => {
+    expect(normalizeSummaryOutput(NO_DURABLE_CONTENT)).toBeNull();
+    expect(normalizeSummaryOutput(`  ${NO_DURABLE_CONTENT}\n`)).toBeNull();
+    expect(normalizeSummaryOutput('')).toBeNull();
+  });
+
+  it('keeps only bullet lines so a chatty preamble cannot become the summary', () => {
+    const output = normalizeSummaryOutput([
+      '알겠습니다! 요약해 드리겠습니다.',
+      '',
+      '- 결정: publish 설정을 electron-builder.yml 에 추가하기로 함',
+      '* 실패: arm64 전용 빌드는 intel 에서 채널이 비어 있었음',
+      '',
+      '도움이 되었기를 바랍니다.'
+    ].join('\n'));
+
+    expect(output).toBe([
+      '- 결정: publish 설정을 electron-builder.yml 에 추가하기로 함',
+      '- 실패: arm64 전용 빌드는 intel 에서 채널이 비어 있었음'
+    ].join('\n'));
+  });
+
+  it('returns null when the model answered without any bullet content', () => {
+    expect(normalizeSummaryOutput('이 세션에는 특별한 내용이 없었습니다.')).toBeNull();
+  });
+
+  it('caps the summary at five bullets', () => {
+    const output = normalizeSummaryOutput(
+      Array.from({ length: 9 }, (_, index) => `- 결정 ${index}`).join('\n')
+    );
+    expect(output?.split('\n')).toHaveLength(5);
+  });
+
+  it('classifies provider failures so callers can distinguish retryable causes', () => {
+    expect(classifySummaryFailure('ENOENT not found').code).toBe('provider-not-found');
+    expect(classifySummaryFailure('timed out').code).toBe('provider-timeout');
+    expect(classifySummaryFailure('invalid credential').code).toBe('provider-auth');
+    expect(classifySummaryFailure('boom').code).toBe('provider-error');
+  });
+
+  it('honours provider and mode configuration', () => {
+    expect(getSummaryProviderName({} as NodeJS.ProcessEnv)).toBe('claude');
+    expect(getSummaryProviderName({ CLAUDE_MEMORY_SUMMARY_PROVIDER: 'codex' } as NodeJS.ProcessEnv)).toBe('codex');
+    expect(isLlmSummaryEnabled({} as NodeJS.ProcessEnv)).toBe(true);
+    expect(isLlmSummaryEnabled({ CLAUDE_MEMORY_SUMMARY_MODE: 'rule' } as NodeJS.ProcessEnv)).toBe(false);
+    expect(isLlmSummaryEnabled({ CLAUDE_MEMORY_SUMMARY_MODE: 'off' } as NodeJS.ProcessEnv)).toBe(false);
+  });
+});

--- a/tests/core/lesson-candidate-service.test.ts
+++ b/tests/core/lesson-candidate-service.test.ts
@@ -192,3 +192,84 @@ describe('LessonCandidateService', () => {
     expect(result.candidates).toHaveLength(0);
   });
 });
+
+describe('LessonCandidateService failure recovery semantics', () => {
+  it('keeps sessions that hit a failure and then recovered', async () => {
+    const { store, service, cleanup } = await createFixture();
+    const projectHash = 'project-recovery';
+    const withEarlyFailure = (sessionId: string, offset: number): MemoryEvent[] => [
+      memoryEvent({
+        sessionId,
+        eventType: 'tool_observation',
+        index: offset - 1,
+        metadata: projectMetadata(projectHash),
+        content: 'terminal: npm test -- --run failed with exit_code 1; 2 tests failed'
+      }),
+      ...implementationSession(sessionId, projectHash, offset)
+    ];
+
+    await store.importEvents([
+      ...withEarlyFailure('session-recovered-a', 1),
+      ...withEarlyFailure('session-recovered-b', 21)
+    ]);
+
+    const result = await service.findCandidates({ projectHash });
+    await cleanup();
+
+    // The whole-session failure veto used to drop exactly these sessions, which
+    // are the ones worth learning from.
+    expect(result.eligibleSessions).toBe(2);
+    expect(result.candidates.length).toBeGreaterThan(0);
+  });
+
+  it('drops sessions whose last signal is still a failure', async () => {
+    const { store, service, cleanup } = await createFixture();
+    const projectHash = 'project-unrecovered';
+    const endingInFailure = (sessionId: string, offset: number): MemoryEvent[] => [
+      ...implementationSession(sessionId, projectHash, offset),
+      memoryEvent({
+        sessionId,
+        eventType: 'tool_observation',
+        index: offset + 10,
+        metadata: projectMetadata(projectHash),
+        content: 'terminal: npm run build failed with exit_code 1'
+      })
+    ];
+
+    await store.importEvents([
+      ...endingInFailure('session-broken-a', 1),
+      ...endingInFailure('session-broken-b', 21)
+    ]);
+
+    const result = await service.findCandidates({ projectHash });
+    await cleanup();
+
+    expect(result.eligibleSessions).toBe(0);
+    expect(result.candidates).toEqual([]);
+  });
+
+  it('scans the most recent events rather than the oldest window', async () => {
+    const { store, service, cleanup } = await createFixture();
+    const projectHash = 'project-recent-window';
+    const filler: MemoryEvent[] = Array.from({ length: 30 }, (_, index) => memoryEvent({
+      sessionId: `session-ancient-${index}`,
+      eventType: 'user_prompt',
+      index,
+      metadata: projectMetadata(projectHash),
+      content: 'ancient unrelated chatter'
+    }));
+
+    await store.importEvents([
+      ...filler,
+      ...implementationSession('session-recent-a', projectHash, 100),
+      ...implementationSession('session-recent-b', projectHash, 120)
+    ]);
+
+    // A window smaller than the whole corpus must still reach the newest work.
+    const result = await service.findCandidates({ projectHash, eventLimit: 20 });
+    await cleanup();
+
+    expect(result.candidates.length).toBeGreaterThan(0);
+    expect(result.candidates[0].sourceSessionIds).toEqual(['session-recent-a', 'session-recent-b']);
+  });
+});

--- a/tests/core/memory-ingest-service.test.ts
+++ b/tests/core/memory-ingest-service.test.ts
@@ -25,6 +25,9 @@ interface CreateServiceOptions {
   perspectiveDeriver?: {
     deriveFromEvent: (event: MemoryEvent, options?: { projectHash?: string | null; projectPath?: string | null }) => Promise<unknown>;
   };
+  llmSummaryGenerator?: (
+    events: Array<{ eventType: string; content: string }>
+  ) => Promise<{ text: string; metadata: Record<string, unknown> } | null>;
 }
 
 function createService(options: CreateServiceOptions = {}) {
@@ -54,7 +57,8 @@ function createService(options: CreateServiceOptions = {}) {
       createToolEmbedding,
       getProjectHash: () => options.projectHash ?? null,
       getProjectPath: () => options.projectPath ?? null,
-      perspectiveDeriver: options.perspectiveDeriver
+      perspectiveDeriver: options.perspectiveDeriver,
+      llmSummaryGenerator: options.llmSummaryGenerator
     }),
     initialize,
     store,
@@ -347,5 +351,67 @@ describe('MemoryIngestService session summary generation', () => {
     expect(store.getSessionEvents).toHaveBeenCalledWith('broken');
     expect(appended).toHaveLength(1);
     expect(appended[0].sessionId).toBe('candidate');
+  });
+});
+
+describe('MemoryIngestService LLM session summary', () => {
+  const sessionEvents = [
+    event({ id: '11111111-1111-4111-8111-111111111111', sessionId: 's', eventType: 'user_prompt', content: '자동 업데이트가 왜 안 보이지' }),
+    event({ id: '22222222-2222-4222-8222-222222222222', sessionId: 's', eventType: 'agent_response', content: 'publish 설정 누락이 원인' }),
+    event({ id: '33333333-3333-4333-8333-333333333333', sessionId: 's', eventType: 'tool_observation', content: '{}', metadata: { toolName: 'Bash' } })
+  ];
+
+  it('stores the generated outcome summary', async () => {
+    const { service, appended } = createService({
+      eventsBySession: { s: sessionEvents },
+      llmSummaryGenerator: async () => ({ text: '- 결정: publish 설정 추가', metadata: { generated: 'llm' } })
+    });
+
+    await expect(service.generateLlmSessionSummary('s')).resolves.toBe(true);
+    expect(appended).toHaveLength(1);
+    expect(appended[0].eventType).toBe('session_summary');
+    expect(appended[0].content).toBe('- 결정: publish 설정 추가');
+  });
+
+  it('stores nothing when the session holds no durable content', async () => {
+    const { service, appended } = createService({
+      eventsBySession: { s: sessionEvents },
+      llmSummaryGenerator: async () => null
+    });
+
+    await expect(service.generateLlmSessionSummary('s')).resolves.toBe(false);
+    expect(appended).toHaveLength(0);
+  });
+
+  it('does not fall back to the rule-based summary when the generator throws', async () => {
+    const { service, appended } = createService({
+      eventsBySession: { s: sessionEvents },
+      llmSummaryGenerator: async () => { throw new Error('provider timed out'); }
+    });
+
+    await expect(service.generateLlmSessionSummary('s')).rejects.toThrow('provider timed out');
+    // Nothing stored: the session stays eligible for a later backfill retry
+    // instead of being permanently filled with table-of-contents text.
+    expect(appended).toHaveLength(0);
+  });
+
+  it('skips sessions that already have a summary', async () => {
+    const generator = vi.fn(async () => ({ text: '- x', metadata: {} }));
+    const { service, appended } = createService({
+      eventsBySession: {
+        s: [...sessionEvents, event({ id: '44444444-4444-4444-8444-444444444444', sessionId: 's', eventType: 'session_summary', content: 'old' })]
+      },
+      llmSummaryGenerator: generator
+    });
+
+    await expect(service.generateLlmSessionSummary('s')).resolves.toBe(false);
+    expect(generator).not.toHaveBeenCalled();
+    expect(appended).toHaveLength(0);
+  });
+
+  it('is inert when no generator is configured', async () => {
+    const { service, appended } = createService({ eventsBySession: { s: sessionEvents } });
+    await expect(service.generateLlmSessionSummary('s')).resolves.toBe(false);
+    expect(appended).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Why

The memory layer measures its own usefulness, and the measurement said it was not working. `memory_helpfulness.content_overlap_score` records whether an injected memory actually shows up in the resulting answer. On a 16.5k-event project:

| type | stored | injections evaluated | actually used |
|---|---|---|---|
| tool_observation | 13,609 (82%) | 452 | **0.2%** |
| session_summary | 518 | 225 | **0.9%** |
| user_prompt | 838 | 102 | 4.9% |
| agent_response | 1,581 | 1,642 | 11.9% |
| **overall** | 16,546 | 2,421 | **8.4%** |

Over 90% of injected context was tokens spent for nothing.

## Why earlier attempts did not move this

`specs/memory-utilization-improvements/` diagnosed the same problem in March and targeted proxy metrics: summary coverage, trace write rate, tool-observation storage share. The implemented items hit their targets while grounding stayed flat. IMP-03 was built exactly to its spec — the rule-based summary template it prescribed is the one still in the tree — reached full coverage, and grounds at 0.9%. The criterion measured production rather than usefulness, so it was possible to satisfy the spec and produce something useless.

This work therefore takes `content_overlap_score` as its only success criterion. Proxy metrics are observed, never targeted.

## What changed

**Injection.** `tool_observation` earned a utility bonus regardless of the question, and the answerability gate had a final fallback returning raw tool attempts whenever nothing better survived ranking (131 traces). The bonus is now conditional on the question asking for tool evidence, and the fallback is gone — abstaining costs less than unusable context. The intent regex also matched `command`, `log` and `output`, which fire on `<task-notification>` payloads carrying `<output-file>`.

`isPromptOnlySessionSummary` already detected the table-of-contents summary shape but ran in only one of three lanes, so those summaries kept winning the other two on the highest type bonus of all. It now applies everywhere.

**Summaries.** The rule-based deriver records that work happened, not what was decided or what failed. Summaries are now generated by a local Claude/Codex CLI that extracts decisions, failures and constraints, and returns nothing at all rather than manufacturing filler. There is deliberately no fallback to the rule-based text: a failed summary leaves the session eligible for the existing backfill to retry.

**Lessons.** `memory_lessons` lives outside the events table, so no retrieval lane could ever surface a lesson — the feature was write-only. Candidate detection was also broken two ways: it scanned the *oldest* event window (32 of 207 sessions), and it rejected any session containing an error/failed/blocked token anywhere, which is 93.7% of real sessions and excludes precisely the sessions worth learning from. Eligibility now asks whether the session recovered.

## Relationship to #37–#40

Those PRs attack the same tool_observation symptom at other layers: embedding (#37/#38), stored vectors (#39) and the keyword retrieval lane (#40). This PR is the injection-policy layer, and it composes with them rather than duplicating: #40 keeps tool observations out of keyword *candidates*, while this keeps them from taking injection *slots* and removes the gate's last-resort fallback. What remains F1's own territory is episode seeding — which opts back in with `includeToolObservations: true` precisely because a same-turn tool call anchors that turn's answer — plus the semantic/graduated lanes and the gate backstop.

The measurement consequence is recorded in the baseline: **tool_observation improvements must be attributed to #37–#40 and this PR jointly, not to this PR alone.** The `session_summary` and `lesson` numbers are untouched by other work and can be attributed here.

## Hazards handled

- **Hook recursion.** A child `claude` run re-executes the user-level hooks, whose Stop hook would request another summary and spawn another child. Verified empirically: without `--setting-sources project` a child run creates a new memory project store; with it the count is unchanged. `--bare` also skips hooks but never reads OAuth, which this environment relies on.
- **Stale daemons.** The daemon is long-lived, so a build or upgrade replaces `dist/` while the old process keeps serving, and it rejects request types it does not know — silently, because callers swallow the error. This is how the first end-to-end summarize run produced nothing. The daemon now fingerprints its own script and retires itself when it changes; clients already retry on connection errors, so the retry lands on the new build. No manual restart needed after upgrade.

## Rejected during design

- A flat penalty on `tool_observation`: arithmetic showed the resulting score gap exceeds the cliff threshold, cutting legitimate tool evidence before the gate ever sees it.
- Skipping same-session memories as redundant: the data refuted it (9.4% vs 7.9% grounding, same-session slightly ahead).

## Verification

1041 tests pass, typecheck and lint clean, and every commit typechecks independently after the rebase onto current `main`. End-to-end runs confirmed the summary path (outcome-focused text stored, Stop hook non-blocking, no recursion), the daemon swap without manual restart, and the lesson lane injecting a saved runbook for a relevant query and nothing for an unrelated one.

Measurement of the effect itself is still pending: per-change cutover timestamps and the re-run query are in `specs/memory-grounding-remediation/baseline-6ab6d837.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)