### PR TITLE
fix(summary): stop SessionEnd from reintroducing the table-of-contents summary

### DIFF
--- a/src/adapters/claude/hooks/session-end.ts
+++ b/src/adapters/claude/hooks/session-end.ts
@@ -5,7 +5,6 @@
 
 import { getLightweightMemoryService } from '../../../services/memory-service.js';
 import type { SessionEndInput } from '../../../core/types.js';
-import { generateSessionSummary } from '../transcript/turn-reconstructor.js';
 import { readStdin } from './hook-runtime.js';
 
 export async function main(): Promise<string> {
@@ -20,14 +19,15 @@ export async function main(): Promise<string> {
     const sessionEvents = await memoryService.getSessionHistory(input.session_id);
 
     if (sessionEvents.length > 0) {
-      // Generate a simple session summary
-      const summary = generateSessionSummary(sessionEvents);
-
-      // Store session summary
-      await memoryService.storeSessionSummary(input.session_id, summary);
-
-      // End session with summary
-      await memoryService.endSession(input.session_id, summary);
+      // The Stop hook already asks the daemon to build the outcome-focused
+      // summary (see stop.ts / session-summary-llm.ts). This hook used to
+      // also generate its own rule-based table-of-contents summary and store
+      // it unconditionally — with no check for an existing summary — which
+      // measurably kept producing the "Session with N prompts..." text the
+      // LLM summary was built to replace, sometimes racing ahead of it.
+      // endSession's own `summary` column is separate bookkeeping (not an
+      // injectable session_summary event) and is fine to leave unset here.
+      await memoryService.endSession(input.session_id);
 
       // Evaluate helpfulness of memory retrievals in this session
       try {

--- a/src/adapters/claude/hooks/session-start.ts
+++ b/src/adapters/claude/hooks/session-start.ts
@@ -6,7 +6,8 @@
 import { randomUUID } from 'crypto';
 import { getLightweightMemoryService } from '../../../services/memory-service.js';
 import { registerSession } from '../../../core/registry/session-registry.js';
-import { ensureDaemonRunning } from './semantic-daemon-client.js';
+import { ensureDaemonRunning, scheduleSessionSummary } from './semantic-daemon-client.js';
+import { isLlmSummaryEnabled } from '../../llm/session-summary-llm.js';
 import { spawnToolObservationVectorAutoHealIfNeeded } from './tool-observation-vector-auto-heal-client.js';
 import { readStdin } from './hook-runtime.js';
 import { formatClaudeContextHookOutput, isHookEvaluationMode } from './hook-output.js';
@@ -49,8 +50,22 @@ export async function main(): Promise<string> {
 
     // Backfill session summaries for recent sessions that ended without Stop hook
     // (crash, force-close, etc.). Run in background - non-blocking.
+    //
+    // Routed through the same daemon-scheduled LLM path Stop uses, not the
+    // local rule-based generator: this backfill previously called
+    // generateSessionSummary directly, which kept reintroducing the
+    // table-of-contents summary shape the LLM path exists to replace, on
+    // every session that needed a backfill.
     if (!isHookEvaluationMode()) {
-      memoryService.backfillMissingSummaries(input.session_id, 5).catch(() => {});
+      if (isLlmSummaryEnabled()) {
+        memoryService.getSessionsWithoutSummary(input.session_id, 5)
+          .then((sessionIds) => Promise.all(
+            sessionIds.map((sessionId) => scheduleSessionSummary(sessionId).catch(() => {}))
+          ))
+          .catch(() => {});
+      } else {
+        memoryService.backfillMissingSummaries(input.session_id, 5).catch(() => {});
+      }
     }
 
     // Get recent context for this project (now automatically scoped)

--- a/src/core/engine/memory-ingest-service.ts
+++ b/src/core/engine/memory-ingest-service.ts
@@ -200,6 +200,16 @@ export class MemoryIngestService {
   }
 
   /**
+   * Session ids missing a summary, for callers that want to backfill through
+   * the LLM path (see semantic-daemon-client's scheduleSessionSummary) rather
+   * than this class's own rule-based generateSessionSummary.
+   */
+  async getSessionsWithoutSummary(currentSessionId: string, limit = 5): Promise<string[]> {
+    await this.initialize();
+    return this.eventStore.getSessionsWithoutSummary(currentSessionId, limit);
+  }
+
+  /**
    * Generate a rule-based session summary from stored events.
    * Skips short sessions and sessions that already contain a summary event.
    */

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -221,6 +221,11 @@ export class MemoryService {
     return this.ingestService.backfillMissingSummaries(currentSessionId, limit);
   }
 
+  /** Session ids missing a summary; see MemoryIngestService.getSessionsWithoutSummary. */
+  async getSessionsWithoutSummary(currentSessionId: string, limit = 5): Promise<string[]> {
+    return this.ingestService.getSessionsWithoutSummary(currentSessionId, limit);
+  }
+
   /**
    * Generate a rule-based session summary from stored events.
    * Called at session end (Stop hook) when no LLM-generated summary exists.

--- a/tests/core/memory-ingest-service.test.ts
+++ b/tests/core/memory-ingest-service.test.ts
@@ -415,3 +415,15 @@ describe('MemoryIngestService LLM session summary', () => {
     expect(appended).toHaveLength(0);
   });
 });
+
+describe('MemoryIngestService.getSessionsWithoutSummary', () => {
+  it('delegates to the event store without generating a rule-based summary', async () => {
+    const { service, store } = createService({
+      eventsBySession: { s: [] }
+    });
+    store.getSessionsWithoutSummary = vi.fn(async () => ['a', 'b']);
+
+    await expect(service.getSessionsWithoutSummary('current', 5)).resolves.toEqual(['a', 'b']);
+    expect(store.getSessionsWithoutSummary).toHaveBeenCalledWith('current', 5);
+  });
+});


### PR DESCRIPTION
## What happened

Re-measuring grounding after the F1/F2/F3 remediation (real usage since the F2-b cutover) turned up something the plan missed: sessions after the LLM summary path was deployed still sometimes got a table-of-contents summary — the exact "Session with N user prompts. Topics discussed: ..." shape F2-b exists to replace.

## Root cause

`SessionEnd` had its own, completely separate summary path that F2-b never touched:

```ts
const summary = generateSessionSummary(sessionEvents);   // turn-reconstructor's rule-based generator
await memoryService.storeSessionSummary(input.session_id, summary);  // unconditional — no existing-summary check
```

`Stop` already asks the daemon for an LLM summary in the background. Depending on timing, either hook could end up storing a `session_summary` event for the same session — and SessionEnd's had no guard to defer to Stop's, so it just added its own regardless.

## Fix

- `SessionEnd` no longer generates or stores a `session_summary` event. It still calls `endSession()` for the sessions-table bookkeeping (a separate, non-injectable column), evaluates helpfulness, and processes pending embeddings.
- The crash-recovery backfill in `session-start.ts` (for sessions that ended without `Stop` completing) had the identical defect: it called the same rule-based generator directly. It's now routed through `scheduleSessionSummary` — the same daemon-based LLM path `Stop` uses — via a new `getSessionsWithoutSummary` accessor, falling back to the rule-based path only when `CLAUDE_MEMORY_SUMMARY_MODE` explicitly disables the LLM path.

## Verification

Ran a full `Stop -> SessionEnd` cycle end to end: exactly one `session_summary` event, LLM-generated, no duplicate. 1082 tests pass (1 new), typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)