### PR TITLE
feat(privacy): add a credential scrub for already-stored data

### DIFF
--- a/src/apps/cli/index.ts
+++ b/src/apps/cli/index.ts
@@ -48,7 +48,11 @@ import {
   type MemoryAction,
   type MemoryCheckpoint,
   type MemoryFacetAssignment,
-  type PerspectiveSessionActorBackfillResult
+  type PerspectiveSessionActorBackfillResult,
+  formatRedactionPlan,
+  planMarkdownRedaction,
+  planSqliteRedaction,
+  requeueEmbeddings
 } from '../../core/operations/index.js';
 import {
   CreateCheckpointInputSchema,
@@ -1421,6 +1425,61 @@ repairCommand
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       console.error(`Prune tool_observation vectors failed: ${message}`);
+      process.exit(1);
+    }
+  });
+
+repairCommand
+  .command('redact-credentials')
+  .description('Redact credentials already stored in SQLite, the markdown mirror and vectors (dry-run by default)')
+  .option('-p, --project <path>', 'Project path (defaults to cwd)')
+  .option('--apply', 'Write the redactions (default is a dry-run preview)')
+  .action(async (options) => {
+    try {
+      const projectPath: string = options.project ?? process.cwd();
+      const dryRun = options.apply !== true;
+      const storagePath = getProjectStoragePath(projectPath);
+      const dbPath = path.join(storagePath, 'events.sqlite');
+
+      if (!fs.existsSync(dbPath)) {
+        console.log(formatRedactionPlan({
+          dryRun, rowChanges: [], fileChanges: [],
+          affectedEventIds: [], vectorsDeleted: 0, embeddingsRequeued: 0
+        }));
+        return;
+      }
+
+      const store = new SQLiteEventStore(dbPath, { readonly: dryRun });
+      let vectorsDeleted = 0;
+      let embeddingsRequeued = 0;
+      try {
+        await store.initialize();
+        const db = store.getDatabase();
+        const { rowChanges, affectedEventIds } = planSqliteRedaction(db, { apply: !dryRun });
+        const fileChanges = planMarkdownRedaction(storagePath, { apply: !dryRun });
+
+        if (!dryRun && affectedEventIds.length > 0) {
+          // Lance rows cannot be edited in place, so the stale vectors are
+          // dropped and the redacted content is queued for re-embedding.
+          const vectorStore = new VectorStore(path.join(storagePath, 'vectors'));
+          for (const eventId of affectedEventIds) {
+            try {
+              await vectorStore.deleteEventEverywhere(eventId);
+              vectorsDeleted += 1;
+            } catch { /* a missing vector is not an error here */ }
+          }
+          embeddingsRequeued = requeueEmbeddings(db, affectedEventIds, { apply: true });
+        }
+
+        console.log(formatRedactionPlan({
+          dryRun, rowChanges, fileChanges, affectedEventIds, vectorsDeleted, embeddingsRequeued
+        }));
+      } finally {
+        await store.close().catch(() => undefined);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`Redact credentials failed: ${message}`);
       process.exit(1);
     }
   });

