### PR TITLE
fix(privacy): redact credentials from user prompts before they are stored

### DIFF
--- a/src/adapters/claude/hooks/user-prompt-submit.ts
+++ b/src/adapters/claude/hooks/user-prompt-submit.ts
@@ -23,6 +23,7 @@ import { writeTurnState, readLastAssistantSnippet } from '../../../core/turn-sta
 import { retrieveSemanticMemories, scheduleSemanticGraduation } from './semantic-daemon-client.js';
 import { readStdin, readNumberEnv } from './hook-runtime.js';
 import { formatClaudeContextHookOutput, isHookEvaluationMode } from './hook-output.js';
+import { applyPrivacyFilter } from '../../../core/privacy/index.js';
 import {
   filterHookInjectableMemories,
   getHookInjectionPolicy,
@@ -32,7 +33,7 @@ import {
   summarizeHookInjectionConfidence,
   type HookMemoryCandidate
 } from './prompt-injection-policy.js';
-import type { UserPromptSubmitInput, UserPromptSubmitOutput } from '../../../core/types.js';
+import type { Config, UserPromptSubmitInput, UserPromptSubmitOutput } from '../../../core/types.js';
 
 // Configuration. All numeric env vars go through readNumberEnv so an invalid
 // value (e.g. a typo) falls back to the default instead of producing NaN, which
@@ -69,6 +70,37 @@ export interface AdherenceState {
 }
 
 export type AdherenceDecision = { run: boolean; reason: string };
+
+/**
+ * Privacy config for prompt persistence.
+ *
+ * The Stop hook filters assistant responses and PostToolUse filters tool
+ * output, but user prompts were stored verbatim — so a credential pasted into
+ * a question was written to the events table and then copied into every
+ * derived artifact: query_preview, retrieval_traces, the adherence state file
+ * and any session summary quoting the prompt. Real leaks were found this way.
+ */
+const PROMPT_PRIVACY_CONFIG: Config['privacy'] = {
+  excludePatterns: ['password', 'secret', 'api_key', 'token', 'bearer'],
+  anonymize: false,
+  privateTags: {
+    enabled: true,
+    marker: '[PRIVATE]',
+    preserveLineCount: false,
+    supportedFormats: ['xml']
+  }
+};
+
+/**
+ * Redact a prompt before it is persisted.
+ *
+ * Retrieval itself keeps using the raw prompt: redaction is only about what
+ * gets written down, and searching on the redacted form would lose recall for
+ * questions that merely mention a credential-shaped word.
+ */
+export function redactForStorage(text: string): string {
+  return applyPrivacyFilter(text, PROMPT_PRIVACY_CONFIG).content;
+}
 
 /**
  * Determine if a prompt is worth storing as a memory.
@@ -605,7 +637,7 @@ export async function main(): Promise<string> {
               m.id,
               input.session_id,
               m.score ?? minScore,
-              input.prompt,
+              redactForStorage(input.prompt),
               {
                 traceId: retrievalTraceId,
                 source: 'user_prompt',
@@ -626,8 +658,8 @@ export async function main(): Promise<string> {
           await memoryService.recordQueryTrace({
             traceId: retrievalTraceId,
             sessionId: input.session_id,
-            queryText: retrievalQuery,
-            rawQueryText: input.prompt,
+            queryText: redactForStorage(retrievalQuery),
+            rawQueryText: redactForStorage(input.prompt),
             queryRewriteKind,
             strategy: RETRIEVAL_MODE,
             candidateEventIds: allCandidateIds,
@@ -650,7 +682,7 @@ export async function main(): Promise<string> {
     if (!isHookEvaluationMode() && shouldStorePrompt(input.prompt)) {
       await memoryService.storeUserPrompt(
         input.session_id,
-        input.prompt,
+        redactForStorage(input.prompt),
         {
           turnId,
           adherence: {
@@ -667,7 +699,9 @@ export async function main(): Promise<string> {
         sessionId: input.session_id,
         turnCount: currentTurn,
         lastCheckedTurn: adherenceDecision.run ? currentTurn : adherenceState.lastCheckedTurn,
-        lastPrompt: input.prompt,
+        // Also redacted: this file feeds the next turn's retrieval-query
+        // enrichment, so an unfiltered prompt here would resurface a secret.
+        lastPrompt: redactForStorage(input.prompt),
         lastReason: adherenceDecision.reason,
         updatedAt: new Date().toISOString()
       });

--- a/src/core/privacy/filter.ts
+++ b/src/core/privacy/filter.ts
@@ -34,6 +34,17 @@ const SENSITIVE_PATTERNS = [
   /-----BEGIN\s+(RSA\s+)?PRIVATE\s+KEY-----[\s\S]*?-----END\s+(RSA\s+)?PRIVATE\s+KEY-----/g,
   /ghp_[a-zA-Z0-9]{36}/g,  // GitHub Personal Access Token
   /sk-[a-zA-Z0-9]{48}/g,   // OpenAI API Key
+  // Vendor-prefixed tokens. The `token\s*[:=]` rule above only fires when a
+  // token is introduced with a colon or equals sign, so a key pasted as prose
+  // ("hugging face token hf_… Invalid token") slipped through untouched. These
+  // prefixes are distinctive enough to match on their own.
+  /\bhf_[a-zA-Z0-9]{30,}/g,            // Hugging Face access token
+  /\bgh[opsu]_[a-zA-Z0-9]{36,}/g,      // GitHub OAuth/server/user tokens
+  /\bgithub_pat_[a-zA-Z0-9_]{50,}/g,   // GitHub fine-grained PAT
+  /\bsk-ant-[a-zA-Z0-9_-]{20,}/g,      // Anthropic API key
+  /\bglpat-[a-zA-Z0-9_-]{20,}/g,       // GitLab personal access token
+  /\bxox[abprs]-[a-zA-Z0-9-]{10,}/g,   // Slack tokens
+  /\bAKIA[0-9A-Z]{16}\b/g,             // AWS access key id
 ];
 
 const CLI_SECRET_OPTION_PATTERNS = [

--- a/tests/adapters/claude-hook-adherence.test.ts
+++ b/tests/adapters/claude-hook-adherence.test.ts
@@ -6,7 +6,8 @@ import {
   shouldRunAdherenceCheck,
   type AdherenceState,
   selectEvidencePreview,
-  formatMemoryContext
+  formatMemoryContext,
+  redactForStorage
 } from '../../src/adapters/claude/hooks/user-prompt-submit.js';
 
 function adherenceState(overrides: Partial<AdherenceState> = {}): AdherenceState {
@@ -201,5 +202,22 @@ describe('formatMemoryContext', () => {
 
   it('returns an empty string when there is nothing to inject', () => {
     expect(formatMemoryContext([], '질문')).toBe('');
+  });
+});
+
+describe('prompt redaction before persistence', () => {
+  // Assistant responses and tool output were already filtered; user prompts
+  // were not, so a pasted credential reached the events table and from there
+  // query_preview, retrieval_traces and the adherence state file.
+  it('redacts credentials from anything written down', () => {
+    expect(redactForStorage('id:tester@example.com password:Zt9wQx2027@ 로 로그인해줘'))
+      .not.toContain('Zt9wQx2027');
+    expect(redactForStorage('hugging face token hf_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 왜 안되지'))
+      .not.toContain('hf_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789');
+  });
+
+  it('leaves an ordinary question unchanged', () => {
+    const question = 'preview 서버가 죽는 원인이 뭐야?';
+    expect(redactForStorage(question)).toBe(question);
   });
 });

--- a/tests/core/privacy-filter.test.ts
+++ b/tests/core/privacy-filter.test.ts
@@ -97,3 +97,34 @@ describe('privacy filter', () => {
     expect(result.content).not.toContain('[REDACTED]');
   });
 });
+
+describe('vendor-prefixed token redaction', () => {
+  // The `token\s*[:=]` rule only fires when a token is introduced with a colon
+  // or equals sign. A key pasted as prose — which is how a real Hugging Face
+  // token reached the store — has neither.
+  const prose = (value: string) => `hugging face token ${value} Invalid token. Please check`;
+
+  it.each([
+    ['hugging face', 'hf_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'],
+    ['github oauth', 'gho_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'],
+    ['github fine-grained pat', 'github_pat_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnop'],
+    ['anthropic', 'sk-ant-ABCDEFGHIJKLMNOPQRSTUVWXYZ01'],
+    ['gitlab', 'glpat-ABCDEFGHIJKLMNOPQRSTUV'],
+    ['slack', 'xoxb-ABCDEFGHIJKLMNOPQRSTUV'],
+    ['aws access key id', 'AKIAABCDEFGHIJKLMNOP']
+  ])('redacts a %s token pasted without a key/value separator', (_label, secret) => {
+    const result = applyPrivacyFilter(prose(secret), privacy);
+    expect(result.content).not.toContain(secret);
+    expect(result.content).toContain('[REDACTED]');
+  });
+
+  it('leaves ordinary prose containing the word token untouched', () => {
+    const benign = '이 API 의 token 만료 시간을 어떻게 늘리지?';
+    expect(applyPrivacyFilter(benign, privacy).content).toBe(benign);
+  });
+
+  it('does not redact short identifiers that merely start with a vendor prefix', () => {
+    const benign = 'hf_small 이라는 변수명을 쓰고 있어';
+    expect(applyPrivacyFilter(benign, privacy).content).toBe(benign);
+  });
+});


### PR DESCRIPTION
## What happened

Real credentials were found in plaintext in the local memory store — a password in `memory_helpfulness.query_preview`, and a Hugging Face token inside a session summary. Two independent defects had to line up.

**1. User prompts were never filtered.** The Stop hook filters assistant responses and PostToolUse filters tool output, but `UserPromptSubmit` called the privacy filter nowhere. Anything pasted into a question was stored verbatim and then copied into every derived artifact:

- `events.content`
- `memory_helpfulness.query_preview`
- `retrieval_traces.raw_query_text` / `query_text`
- the adherence state file, which seeds the *next* turn's retrieval query
- any session summary quoting the prompt

The password leak is entirely this defect: running the existing filter over that same text redacts it correctly. It simply was never called.

**2. Tokens pasted as prose matched nothing.** The token rules require a key/value separator (`token: value`, `--token value`). The real Hugging Face key arrived as `hugging face token hf_… Invalid token` — no separator, no match.

## Fix

Prompts are now redacted before anything is written down, at all five persistence points above.

Retrieval still searches on the **raw** prompt: redaction is about what gets stored, and searching the redacted form would lose recall for questions that merely mention a credential-shaped word.

Vendor-prefixed tokens are now matched on their own, independent of any separator:

| vendor | prefix |
|---|---|
| Hugging Face | `hf_` |
| GitHub | `gho_` `ghs_` `ghu_` `github_pat_` |
| Anthropic | `sk-ant-` |
| GitLab | `glpat-` |
| Slack | `xoxb-` etc. |
| AWS | `AKIA…` access key id |

Length floors keep ordinary identifiers out of it — a `hf_small` variable name and the sentence "이 API 의 token 만료 시간" are both verified to pass through untouched.

## Verification

Both real leak shapes were fed through the actual hook. Nothing remains in `events`, `query_preview`, `retrieval_traces` or the adherence file. 1052 tests pass, typecheck and lint clean.

## Not covered by this PR

This stops **new** leaks. It does not scrub what is already stored — a scan found **63 affected rows across six project databases**:

| project | events | helpfulness | traces |
|---|---|---|---|
| `44512761` | 45 | 0 | 3 |
| `0c742924` | 5 | 0 | 0 |
| `73c3b2b0` | 4 | 0 | 0 |
| `6ab6d837` | 1 | 4 | 1 |
| `1fdd26eb` | 1 | 1 | 1 |
| `e9894ad9` | 1 | 0 | 1 |

Remediating those is a separate pass. Independently of any scrubbing, the exposed credentials should be treated as compromised and rotated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)