### PR TITLE
fix(embedder): self-heal a truncated model cache instead of failing forever

### DIFF
--- a/src/extensions/vector/embedder.ts
+++ b/src/extensions/vector/embedder.ts
@@ -46,7 +46,7 @@ export class Embedder {
     });
 
     try {
-      this.pipeline = await withSuppressedKnownTransformersWarnings(() => pipeline('feature-extraction', this.modelName));
+      this.pipeline = await this.loadPipelineWithCorruptionRecovery(pipeline, this.modelName);
       this.activeModelName = this.modelName;
       this.initialized = true;
       return;
@@ -57,9 +57,41 @@ export class Embedder {
       }
 
       console.warn(`[Embedder] Primary model failed (${this.modelName}). Falling back to ${fallbackModel}`);
-      this.pipeline = await withSuppressedKnownTransformersWarnings(() => pipeline('feature-extraction', fallbackModel));
+      this.pipeline = await this.loadPipelineWithCorruptionRecovery(pipeline, fallbackModel);
       this.activeModelName = fallbackModel;
       this.initialized = true;
+    }
+  }
+
+  /**
+   * Load a model, self-healing a truncated/corrupted cache.
+   *
+   * @huggingface/transformers only checks whether a cached file *exists*
+   * before skipping the download, not whether it is valid. A download
+   * interrupted mid-write (killed process, lost connection) leaves a file
+   * that exists but fails ONNX parsing — every future load hits the same
+   * error forever, since nothing ever re-downloads it. This was observed on
+   * a real machine after a global npm install: two ~450MB files, sizes not
+   * matching the known-good ~470MB build, failing with
+   * "Load model from <path> failed:Protobuf parsing failed." on every
+   * attempt. Detecting that shape, clearing the specific model's cache
+   * directory, and retrying once converts a permanently stuck install into
+   * one that repairs itself on the next start.
+   */
+  private async loadPipelineWithCorruptionRecovery(
+    pipeline: FeatureExtractionPipelineFactory,
+    modelName: string
+  ): Promise<NonNullable<Embedder['pipeline']>> {
+    try {
+      return await withSuppressedKnownTransformersWarnings(() => pipeline('feature-extraction', modelName));
+    } catch (error) {
+      if (!isCorruptedModelCacheError(error)) throw error;
+
+      const cleared = await clearModelCacheDirectory(modelName);
+      if (!cleared) throw error;
+
+      console.warn(`[Embedder] Detected a corrupted cache for ${modelName}; cleared it and retrying.`);
+      return await withSuppressedKnownTransformersWarnings(() => pipeline('feature-extraction', modelName));
     }
   }
 
@@ -231,4 +263,66 @@ async function loadTransformersPipeline(): Promise<FeatureExtractionPipelineFact
   ) => Promise<{ pipeline: unknown }>;
   const transformers = await dynamicImport('@huggingface/transformers');
   return transformers.pipeline as FeatureExtractionPipelineFactory;