--- a/src/core/operations/credential-redaction.ts
+++ b/src/core/operations/credential-redaction.ts
@@ -1,0 +1,279 @@
+/**
+ * Retroactive credential redaction for an already-populated store.
+ *
+ * The ingest-side fix stops new leaks, but everything written before it stays
+ * in place. A partial scrub is worse than none — it reads as "cleaned" while
+ * copies survive elsewhere — so this covers every place a prompt's text is
+ * duplicated:
+ *
+ * - `events.content`
+ * - `memory_helpfulness.query_preview` and `injected_content`
+ * - `retrieval_traces.query_text` and `raw_query_text`
+ * - the markdown mirror under `<storage>/memory/`
+ * - the Lance vector store, which keeps the source text alongside the embedding
+ *
+ * Vectors cannot be edited in place, so affected events are deleted from the
+ * vector store and re-queued for embedding; the next embedding pass rebuilds
+ * them from the redacted SQLite content.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { sqliteAll, sqliteRun, type SQLiteDatabase } from '../sqlite-wrapper.js';
+import { applyPrivacyFilter } from '../privacy/filter.js';
+import type { Config } from '../types.js';
+
+const REDACTION_PRIVACY_CONFIG: Config['privacy'] = {
+  excludePatterns: ['password', 'secret', 'api_key', 'token', 'bearer'],
+  anonymize: false,
+  privateTags: {
+    enabled: true,
+    marker: '[PRIVATE]',
+    preserveLineCount: false,
+    supportedFormats: ['xml']
+  }
+};
+
+interface TextColumnTarget {
+  table: string;
+  idColumn: string;
+  columns: string[];
+}
+
+const SQLITE_TARGETS: TextColumnTarget[] = [
+  { table: 'events', idColumn: 'id', columns: ['content'] },
+  { table: 'memory_helpfulness', idColumn: 'id', columns: ['query_preview', 'injected_content'] },
+  { table: 'retrieval_traces', idColumn: 'trace_id', columns: ['query_text', 'raw_query_text'] }
+];
+
+export interface RedactionRowChange {
+  table: string;
+  rowId: string;
+  column: string;
+  /** Already-redacted preview, safe to print. */
+  preview: string;
+}
+
+export interface RedactionFileChange {
+  filePath: string;
+  occurrences: number;
+}
+
+export interface CredentialRedactionPlan {
+  dryRun: boolean;
+  rowChanges: RedactionRowChange[];
+  fileChanges: RedactionFileChange[];
+  /** Event ids whose vectors must be rebuilt from the redacted text. */
+  affectedEventIds: string[];
+  vectorsDeleted: number;
+  embeddingsRequeued: number;
+}
+
+export function redactText(value: string): string {
+  return applyPrivacyFilter(value, REDACTION_PRIVACY_CONFIG).content;
+}
+
+function previewOf(redacted: string): string {
+  const compact = redacted.replace(/\s+/g, ' ').trim();
+  return compact.length > 120 ? `${compact.slice(0, 120)}…` : compact;
+}
+
+function tableExists(db: SQLiteDatabase, table: string): boolean {
+  const rows = sqliteAll<{ name: string }>(
+    db,
+    `SELECT name FROM sqlite_master WHERE type='table' AND name = ?`,
+    [table]
+  );
+  return rows.length > 0;
+}
+
+function columnExists(db: SQLiteDatabase, table: string, column: string): boolean {
+  const rows = sqliteAll<{ name: string }>(db, `PRAGMA table_info(${table})`);
+  return rows.some((row) => row.name === column);
+}
+
+/**
+ * Scan SQLite for values the privacy filter would change, and optionally write
+ * the redacted form back.
+ */
+export function planSqliteRedaction(
+  db: SQLiteDatabase,
+  options: { apply: boolean }
+): { rowChanges: RedactionRowChange[]; affectedEventIds: string[] } {
+  const rowChanges: RedactionRowChange[] = [];
+  const affectedEventIds = new Set<string>();
+
+  for (const target of SQLITE_TARGETS) {
+    if (!tableExists(db, target.table)) continue;
+    for (const column of target.columns) {
+      if (!columnExists(db, target.table, column)) continue;
+
+      const rows = sqliteAll<Record<string, unknown>>(
+        db,
+        `SELECT ${target.idColumn} AS row_id, ${column} AS value
+         FROM ${target.table}
+         WHERE ${column} IS NOT NULL AND ${column} <> ''`
+      );
+
+      for (const row of rows) {
+        const value = typeof row.value === 'string' ? row.value : null;
+        const rowId = row.row_id === null || row.row_id === undefined ? null : String(row.row_id);
+        if (!value || !rowId) continue;
+
+        const redacted = redactText(value);
+        if (redacted === value) continue;
+
+        rowChanges.push({
+          table: target.table,
+          rowId,
+          column,
+          preview: previewOf(redacted)
+        });
+        if (target.table === 'events') affectedEventIds.add(rowId);
+
+        if (options.apply) {
+          sqliteRun(
+            db,
+            `UPDATE ${target.table} SET ${column} = ? WHERE ${target.idColumn} = ?`,
+            [redacted, rowId]
+          );
+        }
+      }
+    }
+  }
+
+  return { rowChanges, affectedEventIds: Array.from(affectedEventIds) };
+}
+
+function walkMarkdown(dir: string, found: string[]): void {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walkMarkdown(full, found);
+    else if (entry.isFile() && entry.name.endsWith('.md')) found.push(full);
+  }
+}
+
+/**
+ * The markdown mirror is a plain-text copy of ingested events, so it leaks
+ * independently of the database.
+ */
+export function planMarkdownRedaction(
+  storagePath: string,
+  options: { apply: boolean }
+): RedactionFileChange[] {
+  const memoryRoot = path.join(storagePath, 'memory');
+  if (!fs.existsSync(memoryRoot)) return [];
+
+  const files: string[] = [];
+  walkMarkdown(memoryRoot, files);
+
+  const changes: RedactionFileChange[] = [];
+  for (const filePath of files) {
+    let original: string;
+    try {
+      original = fs.readFileSync(filePath, 'utf8');
+    } catch {
+      continue;
+    }
+    const redacted = redactText(original);
+    if (redacted === original) continue;
+
+    const occurrences = redacted.split('[REDACTED]').length - original.split('[REDACTED]').length;
+    changes.push({ filePath, occurrences: Math.max(1, occurrences) });
+    if (options.apply) {
+      try {
+        fs.writeFileSync(filePath, redacted, 'utf8');
+      } catch {
+        // Reported as a planned change; a write failure must not abort the rest.
+      }
+    }
+  }
+  return changes;
+}
+
+/**
+ * Queue redacted events for re-embedding. Callers delete the stale vectors
+ * separately, since that needs the vector store rather than SQLite.
+ */
+export function requeueEmbeddings(
+  db: SQLiteDatabase,
+  eventIds: string[],
+  options: { apply: boolean }
+): number {
+  if (eventIds.length === 0 || !tableExists(db, 'embedding_outbox')) return 0;
+
+  let queued = 0;
+  for (const eventId of eventIds) {
+    const rows = sqliteAll<{ content: string }>(
+      db,
+      `SELECT content FROM events WHERE id = ?`,
+      [eventId]
+    );
+    const content = rows[0]?.content;
+    if (typeof content !== 'string' || content.length === 0) continue;
+    queued += 1;
+    if (!options.apply) continue;
+
+    sqliteRun(db, `DELETE FROM embedding_outbox WHERE event_id = ?`, [eventId]);
+    sqliteRun(
+      db,
+      `INSERT INTO embedding_outbox (id, event_id, content, status, retry_count, created_at)
+       VALUES (?, ?, ?, 'pending', 0, datetime('now'))`,
+      [`redact-${eventId}`, eventId, content]
+    );
+  }
+  return queued;
+}
+
+export function formatRedactionPlan(plan: CredentialRedactionPlan): string {
+  const lines: string[] = [];
+  const mode = plan.dryRun ? 'DRY RUN — nothing was modified' : 'APPLIED';
+  lines.push(`Credential redaction: ${mode}`);
+  lines.push('');
+  lines.push(`SQLite values to redact : ${plan.rowChanges.length}`);
+  lines.push(`Markdown files to redact: ${plan.fileChanges.length}`);
+  lines.push(`Events needing re-embed : ${plan.affectedEventIds.length}`);
+  if (!plan.dryRun) {
+    lines.push(`Vectors deleted         : ${plan.vectorsDeleted}`);
+    lines.push(`Embeddings re-queued    : ${plan.embeddingsRequeued}`);
+  }
+
+  if (plan.rowChanges.length > 0) {
+    lines.push('', 'Rows (previews already redacted):');
+    const byTable = new Map<string, number>();
+    for (const change of plan.rowChanges) {
+      byTable.set(`${change.table}.${change.column}`, (byTable.get(`${change.table}.${change.column}`) ?? 0) + 1);
+    }
+    for (const [key, count] of Array.from(byTable.entries()).sort()) {
+      lines.push(`  ${key}: ${count}`);
+    }
+    for (const change of plan.rowChanges.slice(0, 5)) {
+      lines.push(`  - ${change.table}.${change.column} [${change.rowId.slice(0, 8)}] ${change.preview}`);
+    }
+    if (plan.rowChanges.length > 5) lines.push(`  … and ${plan.rowChanges.length - 5} more`);
+  }
+
+  if (plan.fileChanges.length > 0) {
+    lines.push('', 'Markdown files:');
+    for (const change of plan.fileChanges.slice(0, 10)) {
+      lines.push(`  - ${change.filePath}`);
+    }
+    if (plan.fileChanges.length > 10) lines.push(`  … and ${plan.fileChanges.length - 10} more`);
+  }
+
+  if (plan.dryRun && (plan.rowChanges.length > 0 || plan.fileChanges.length > 0)) {
+    lines.push('', 'Re-run with --apply to write these changes.');
+  }
+  lines.push(
+    '',
+    'Redacting local copies does not un-expose a credential: rotate anything found here.'
+  );
+  return lines.join('\n');
+}

