### PR TITLE
fix(privacy): stop redacting process.env references as credentials

### DIFF
--- a/src/core/privacy/filter.ts
+++ b/src/core/privacy/filter.ts
@@ -33,7 +33,12 @@ const NOT_A_SECRET_VALUE =
   + '(?![A-Za-z_$][\\w.$]*\\s*\\()'
   // `var token = ++fitRetryToken` — a credential literal never starts with a
   // unary/increment operator, so this is unambiguously a variable reference.
-  + '(?!\\+\\+|--|!|~)';
+  + '(?!\\+\\+|--|!|~)'
+  // `const TOKEN = process.env.TOKEN || randomBytes(32)…` reads the variable
+  // rather than containing it — a very common Node.js pattern in this kind of
+  // codebase, and unambiguous because a literal secret is never spelled
+  // `process.env.<NAME>`.
+  + '(?!process\\.env\\.)';
 
 const SENSITIVE_PATTERNS = [
   // Credential-bearing URLs/connection strings with userinfo before the host.

--- a/tests/core/privacy-filter.test.ts
+++ b/tests/core/privacy-filter.test.ts
@@ -198,3 +198,17 @@ describe('unary/increment expressions are not mistaken for credentials', () => {
     expect(applyPrivacyFilter(source, privacy).content).toBe(source);
   });
 });
+
+describe('process.env references are not mistaken for credentials', () => {
+  // Found on live data: `const TOKEN = process.env.TOKEN || randomBytes(32)…`
+  // reads the variable, it does not contain the secret.
+  it('leaves an env-var reference untouched', () => {
+    const source = "const TOKEN = process.env.TOKEN || randomBytes(32).toString('hex')";
+    expect(applyPrivacyFilter(source, privacy).content).toBe(source);
+  });
+
+  it('still redacts a literal value assigned from a non-env source', () => {
+    const source = 'const apiKey = "sk_live_abcdef123456"';
+    expect(applyPrivacyFilter(source, privacy).content).toContain('[REDACTED]');
+  });
+});


### PR DESCRIPTION
Found while sample-checking `repair redact-credentials` output on real data before applying it:

```
const TOKEN = process.env.TOKEN || randomBytes(32).toString('hex')
→
const [REDACTED] || randomBytes(32).toString('hex')
```

`process.env.<NAME>` reads a variable rather than containing a secret, and this pattern is common enough in Node.js codebases to be worth its own guard. Unambiguous: a literal credential is never spelled `process.env.X`.

2 tests added. 1074 tests pass, typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)