### PR TITLE
fix(privacy): stop redacting unary/increment expressions as credentials

### DIFF
--- a/src/core/privacy/filter.ts
+++ b/src/core/privacy/filter.ts
@@ -30,7 +30,10 @@ const NOT_A_SECRET_VALUE =
   + '|Promise|Record|Array|Partial|Readonly)\\b)'
   // `token = json.dumps(...)` assigns in code: the secret would be the result
   // of the call, not this expression.
-  + '(?![A-Za-z_$][\\w.$]*\\s*\\()';
+  + '(?![A-Za-z_$][\\w.$]*\\s*\\()'
+  // `var token = ++fitRetryToken` — a credential literal never starts with a
+  // unary/increment operator, so this is unambiguously a variable reference.
+  + '(?!\\+\\+|--|!|~)';
 
 const SENSITIVE_PATTERNS = [
   // Credential-bearing URLs/connection strings with userinfo before the host.

--- a/tests/core/privacy-filter.test.ts
+++ b/tests/core/privacy-filter.test.ts
@@ -186,3 +186,15 @@ describe('documentation prose is not mistaken for credentials', () => {
       .toContain('[REDACTED]');
   });
 });
+
+describe('unary/increment expressions are not mistaken for credentials', () => {
+  // Found on live data: `var token = ++fitRetryToken` — a JS retry counter,
+  // not a secret. A credential literal never starts with an operator.
+  it.each([
+    ['increment', 'var token = ++fitRetryToken'],
+    ['decrement', 'let secret = --remainingAttempts'],
+    ['negation', 'const password = !isValid']
+  ])('leaves %s untouched', (_label, source) => {
+    expect(applyPrivacyFilter(source, privacy).content).toBe(source);
+  });
+});


### PR DESCRIPTION
Found while sample-checking `repair redact-credentials` output on real data before applying it:

```
function applyFitScale(reason) {
  var token = ++fitRetryToken
→
  var [REDACTED]
```

A credential literal never begins with an operator, so rejecting `++`/`--`/`!`/`~` prefixes is unambiguous — unlike the camelCase-identifier cases handled in #46, there's no real secret shape this could accidentally exclude.

3 tests added. 1072 tests pass, typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)