+}
+
+/**
+ * Matches ONNX Runtime's model-load failure text, which is how a truncated
+ * download surfaces: the file exists (so nothing re-downloads it) but is not
+ * a valid protobuf. Intentionally narrow — only errors that name onnx/protobuf
+ * loading are treated as a corrupted cache; a model that is merely missing or
+ * a network failure during download should surface as-is.
+ */
+export function isCorruptedModelCacheError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /load model from .*failed/i.test(message)
+    || /protobuf parsing failed/i.test(message)
+    || /invalid[_ ]protobuf/i.test(message)
+    || /onnxruntime[^a-z]*error/i.test(message);
+}
+
+async function resolveTransformersCacheDir(): Promise<string | undefined> {
+  const dynamicImport = new Function('specifier', 'return import(specifier)') as (
+    specifier: string
+  ) => Promise<{ env: { cacheDir?: string } }>;
+  const transformers = await dynamicImport('@huggingface/transformers');
+  return transformers.env?.cacheDir;
+}
+
+/**
+ * Delete a model's cache directory so the library re-downloads it from
+ * scratch. Returns false (not true-with-no-op) when the cache directory
+ * cannot even be determined, so the caller knows recovery was not actually
+ * attempted and should surface the original error instead of retrying
+ * against the same corrupted files.
+ *
+ * `cacheDir` is injectable so tests can exercise the path-safety logic
+ * directly: the production caller (below) resolves it via an indirect
+ * dynamic import of @huggingface/transformers, which — like the rest of this
+ * file's lazy loading — does not share module state with a bundler/test
+ * runner's own transformed import of the same package.
+ */
+export async function clearModelCacheDirectory(
+  modelName: string,
+  cacheDir?: string
+): Promise<boolean> {
+  try {
+    const resolvedCacheDirInput = cacheDir ?? await resolveTransformersCacheDir();
+    if (!resolvedCacheDirInput) return false;
+
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const modelDir = path.join(resolvedCacheDirInput, modelName);
+
+    // Guard against a misconfigured cacheDir turning this into `rm -rf` of
+    // something unrelated: only remove a path that actually resolves inside
+    // the resolved cache directory.
+    const resolvedCacheDir = path.resolve(resolvedCacheDirInput);
+    const resolvedModelDir = path.resolve(modelDir);
+    if (!resolvedModelDir.startsWith(resolvedCacheDir + path.sep)) return false;
+
+    await fs.rm(resolvedModelDir, { recursive: true, force: true });
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/tests/extensions/embedder-corrupted-cache-recovery.test.ts
+++ b/tests/extensions/embedder-corrupted-cache-recovery.test.ts
@@ -1,0 +1,90 @@
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { clearModelCacheDirectory, isCorruptedModelCacheError } from '../../src/extensions/vector/embedder.js';
+
+describe('isCorruptedModelCacheError', () => {
+  it('recognizes the real ONNX load failure text', () => {
+    // The exact message observed on a real machine after a global npm
+    // install left a truncated model file behind.
+    const real = new Error(
+      'Load model from /path/to/model.onnx failed:Protobuf parsing failed.'
+    );
+    expect(isCorruptedModelCacheError(real)).toBe(true);
+  });
+
+  it('recognizes other onnxruntime/protobuf failure shapes', () => {
+    expect(isCorruptedModelCacheError(new Error('INVALID_PROTOBUF: bad data'))).toBe(true);
+    expect(isCorruptedModelCacheError(new Error('OnnxRuntimeError: something broke'))).toBe(true);
+  });
+
+  it('does not treat an ordinary missing-file or network error as corruption', () => {
+    // These must surface as-is: clearing a cache directory would not fix
+    // a network outage, and could delete a model that simply isn't
+    // downloaded yet for an unrelated reason.
+    expect(isCorruptedModelCacheError(new Error('fetch failed'))).toBe(false);
+    expect(isCorruptedModelCacheError(new Error('ENOENT: no such file or directory'))).toBe(false);
+    expect(isCorruptedModelCacheError(new Error('getaddrinfo ENOTFOUND huggingface.co'))).toBe(false);
+  });
+});
+
+describe('clearModelCacheDirectory', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function withCacheDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'cml-embedder-cache-'));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  it('deletes only the named model directory', async () => {
+    const cacheDir = withCacheDir();
+    const target = join(cacheDir, 'Xenova', 'multilingual-e5-small', 'onnx');
+    mkdirSync(target, { recursive: true });
+    writeFileSync(join(target, 'model.onnx'), 'truncated');
+
+    const sibling = join(cacheDir, 'Xenova', 'other-model');
+    mkdirSync(sibling, { recursive: true });
+    writeFileSync(join(sibling, 'config.json'), '{}');
+
+    const result = await clearModelCacheDirectory('Xenova/multilingual-e5-small', cacheDir);
+
+    expect(result).toBe(true);
+    expect(existsSync(join(cacheDir, 'Xenova', 'multilingual-e5-small'))).toBe(false);
+    expect(existsSync(sibling)).toBe(true);
+  });
+
+  it('is a safe no-op-with-false-return when the model directory does not exist', async () => {
+    const cacheDir = withCacheDir();
+    const result = await clearModelCacheDirectory('Xenova/never-downloaded', cacheDir);
+    // fs.rm with force:true does not error on a missing path, so this
+    // reports success — there is simply nothing left to clear.
+    expect(result).toBe(true);
+  });
+
+  it('refuses to delete outside the resolved cache directory', async () => {
+    const cacheDir = withCacheDir();
+    const outside = mkdtempSync(join(tmpdir(), 'cml-embedder-outside-'));
+    tempDirs.push(outside);
+    writeFileSync(join(outside, 'do-not-delete.txt'), 'x');
+
+    // A model name is always a repo id like "org/model"; this simulates a
+    // pathological value trying to escape the cache directory.
+    const escaping = `../${outside.split('/').pop()}`;
+    const result = await clearModelCacheDirectory(escaping, cacheDir);
+
+    expect(result).toBe(false);
+    expect(existsSync(join(outside, 'do-not-delete.txt'))).toBe(true);
+  });
+
+  it('returns false when no cache directory is available', async () => {
+    const result = await clearModelCacheDirectory('Xenova/multilingual-e5-small', '');
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
## What happened

Found while verifying a global npm upgrade on a real machine: after `npm install -g claude-memory-layer@latest`, the daemon logged this on every retrieval attempt:

```
[Embedder] Primary model failed (Xenova/multilingual-e5-small). Falling back to intfloat/multilingual-e5-small
[semantic-daemon] session summary failed: Error: Load model from .../model.onnx failed:Protobuf parsing failed.
```

The two cached model files were **449MB and 464MB** — smaller than, and inconsistent with each other and with, the known-good **~470MB** build from a working install (verified byte-identical between two independently-downloaded copies: 470268533 and 470268510 bytes). The sizes stayed static across dozens of retries: the download had been interrupted mid-write at some point, leaving a file that exists but does not parse.

## Root cause

`@huggingface/transformers` only checks whether a cached file **exists** before skipping the download — not whether it's valid. Once corrupted this way, nothing ever re-downloads it. Every future load hits the identical protobuf error, permanently, with no path to recovery short of a human finding and deleting the right `node_modules/.cache` directory by hand.

## Fix

The embedder now:
1. Recognizes this failure shape (`Load model from ... failed`, protobuf/onnxruntime error text) via `isCorruptedModelCacheError`
2. Clears the specific model's cache directory
3. Retries the load once

A path-traversal guard keeps `clearModelCacheDirectory` from ever touching anything outside the resolved cache directory, even if `cacheDir` resolution is ever misconfigured — verified with a test that an escaping model name is rejected and the guard correctly resolves nested real paths.

## Verification

Reproduced the exact failure in isolation (valid config/tokenizer files, `model.onnx` truncated to 5MB) and confirmed the embedder self-heals on the next `initialize()` call, producing a working 384-dim embedding — where before this fix it failed identically forever.

7 new unit tests (classification + directory-safety logic, dependency-injected for testability since production resolves `cacheDir` via the same lazy dynamic-import pattern the rest of this file already uses). 1081 tests pass, typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)