--- a/src/core/operations/index.ts
+++ b/src/core/operations/index.ts
@@ -25,3 +25,4 @@ export * from './perspective-query-agent.js';
 export * from './perspective-consolidator.js';
 export * from './perspective-session-actor-backfill.js';
 export * from './tool-observation-vector-backfill.js';
+export * from './credential-redaction.js';

--- a/src/core/privacy/filter.ts
+++ b/src/core/privacy/filter.ts
@@ -19,15 +19,39 @@ export interface FilterResult {
 }
 
 // Sensitive data patterns
+/**
+ * Rejects values that are code rather than a credential: an already-redacted
+ * marker, a type annotation, an arrow function, or an opening bracket.
+ */
+const NOT_A_SECRET_VALUE =
+  '(?!\\[REDACTED\\])(?![({\\[]|=>|\\s*$)'
+  // The optional quote matters: `apiKey: "string"` is still a type, not a key.
+  + '(?![\'"]?(?:string|number|boolean|any|unknown|void|never|null|undefined|true|false'
+  + '|Promise|Record|Array|Partial|Readonly)\\b)';
+
 const SENSITIVE_PATTERNS = [
   // Credential-bearing URLs/connection strings with userinfo before the host.
   // Redact the whole URI so usernames, credentials, hosts, paths, and query
   // params do not leak either.
   /\b[a-z][a-z0-9+.-]*:\/\/[^\s'"`<>/@]+@[^\s'"`<>]+/gi,
-  /(?:[\w.-]+[-_])?password\s*[:=]\s*(?!\[REDACTED\])['"]?[^\s'"]+/gi,
-  /(?:[\w.-]+[-_])?api[-_]?key\s*[:=]\s*(?!\[REDACTED\])['"]?[^\s'"]+/gi,
-  /(?:[\w.-]+[-_])?secret\s*[:=]\s*(?!\[REDACTED\])['"]?[^\s'"]+/gi,
-  /(?:[\w.-]+[-_])?token\s*[:=]\s*(?!\[REDACTED\])['"]?[^\s'"]+/gi,
+  // Two guards keep source code out of these rules. Without them a stored
+  // discussion of real code gets mangled — `getAccessToken: () => …` became
+  // `getAccess[REDACTED] => …` on live data.
+  //
+  // The leading lookbehind rejects camelCase identifiers (`getAccessToken:`),
+  // while underscore/dash forms (`access_token=…`) still match through the
+  // optional prefix group. The trailing guard rejects values that are plainly
+  // code rather than a secret: a type annotation, an arrow function, or an
+  // opening bracket.
+  new RegExp(`(?<![A-Za-z0-9])(?:[\\w.-]+[-_])?password\\s*[:=]\\s*${NOT_A_SECRET_VALUE}['"]?[^\\s'"]+`, 'gi'),
+  new RegExp(`(?<![A-Za-z0-9])(?:[\\w.-]+[-_])?api[-_]?key\\s*[:=]\\s*${NOT_A_SECRET_VALUE}['"]?[^\\s'"]+`, 'gi'),
+  new RegExp(`(?<![A-Za-z0-9])(?:[\\w.-]+[-_])?secret\\s*[:=]\\s*${NOT_A_SECRET_VALUE}['"]?[^\\s'"]+`, 'gi'),
+  new RegExp(`(?<![A-Za-z0-9])(?:[\\w.-]+[-_])?token\\s*[:=]\\s*${NOT_A_SECRET_VALUE}['"]?[^\\s'"]+`, 'gi'),
+  // camelCase keys are excluded above because `accessToken: () => …` is code.
+  // But `accessToken: "eyJhbGciOi…"` is a real credential, and the difference
+  // is the value, not the key. A quoted, long, secret-shaped literal is the
+  // one camelCase form worth redacting.
+  /[A-Za-z0-9_.-]*(?:password|secret|token|api[-_]?key)\s*[:=]\s*['"][A-Za-z0-9._\-+/=]{12,}['"]/gi,
   /bearer\s+[a-zA-Z0-9\-_.]+/gi,
   /AWS[_-]?ACCESS[_-]?KEY[_-]?ID\s*[:=]\s*['"]?[A-Z0-9]+/gi,
   /AWS[_-]?SECRET[_-]?ACCESS[_-]?KEY\s*[:=]\s*['"]?[^\s'"]+/gi,

--- a/tests/core/privacy-filter.test.ts
+++ b/tests/core/privacy-filter.test.ts
@@ -128,3 +128,32 @@ describe('vendor-prefixed token redaction', () => {
     expect(applyPrivacyFilter(benign, privacy).content).toBe(benign);
   });
 });
+
+describe('source code is not mistaken for credentials', () => {
+  // Found on live data: `getAccessToken: () => storage.get(…)` was rewritten to
+  // `getAccess[REDACTED] => storage.get(…)`, corrupting 22 stored discussions
+  // of real source files. The keyword rules had no word boundary, so the
+  // `Token:` inside a camelCase identifier looked like `token=value`.
+  it.each([
+    ['type annotation', 'export async function sync(accessToken: Promise<CloudSyncResult>)'],
+    ['arrow function', 'authInterceptors(base, { getAccessToken: () => storage.get(K.ACCESS_TOKEN) })'],
+    ['destructuring', 'const { mode, cloudAccessToken } = useAppModeStore((s) => ({ mode: s.mode, cloudAccessToken }))'],
+    ['interface fields', 'interface Cfg { clientSecret: string; apiKey: string }'],
+    ['optional fields', 'type T = { apiKey?: string; token?: number }'],
+    ['quoted type name', 'apiKey: "string"'],
+    ['prose', 'token 만료 시간을 어떻게 늘리지?']
+  ])('leaves %s untouched', (_label, source) => {
+    expect(applyPrivacyFilter(source, privacy).content).toBe(source);
+  });
+
+  // The discriminator is the value, not the key: a camelCase key with a long
+  // quoted literal is still a credential.
+  it.each([
+    ['double-quoted jwt', 'accessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"'],
+    ['single-quoted secret', "clientSecret: 'abc123def456ghi'"],
+    ['snake_case assignment', 'access_token=eyJhbGciOiJIUzI1NiJ9abc'],
+    ['bare password', 'password: Zt9wQx2027@']
+  ])('still redacts %s', (_label, source) => {
+    expect(applyPrivacyFilter(source, privacy).content).toContain('[REDACTED]');
+  });
+});


### PR DESCRIPTION
Follow-up to #44, which stopped new leaks but left everything written before it in place.

## The command

```bash
claude-memory-layer repair redact-credentials -p <project>          # dry run
claude-memory-layer repair redact-credentials -p <project> --apply  # write
```

Dry-run is the default and provably writes nothing — verified by comparing database and markdown checksums before and after.

## Coverage

A partial scrub reads as "cleaned" while copies survive elsewhere, so it covers every place a prompt's text is duplicated:

| location | why it matters |
|---|---|
| `events.content` | the original |
| `memory_helpfulness.query_preview`, `injected_content` | where the first real leak was found |
| `retrieval_traces.query_text`, `raw_query_text` | both columns |
| markdown mirror under `<storage>/memory/` | a plain-text copy that leaks independently of the DB |
| Lance vector store | keeps source text alongside the embedding |

Lance rows cannot be edited in place, so affected events are deleted from the vector store and re-queued for embedding; the next pass rebuilds them from the redacted SQLite content.

## A defect the dry-run exposed

Running the dry-run against a real store surfaced a problem in the *existing* filter that would have made `--apply` destructive. The keyword rules had no word boundary, so the `Token:` inside a camelCase identifier read as `token=value`:

```
getAccessToken: () => storage.get(K.ACCESS_TOKEN)
→ getAccess[REDACTED] => storage.get(K.ACCESS_TOKEN)
```

**22 of 55 flagged rows were source-code discussions being corrupted this way.** Applying the scrub as originally written would have destroyed them.

Two guards now separate code from secrets:

- a leading lookbehind rejects camelCase keys, while `access_token=…` and `client-secret: …` still match through the prefix group
- a value guard rejects type annotations, arrow functions and brackets — including quoted ones, since `apiKey: "string"` is still a type

Because the discriminator is the **value**, not the key, camelCase with a long quoted literal is matched separately: `accessToken: "eyJhbGciOi…"` is a credential, `accessToken: Promise<T>` is not.

On the real store this cut flagged rows from 63 to 56, with every remaining hit a genuine credential position — env assignments and `?token=` URL parameters.

## Verification

End to end on an isolated fixture: the secret row was redacted, its vector deleted and re-queued for embedding, and a camelCase code row in the same store left untouched. 1063 tests pass (11 new, covering both the false-positive shapes and the credential shapes that must still redact), typecheck and lint clean.

## Note

Redacting local copies does not un-expose a credential. Anything found by this tool should be rotated regardless — the command says so in its own output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)