### PR TITLE
fix(privacy): stop redacting documentation prose and code assignments

### DIFF
--- a/src/core/privacy/filter.ts
+++ b/src/core/privacy/filter.ts
@@ -27,7 +27,10 @@ const NOT_A_SECRET_VALUE =
   '(?!\\[REDACTED\\])(?![({\\[]|=>|\\s*$)'
   // The optional quote matters: `apiKey: "string"` is still a type, not a key.
   + '(?![\'"]?(?:string|number|boolean|any|unknown|void|never|null|undefined|true|false'
-  + '|Promise|Record|Array|Partial|Readonly)\\b)';
+  + '|Promise|Record|Array|Partial|Readonly)\\b)'
+  // `token = json.dumps(...)` assigns in code: the secret would be the result
+  // of the call, not this expression.
+  + '(?![A-Za-z_$][\\w.$]*\\s*\\()';
 
 const SENSITIVE_PATTERNS = [
   // Credential-bearing URLs/connection strings with userinfo before the host.
@@ -52,7 +55,11 @@ const SENSITIVE_PATTERNS = [
   // is the value, not the key. A quoted, long, secret-shaped literal is the
   // one camelCase form worth redacting.
   /[A-Za-z0-9_.-]*(?:password|secret|token|api[-_]?key)\s*[:=]\s*['"][A-Za-z0-9._\-+/=]{12,}['"]/gi,
-  /bearer\s+[a-zA-Z0-9\-_.]+/gi,
+  // "Bearer token", "Bearer JWT" and friends are how documentation names the
+  // scheme, not a secret. On a real store the loose form matched 29 such
+  // phrases against a single actual token, so the word after Bearer must not be
+  // one of those nouns and the value has to be long enough to be a credential.
+  /bearer\s+(?!token\b|jwt\b|auth\b|authentication\b|access\b|scheme\b|header\b|prefix\b)[a-zA-Z0-9\-_.]{16,}/gi,
   /AWS[_-]?ACCESS[_-]?KEY[_-]?ID\s*[:=]\s*['"]?[A-Z0-9]+/gi,
   /AWS[_-]?SECRET[_-]?ACCESS[_-]?KEY\s*[:=]\s*['"]?[^\s'"]+/gi,
   /-----BEGIN\s+(RSA\s+)?PRIVATE\s+KEY-----[\s\S]*?-----END\s+(RSA\s+)?PRIVATE\s+KEY-----/g,
@@ -159,10 +166,15 @@ export function applyPrivacyFilter(
   }
 
   // 3. Custom pattern filtering from config
+  //
+  // This mirrors the built-in keyword rules, so it needs the same value guard.
+  // Without it the config list silently re-introduced every false positive the
+  // built-ins had been taught to avoid — `token = json.dumps(payload)` was
+  // still being rewritten to `[REDACTED]` through this loop alone.
   for (const patternStr of config.excludePatterns || []) {
     try {
       const regex = new RegExp(
-        `(^|[^\\w-])(${patternStr})\\s*[:=]\\s*['"]?[^\\s'"]+`,
+        `(^|[^\\w-])(${patternStr})\\s*[:=]\\s*${NOT_A_SECRET_VALUE}['"]?[^\\s'"]+`,
         'gi'
       );
       const matches = filtered.match(regex);

--- a/tests/core/privacy-filter.test.ts
+++ b/tests/core/privacy-filter.test.ts
@@ -157,3 +157,32 @@ describe('source code is not mistaken for credentials', () => {
     expect(applyPrivacyFilter(source, privacy).content).toContain('[REDACTED]');
   });
 });
+
+describe('documentation prose is not mistaken for credentials', () => {
+  // On a real store the loose bearer rule matched 29 documentation phrases
+  // against a single actual token.
+  it.each([
+    ['scheme description', 'Auth: Bearer token (Header/Cookie)'],
+    ['jwt description', 'All sync endpoints require Bearer JWT auth'],
+    ['python assignment', 'if token = json.dumps(payload):'],
+    ['js assignment', 'const token = getToken(user)']
+  ])('leaves %s untouched', (_label, source) => {
+    expect(applyPrivacyFilter(source, privacy).content).toBe(source);
+  });
+
+  it('still redacts a real bearer credential', () => {
+    const header = 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9abcdef';
+    expect(applyPrivacyFilter(header, privacy).content).toContain('[REDACTED]');
+  });
+
+  // The config-driven excludePatterns loop mirrors the built-in keyword rules,
+  // so it needs the same value guard or it silently reintroduces every false
+  // positive the built-ins were taught to avoid.
+  it('applies the same guard to config-driven patterns', () => {
+    const custom: typeof privacy = { ...privacy, excludePatterns: ['token'] };
+    expect(applyPrivacyFilter('if token = json.dumps(payload):', custom).content)
+      .toBe('if token = json.dumps(payload):');
+    expect(applyPrivacyFilter('token: Zt9wQx2027abc', custom).content)
+      .toContain('[REDACTED]');
+  });
+});


### PR DESCRIPTION
Follow-up to #45. Running the scrub dry-run against a real store — and checking *why* each row was flagged rather than trusting the count — turned up two more false-positive sources. Both would have destroyed legitimate content on `--apply`.

## 1. "Bearer token" is documentation, not a secret

The rule matched any word after `Bearer`, so it hit the phrases that name the scheme:

```
Auth: Bearer token (Header/Cookie)
All sync endpoints require Bearer JWT auth
```

On the measured store: **29 such phrases against exactly 1 real token.** The rule now rejects those nouns (`token`, `jwt`, `auth`, `access`, `scheme`, `header`, `prefix`) and requires a value long enough to be a credential.

## 2. `token = json.dumps(payload)` is an assignment in code

The secret would be the call's *result*, not this expression. Values that are a function call or member expression are now excluded, alongside the type annotations and arrow functions handled in #45.

## 3. The config loop bypassed every guard

This is what made #2 survive: `excludePatterns` from config builds its own regex that duplicated the built-in keyword rules **without any of their guards**. So the Python assignment above was still being rewritten through that path alone, no matter how carefully the built-ins were tuned.

Both paths now share the same value guard.

## Effect

| | flagged rows |
|---|---|
| before #45 | 63 |
| after #45 | 56 |
| after this PR | **45** |

Spot-checking the remaining 45 shows genuine credential positions: URL query parameters (`?token=`), `hf_` tokens, env assignments, and tokens inside logged API response bodies.

## Verification

1069 tests pass (6 new, covering both the prose/code shapes that must survive and the real credential that must still redact), typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)