### PR TITLE
chore(deps): patch brace-expansion DoS advisory in the eslint tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -580,9 +580,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -678,9 +678,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1456,12 +1456,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -3370,9 +3370,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## What

`brace-expansion` below 1.1.17 can be driven into unbounded expansion, crashing the process with an out-of-memory error (DoS). Three copies were pinned at `1.1.16`, all reached through eslint's bundled `minimatch@3.1.5`:

```
eslint@9.39.4
├─ @eslint/config-array → minimatch@3.1.5 → brace-expansion@1.1.16
├─ @eslint/eslintrc     → minimatch@3.1.5 → brace-expansion@1.1.16
└─                        minimatch@3.1.5 → brace-expansion@1.1.16
```

All three are now `1.1.18`. The `5.0.8` copy under `typescript-eslint` was already outside the vulnerable range and is untouched.

Lockfile only — the dependency is transitive, so `package.json` does not change. Exposure was limited to lint runs, since eslint is a devDependency and is not part of the published package.

## Scope

`npm audit fix` without `--force`, so nothing breaking. This clears the `brace-expansion` finding and the `@modelcontextprotocol/sdk` one that resolved with it: 5 findings → 3.

Deliberately left alone:

| severity | package | why |
|---|---|---|
| HIGH | `sharp` | libvips CVEs, no fix published upstream |
| HIGH | `@huggingface/transformers` | inherits the above through `sharp` |
| MODERATE | `@hono/node-server` | fix is a breaking major; needs an MCP SDK compatibility check |

## Note on the open Dependabot alert

The critical `vitest` alert on the default branch is **stale, not a real finding**. Its vulnerable ranges are `< 3.2.6` and `>= 4.0.0, < 4.1.0`; `main` declares and pins **4.1.8**, which is in neither. The alert was raised 2026-06-08 and never re-evaluated after the upgrade. `npm audit` reports `critical: 0` and no `vitest` entry at all, and `@vitest/ui` — which the advisory requires to be listening — is not installed. It can be closed as fixed.

Worth noting the inverse too: Dependabot is showing a resolved critical while raising nothing for the three findings above that are still open.

## Verification

Lint, typecheck and the full suite (1014 tests) pass. `npm list claude-memory-layer` confirms no self-dependency was reintroduced by the install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)