### PR TITLE
fix(dashboard): make memory usefulness metrics trustworthy

### DIFF
--- a/specs/dashboard-reliability-and-utilization/context.md
+++ b/specs/dashboard-reliability-and-utilization/context.md
@@ -18,7 +18,7 @@
 
 ### Delivered
 
-- helpfulness 통계의 `[since, until)` 조회와 KPI current/previous/daily 분리
+- helpfulness 통계의 `[since, until)` 조회와 KPI current/previous 분리, 인덱스 범위 기반 단일 daily 집계
 - outcome evidence가 없을 때 `score.value: null`, `status: insufficient-data`
 - 평가가 없는 Useful Recall KPI/일별 추세를 unavailable로 처리하고 임계치 경고에서 제외
 - Global Store / Stored Sessions 의미 정정
@@ -29,7 +29,7 @@
 ### Verification results
 
 - targeted Vitest: 6 files, 38 tests passed
-- full Vitest: 172 files, 1,090 tests passed
+- full Vitest: 172 files, 1,091 tests passed
 - TypeScript typecheck: passed
 - ESLint: 0 errors, 기존 경고 44개
 - build: passed

--- a/specs/dashboard-reliability-and-utilization/context.md
+++ b/specs/dashboard-reliability-and-utilization/context.md
@@ -1,0 +1,46 @@
+# Implementation Context
+
+## Baseline findings
+
+- 선택 프로젝트 store: 840 events, 184 vectors, 3 stored sessions
+- 검색 35회 중 selection이 있는 query 31회
+- helpful evaluation 76건 중 helpful 9건(11.8%)
+- 평균 content grounding 12%
+- global store는 4 events지만 UI는 전체 프로젝트 합계처럼 표시
+- Useful Recall KPI current/previous/daily가 동일 all-time 값을 공유
+- global scope에서 결과 평가가 없어도 복합 점수 75 / good이 표시될 수 있음
+- 프로젝트 디렉터리 81개 중 backup/unknown/zero-byte 항목이 선택기에 섞임
+- 390px viewport에서 document 폭이 679px로 확장됨
+
+## Implementation status
+
+완료.
+
+### Delivered
+
+- helpfulness 통계의 `[since, until)` 조회와 KPI current/previous/daily 분리
+- outcome evidence가 없을 때 `score.value: null`, `status: insufficient-data`
+- 평가가 없는 Useful Recall KPI/일별 추세를 unavailable로 처리하고 임계치 경고에서 제외
+- Global Store / Stored Sessions 의미 정정
+- valid hash + non-empty SQLite 프로젝트 필터
+- `.aplus/worktrees` 별칭에서 main checkout 대표 경로 추론
+- 600px 이하 header/search/usefulness 세로 레이아웃 및 overflow 방지
+
+### Verification results
+
+- targeted Vitest: 6 files, 38 tests passed
+- full Vitest: 172 files, 1,090 tests passed
+- TypeScript typecheck: passed
+- ESLint: 0 errors, 기존 경고 44개
+- build: passed
+- dashboard smoke: passed
+- live project API: 71개 모두 valid hash + non-empty DB, 현재 저장소는 `claude-memory-layer`로 정규화
+- desktop browser: Global Store, Stored Sessions, insufficient-data 표시 확인
+- 390px rendering context: viewport 390px, document 384px, horizontal overflow 없음; header/usefulness column 확인
+- browser console: desktop/mobile 모두 log error 없음
+
+## Deferred follow-ups
+
+- 실제 all-project aggregate view가 필요하면 별도 집계 API/semantic definition으로 설계한다.
+- L2~L4, lessons/actions/graph/perspective가 0인 원인은 projector 활성화/운영 흐름 관점의 별도 작업으로 다룬다.
+- 장기 실행 MCP의 project hash/version parity는 전역 프로세스 재시작 권한과 함께 별도 운영 작업으로 다룬다.

--- a/specs/dashboard-reliability-and-utilization/plan.md
+++ b/specs/dashboard-reliability-and-utilization/plan.md
@@ -1,0 +1,29 @@
+# Implementation Plan
+
+## Phase 1 — Measurement correctness
+
+- [x] SQLite helpfulness 통계에 upper bound 추가
+- [x] service/interface 시그니처 전파
+- [x] KPI current/previous/daily 기간별 helpfulness 계산
+- [x] 기간 계산 API 테스트 추가
+
+## Phase 2 — Honest status and scope
+
+- [x] 결과 평가가 없는 usefulness를 insufficient-data로 반환
+- [x] Overview/Usefulness UI의 insufficient-data 렌더링
+- [x] Global Store 라벨과 설명 정정
+- [x] Stored Sessions 라벨 정정
+
+## Phase 3 — Project hygiene and mobile UX
+
+- [x] 유효 hash + non-empty DB 프로젝트만 노출
+- [x] 동일 hash registry 대표 경로 선택 개선
+- [x] 390px 모바일 가로 overflow 제거
+- [x] API/UI/CSS 회귀 테스트 추가
+
+## Phase 4 — Verification
+
+- [x] targeted tests
+- [x] full tests / typecheck / build
+- [x] dashboard smoke
+- [x] desktop/mobile browser QA 및 console 확인

--- a/specs/dashboard-reliability-and-utilization/spec.md
+++ b/specs/dashboard-reliability-and-utilization/spec.md
@@ -1,0 +1,95 @@
+# Dashboard Reliability & Memory Utilization Spec
+
+## Overview
+
+현재 대시보드는 프로젝트 메모리의 저장·검색 활동을 보여주지만, 일부 라벨과 계산이 실제 데이터 범위와 일치하지 않는다. 특히 Global 선택은 전체 프로젝트 합계처럼 보이나 실제로는 global store만 읽고, Useful Recall KPI는 기간과 무관한 누적 값을 재사용하며, 평가 근거가 없는 복합 점수도 `good`으로 표시될 수 있다.
+
+이 개선은 대시보드를 "상태를 보는 화면"에서 "측정 결과를 신뢰하고 다음 행동을 고르는 화면"으로 만드는 첫 단계다.
+
+## Goals
+
+1. 화면에 표시되는 scope와 실제 조회 storage scope를 일치시킨다.
+2. KPI의 현재 기간, 이전 기간, 일별 추세가 각각 동일 기간의 helpfulness 자료를 사용하게 한다.
+3. 결과 평가가 없는 경우 복합 점수를 수치/등급으로 단정하지 않는다.
+4. 프로젝트 선택기에 유효하고 읽을 데이터가 있는 프로젝트만 노출한다.
+5. 모바일 화면에서 가로 스크롤 없이 핵심 카드와 검색/새로고침을 사용할 수 있게 한다.
+6. sessions 지표가 활성 세션이 아니라 저장된 고유 세션 수임을 명확히 한다.
+
+## Non-goals
+
+- Global store와 모든 project-local store를 합산하는 새 집계 저장소 구현
+- L2~L4 graduation, lesson/action/graph projector 활성화 정책 변경
+- 사용자 Claude 설치를 재시작하거나 전역 플러그인을 재설치하는 작업
+- 기존 메모리 데이터 삭제 또는 마이그레이션
+
+## User Stories
+
+### US-1 정확한 범위 이해
+
+사용자는 Global Store와 프로젝트별 store가 다른 데이터 소스임을 선택기와 scope 안내에서 즉시 이해할 수 있다.
+
+### US-2 기간에 맞는 KPI
+
+사용자는 24h/7d/30d를 바꿀 때 Useful Recall Rate의 현재값, 이전 기간 대비 변화, 일별 추세가 실제 해당 기간 평가만 반영한다고 신뢰할 수 있다.
+
+### US-3 근거 부족 상태
+
+사용자는 평가 데이터가 없으면 `good/low` 점수 대신 `Insufficient data` 상태를 보고, 더 많은 평가가 필요함을 이해할 수 있다.
+
+### US-4 정돈된 프로젝트 선택
+
+사용자는 백업 폴더, 잘못된 hash, 비어 있는 DB 없이 실제 조회 가능한 프로젝트만 선택할 수 있다. 같은 저장소의 main checkout/worktree 별칭은 대표 경로 하나로 표시된다.
+
+### US-5 모바일 사용
+
+사용자는 390px 폭에서도 페이지 전체가 가로로 밀리지 않고 헤더, 검색, 카드, usefulness strip을 사용할 수 있다.
+
+## Acceptance Criteria
+
+### Scope
+
+- 빈 project query는 기존 global store를 계속 읽는다.
+- UI 기본 옵션은 `Global Store`로 표시한다.
+- `All projects`, `Global aggregate`처럼 합산을 암시하는 문구가 남지 않는다.
+- Global Store가 비어 있으면 프로젝트 선택 안내를 유지한다.
+
+### KPI windowing
+
+- helpfulness 통계 API 내부 조회는 `since`와 선택적 `until`을 지원한다.
+- KPI current/previous/day bucket은 각기 다른 `[since, until)` 범위를 사용한다.
+- Useful Recall delta와 trend는 all-time 상수를 재사용하지 않는다.
+- 평가가 없는 current/previous/day bucket은 측정된 0으로 취급하지 않고 unavailable로 표시한다.
+- 기존 `since` 단독 호출은 호환된다.
+
+### Usefulness evidence
+
+- `totalEvaluated === 0`이고 `contentEvaluated === 0`이면 `score.value`는 `null`, `label`은 `unknown`, `status`는 `insufficient-data`다.
+- Overview와 Usefulness UI는 이 상태에서 숫자 `0` 또는 높은 복합 점수를 표시하지 않는다.
+- 평가 자료가 있는 기존 score 계산과 등급은 유지한다.
+
+### Project list
+
+- `/api/projects`는 8자리 소문자 hex 디렉터리만 고려한다.
+- `events.sqlite`가 존재하고 크기가 0보다 큰 프로젝트만 반환한다.
+- 동일 hash의 registry 경로는 main checkout을 우선하고, 그다음 최근 등록 경로를 선택한다.
+- API 응답은 기존처럼 원시 DB 경로나 세션 ID를 노출하지 않는다.
+
+### Mobile and labels
+
+- 600px 이하에서 main content와 header children이 viewport 너비를 넘지 않는다.
+- header actions와 usefulness strip은 세로/줄바꿈 레이아웃을 사용한다.
+- `Active Sessions`는 `Stored Sessions`로 변경한다.
+
+## Technical Constraints
+
+- SQLite WAL/read-only dashboard 동작을 유지한다.
+- dashboard API는 lightweight service를 계속 사용한다.
+- 기존 REST 응답 필드는 가능한 한 유지하고, 새 상태 필드는 추가형으로 제공한다.
+- 사용자 전역 설정과 `~/.claude/settings.json`은 수정하지 않는다.
+
+## Verification
+
+- 관련 Vitest 단위/API/UI 테스트
+- 전체 테스트와 TypeScript/build 검증
+- dashboard smoke test
+- 실제 브라우저 desktop/mobile 레이아웃 및 console 검증

--- a/src/apps/dashboard/assets/js/bootstrap.js
+++ b/src/apps/dashboard/assets/js/bootstrap.js
@@ -61,9 +61,9 @@ function updateProjectScopeUI() {
     return;
   }
 
-  if (label) label.textContent = 'Scope: All projects';
-  if (detail) detail.textContent = 'Global aggregate view. Select a project for live project-local sessions and retrieval evidence.';
-  if (disclosureBadge) disclosureBadge.textContent = 'Search → Expand → Source · Global scope unless a project is selected';
+  if (label) label.textContent = 'Scope: Global Store';
+  if (detail) detail.textContent = 'Unscoped shared/global memory store only. Select a project for project-local sessions and retrieval evidence.';
+  if (disclosureBadge) disclosureBadge.textContent = 'Search → Expand → Source · Global Store unless a project is selected';
   if (empty) empty.hidden = !(eventCount === 0 && sessionCount === 0 && vectorCount === 0);
 }
 
@@ -315,4 +315,3 @@ function setupEventListeners() {
 }
 
 // --- Data Fetching ---
-

--- a/src/apps/dashboard/assets/js/chat.js
+++ b/src/apps/dashboard/assets/js/chat.js
@@ -198,7 +198,7 @@ function updateChatProjectScope() {
     const proj = state.projects.find(p => p.hash === state.currentProject);
     el.textContent = `Scope: ${proj?.projectName || state.currentProject}`;
   } else {
-    el.textContent = 'Scope: All (Global)';
+    el.textContent = 'Scope: Global Store';
   }
 }
 
@@ -388,4 +388,3 @@ function renderMarkdown(text) {
 
   return html;
 }
-

--- a/src/apps/dashboard/assets/js/modals.js
+++ b/src/apps/dashboard/assets/js/modals.js
@@ -147,7 +147,7 @@ async function showEventsListModal() {
 }
 
 async function showSessionsModal() {
-  document.getElementById('list-modal-title').textContent = 'Active Sessions';
+  document.getElementById('list-modal-title').textContent = 'Stored Sessions';
   const body = document.getElementById('list-modal-body');
   body.innerHTML = '<div style="text-align:center; padding:40px; color:var(--text-muted);">Loading sessions...</div>';
   openModal('list-modal');
@@ -316,4 +316,3 @@ function showVectorsModal() {
 // =============================================
 // Sidebar Navigation
 // =============================================
-

--- a/src/apps/dashboard/assets/js/overview.js
+++ b/src/apps/dashboard/assets/js/overview.js
@@ -289,6 +289,9 @@ function updateKpiCardsUI() {
   const usefulRecallAvailable = usefulRecallAvailability
     ? usefulRecallAvailability.currentAvailable === true
     : true;
+  const previousUsefulRecallAvailable = usefulRecallAvailability
+    ? usefulRecallAvailability.previousAvailable === true
+    : d?.usefulRecallRate !== null && d?.usefulRecallRate !== undefined;
   set('kpi-useful-recall', usefulRecallAvailable ? percentText(m.usefulRecallRate) : '-');
   set('kpi-completion-turns', Number(m.avgCompletionTurns || 0).toFixed(2));
   set('kpi-rework-rate', percentText(m.reworkRate));
@@ -301,7 +304,9 @@ function updateKpiCardsUI() {
       const recallDelta = document.getElementById('kpi-useful-recall-delta');
       if (recallDelta) {
         recallDelta.className = 'kpi-delta neutral';
-        recallDelta.textContent = 'No evaluated recalls';
+        recallDelta.textContent = usefulRecallAvailable && !previousUsefulRecallAvailable
+          ? 'No prior-window evaluations'
+          : 'No evaluated recalls';
       }
     }
     renderDelta('kpi-completion-turns-delta', d.avgCompletionTurns, true, false);

--- a/src/apps/dashboard/assets/js/overview.js
+++ b/src/apps/dashboard/assets/js/overview.js
@@ -96,7 +96,7 @@ function updateProjectDetailUI() {
     </div>
     <div class="stats-grid kpi-grid" style="margin-top:0; margin-bottom:14px;">
       <div class="stat-card kpi-card"><div class="stat-value">${formatNumber(storage.eventCount || 0)} events</div><div class="stat-label"><i class="ri-file-list-3-line"></i> total</div></div>
-      <div class="stat-card kpi-card"><div class="stat-value">${formatNumber(sessions.total || 0)} sessions</div><div class="stat-label"><i class="ri-discuss-line"></i> active</div></div>
+      <div class="stat-card kpi-card"><div class="stat-value">${formatNumber(sessions.total || 0)} sessions</div><div class="stat-label"><i class="ri-discuss-line"></i> stored</div></div>
       <div class="stat-card kpi-card"><div class="stat-value">${formatNumber(storage.vectorCount || 0)} vectors</div><div class="stat-label"><i class="ri-node-tree"></i> indexed</div></div>
       <div class="stat-card kpi-card"><div class="stat-value">${formatNumber(retrieval.totalQueries || 0)}</div><div class="stat-label"><i class="ri-search-eye-line"></i> ${selectionRate}</div></div>
     </div>
@@ -285,13 +285,25 @@ function updateKpiCardsUI() {
     const el = document.getElementById(id);
     if (el) el.textContent = value;
   };
-  set('kpi-useful-recall', percentText(m.usefulRecallRate));
+  const usefulRecallAvailability = state.kpi?.availability?.usefulRecallRate;
+  const usefulRecallAvailable = usefulRecallAvailability
+    ? usefulRecallAvailability.currentAvailable === true
+    : true;
+  set('kpi-useful-recall', usefulRecallAvailable ? percentText(m.usefulRecallRate) : '-');
   set('kpi-completion-turns', Number(m.avgCompletionTurns || 0).toFixed(2));
   set('kpi-rework-rate', percentText(m.reworkRate));
   set('kpi-failure-rate', percentText(m.postChangeFailureRate));
 
   if (d) {
-    renderDelta('kpi-useful-recall-delta', d.usefulRecallRate, false, true);
+    if (usefulRecallAvailable && d.usefulRecallRate !== null && d.usefulRecallRate !== undefined) {
+      renderDelta('kpi-useful-recall-delta', d.usefulRecallRate, false, true);
+    } else {
+      const recallDelta = document.getElementById('kpi-useful-recall-delta');
+      if (recallDelta) {
+        recallDelta.className = 'kpi-delta neutral';
+        recallDelta.textContent = 'No evaluated recalls';
+      }
+    }
     renderDelta('kpi-completion-turns-delta', d.avgCompletionTurns, true, false);
     renderDelta('kpi-rework-rate-delta', d.reworkRate, true, true);
     renderDelta('kpi-failure-rate-delta', d.postChangeFailureRate, true, true);
@@ -314,7 +326,9 @@ function renderKpiTrendChart() {
 
   const daily = state.kpi?.trend?.daily || [];
   const categories = daily.map(d => d.date);
-  const useful = daily.map(d => Number(d.usefulRecallRate || 0) * 100);
+  const useful = daily.map(d => d.usefulRecallRate === null || d.usefulRecallRate === undefined
+    ? null
+    : Number(d.usefulRecallRate) * 100);
   const rework = daily.map(d => Number(d.reworkRate || 0) * 100);
   const fail = daily.map(d => Number(d.postChangeFailureRate || 0) * 100);
 
@@ -1121,12 +1135,13 @@ function updateMemoryUsefulnessUI() {
   const score = payload.score || {};
   const counts = payload.counts || {};
   const label = score.label || 'unknown';
+  const insufficient = score.status === 'insufficient-data' || score.value === null || score.value === undefined;
   const confidencePct = ((score.confidence || 0) * 100).toFixed(0);
-  scoreEl.textContent = Number(score.value || 0).toFixed(1).replace(/\.0$/, '');
+  scoreEl.textContent = insufficient ? '-' : Number(score.value).toFixed(1).replace(/\.0$/, '');
   scoreEl.className = `memory-usefulness-score score-${label}`;
 
   summaryEl.innerHTML = `
-    <span class="usefulness-pill usefulness-${escapeHtml(label)}">${escapeHtml(label)}</span>
+    <span class="usefulness-pill usefulness-${escapeHtml(label)}">${insufficient ? 'insufficient data' : escapeHtml(label)}</span>
     <span><strong>${formatNumber(counts.retrievalQueries || 0)}</strong> queries</span>
     <span><strong>${formatNumber(counts.rewrittenQueries || 0)}</strong> rewritten</span>
     <span><strong>${formatNumber(counts.promptCount || 0)}</strong> prompts</span>
@@ -1493,4 +1508,3 @@ async function checkEndlessStatus() {
 // =============================================
 // Modal System
 // =============================================
-

--- a/src/apps/dashboard/assets/js/usefulness.js
+++ b/src/apps/dashboard/assets/js/usefulness.js
@@ -210,19 +210,22 @@ function updateOverviewUsefulnessStrip() {
   const metrics = payload.metrics || {};
   const counts = payload.counts || {};
   const label = score.label || 'unknown';
-  scoreEl.textContent = Number(score.value || 0).toFixed(1).replace(/\.0$/, '');
+  const insufficient = score.status === 'insufficient-data' || score.value === null || score.value === undefined;
+  scoreEl.textContent = insufficient ? '-' : Number(score.value).toFixed(1).replace(/\.0$/, '');
   scoreEl.className = `memory-usefulness-score score-${label}`;
 
   const topDiagnostic = (payload.diagnostics || [])[0];
-  noteEl.textContent = topDiagnostic
+  noteEl.textContent = insufficient
+    ? 'Insufficient outcome evidence — evaluate retrieved memories before interpreting this score.'
+    : topDiagnostic
     ? topDiagnostic.title
     : `Memory is ${label} in the last ${payload.window || 'window'} — open Usefulness for per-question evidence.`;
 
   if (metricsEl) {
-    const pct = (v) => v === undefined || v === null ? 'n/a' : `${(v * 100).toFixed(0)}%`;
+    const pct = (v, available = true) => !available || v === undefined || v === null ? 'n/a' : `${(v * 100).toFixed(0)}%`;
     metricsEl.innerHTML = `
-      <span title="Average of measured helpfulness scores"><strong>${pct(metrics.avgHelpfulnessScore)}</strong> helpfulness</span>
-      <span title="How much injected memory content reappears in answers"><strong>${pct(metrics.contentGroundingRate)}</strong> grounding</span>
+      <span title="Average of measured helpfulness scores"><strong>${pct(metrics.avgHelpfulnessScore, !insufficient)}</strong> helpfulness</span>
+      <span title="How much injected memory content reappears in answers"><strong>${pct(metrics.contentGroundingRate, !insufficient)}</strong> grounding</span>
       <span title="Share of prompts that ran a memory check"><strong>${pct(metrics.memoryHitRate)}</strong> hit rate</span>
       <span><strong>${formatNumber(counts.retrievalQueries || 0)}</strong> queries</span>
     `;

--- a/src/apps/dashboard/index.html
+++ b/src/apps/dashboard/index.html
@@ -33,13 +33,13 @@
       <div class="project-selector">
         <label class="project-label"><i class="ri-folder-line"></i> Project</label>
         <select id="project-select" class="project-dropdown">
-          <option value="">All (Global)</option>
+          <option value="">Global Store</option>
         </select>
       </div>
 
       <div id="scope-context-bar" class="scope-context-bar">
-        <div id="scope-context-label" class="scope-context-label">Scope: All projects</div>
-        <div id="scope-context-detail" class="scope-context-detail">Select a project to inspect project-local memory.</div>
+        <div id="scope-context-label" class="scope-context-label">Scope: Global Store</div>
+        <div id="scope-context-detail" class="scope-context-detail">Unscoped shared/global memory only. Select a project to inspect its local memory.</div>
       </div>
 
       <nav>
@@ -146,7 +146,7 @@
           <div class="stat-card" data-stat="sessions">
             <div class="stat-value" id="stat-sessions">0</div>
             <div class="stat-label">
-              <i class="ri-discuss-line"></i> Active Sessions
+              <i class="ri-discuss-line"></i> Stored Sessions
             </div>
           </div>
           <div class="stat-card" data-stat="retrieval">

--- a/src/apps/dashboard/style.css
+++ b/src/apps/dashboard/style.css
@@ -73,6 +73,7 @@ body {
 .app-container {
   display: flex;
   min-height: 100vh;
+  min-width: 0;
 }
 
 /* Sidebar */
@@ -953,6 +954,43 @@ body {
 }
 
 @media (max-width: 600px) {
+  .app-container,
+  .main-content,
+  .page-view,
+  .card {
+    min-width: 0;
+    max-width: 100%;
+  }
+  .main-content {
+    width: 100%;
+    padding: 16px;
+    overflow-x: hidden;
+  }
+  .top-header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 16px;
+    margin-bottom: 24px;
+  }
+  .header-actions {
+    width: 100%;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+  .search-wrapper {
+    width: 100% !important;
+    min-width: 0;
+  }
+  .usefulness-strip {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .usefulness-strip-score {
+    align-items: flex-start;
+  }
+  .usefulness-strip-cta {
+    justify-content: flex-end;
+  }
   .stats-grid {
     grid-template-columns: 1fr;
   }

--- a/src/apps/server/api/projects.ts
+++ b/src/apps/server/api/projects.ts
@@ -106,17 +106,29 @@ projectsRouter.get('/', async (c) => {
     const projectHashes = fs.readdirSync(projectsDir)
       .filter(name => {
         const fullPath = path.join(projectsDir, name);
-        return fs.statSync(fullPath).isDirectory();
+        if (!/^[a-f0-9]{8}$/.test(name)) return false;
+        try {
+          const dbPath = path.join(fullPath, 'events.sqlite');
+          return fs.statSync(fullPath).isDirectory()
+            && fs.statSync(dbPath).isFile()
+            && fs.statSync(dbPath).size > 0;
+        } catch {
+          return false;
+        }
       });
 
     // Load session registry to map hashes to project paths
     const registry = loadSessionRegistry();
-    const hashToPath = new Map<string, string>();
+    const hashToEntries = new Map<string, Array<{ projectPath: string; registeredAt?: string }>>();
     for (const entry of Object.values(registry.sessions)) {
-      if (!hashToPath.has(entry.projectHash)) {
-        hashToPath.set(entry.projectHash, entry.projectPath);
-      }
+      const entries = hashToEntries.get(entry.projectHash) || [];
+      entries.push(entry);
+      hashToEntries.set(entry.projectHash, entries);
     }
+    const hashToPath = new Map(Array.from(hashToEntries.entries()).map(([hash, entries]) => [
+      hash,
+      selectPreferredProjectPath(entries)
+    ]));
 
     // Build project list
     const projects = projectHashes.map(hash => {
@@ -148,12 +160,28 @@ projectsRouter.get('/', async (c) => {
 });
 
 function getRegisteredProjectPath(registry: ReturnType<typeof loadSessionRegistry>, hash: string): string | undefined {
-  for (const entry of Object.values(registry.sessions)) {
-    if (entry.projectHash === hash) {
-      return entry.projectPath;
-    }
-  }
-  return undefined;
+  const entries = Object.values(registry.sessions).filter((entry) => entry.projectHash === hash);
+  return entries.length > 0 ? selectPreferredProjectPath(entries) : undefined;
+}
+
+export function selectPreferredProjectPath(entries: Array<{ projectPath: string; registeredAt?: string }>): string {
+  const selected = [...entries].sort((a, b) => {
+    const aWorktree = /[\\/](?:\.aplus[\\/]worktrees|worktrees)[\\/]/.test(a.projectPath) ? 1 : 0;
+    const bWorktree = /[\\/](?:\.aplus[\\/]worktrees|worktrees)[\\/]/.test(b.projectPath) ? 1 : 0;
+    if (aWorktree !== bWorktree) return aWorktree - bWorktree;
+    const registeredDelta = Date.parse(b.registeredAt || '') - Date.parse(a.registeredAt || '');
+    if (Number.isFinite(registeredDelta) && registeredDelta !== 0) return registeredDelta;
+    return a.projectPath.length - b.projectPath.length;
+  })[0]?.projectPath || '';
+  const inferredCanonicalPath = inferCanonicalProjectPath(selected);
+  return inferredCanonicalPath !== selected && fs.existsSync(inferredCanonicalPath)
+    ? inferredCanonicalPath
+    : selected;
+}
+
+export function inferCanonicalProjectPath(projectPath: string): string {
+  const marker = projectPath.match(/[\\/]\.aplus[\\/]worktrees[\\/]/);
+  return marker?.index === undefined ? projectPath : projectPath.slice(0, marker.index);
 }
 
 function summarizeProjectEvents(events: ProjectDetailEvent[]) {

--- a/src/apps/server/api/stats.ts
+++ b/src/apps/server/api/stats.ts
@@ -1245,6 +1245,7 @@ function computeMemoryUsefulnessSummary(
     : 0;
   const scoreValue = round(weightedScore * 100, 1);
   const confidence = round(safeRatio(availableWeight, totalWeight), 2);
+  const hasOutcomeEvidence = totalEvaluated > 0 || contentEvaluated > 0;
   const components = componentSpecs.map((component) => ({
     ...component,
     contribution: component.available ? round(component.value * component.weight * 100, 2) : 0
@@ -1253,9 +1254,10 @@ function computeMemoryUsefulnessSummary(
   return {
     window,
     score: {
-      value: scoreValue,
-      label: usefulnessScoreLabel(scoreValue, confidence),
-      confidence
+      value: hasOutcomeEvidence ? scoreValue : null,
+      label: hasOutcomeEvidence ? usefulnessScoreLabel(scoreValue, confidence) : 'unknown',
+      confidence,
+      ...(hasOutcomeEvidence ? {} : { status: 'insufficient-data' as const })
     },
     metrics,
     counts,
@@ -1999,22 +2001,36 @@ statsRouter.get('/kpi', async (c) => {
     const allEvents = await memoryService.getEventsAfter(new Date(now - lookbackMs).toISOString());
     const events = allEvents.filter((e) => inWindow(e, now, window));
 
-    const helpfulness = await memoryService.getHelpfulnessStats();
-    const usefulRecallRate = helpfulness.totalEvaluated > 0
-      ? round(safeRatio(helpfulness.helpful, helpfulness.totalEvaluated))
+    const windowMs = windowToMs(window);
+    const currentStart = new Date(now - windowMs);
+    const currentEnd = new Date(now);
+    const previousStart = new Date(now - windowMs * 2);
+    const previousEnd = currentStart;
+    const [currentHelpfulness, previousHelpfulness] = await Promise.all([
+      memoryService.getHelpfulnessStats(currentStart, currentEnd),
+      memoryService.getHelpfulnessStats(previousStart, previousEnd)
+    ]);
+    const usefulRecallRate = currentHelpfulness.totalEvaluated > 0
+      ? round(safeRatio(currentHelpfulness.helpful, currentHelpfulness.totalEvaluated))
+      : 0;
+    const previousUsefulRecallRate = previousHelpfulness.totalEvaluated > 0
+      ? round(safeRatio(previousHelpfulness.helpful, previousHelpfulness.totalEvaluated))
       : 0;
 
     const metrics = computeKpiMetrics(events, usefulRecallRate);
 
-    const windowMs = windowToMs(window);
     const prevEvents = allEvents.filter((e) => {
       const age = now - e.timestamp.getTime();
       return age > windowMs && age <= windowMs * 2;
     });
-    const previousMetrics = computeKpiMetrics(prevEvents, usefulRecallRate);
+    const previousMetrics = computeKpiMetrics(prevEvents, previousUsefulRecallRate);
+    const currentUsefulRecallAvailable = currentHelpfulness.totalEvaluated > 0;
+    const previousUsefulRecallAvailable = previousHelpfulness.totalEvaluated > 0;
     const deltas = {
       memoryHitRate: round(metrics.memoryHitRate - previousMetrics.memoryHitRate),
-      usefulRecallRate: round(metrics.usefulRecallRate - previousMetrics.usefulRecallRate),
+      usefulRecallRate: currentUsefulRecallAvailable && previousUsefulRecallAvailable
+        ? round(metrics.usefulRecallRate - previousMetrics.usefulRecallRate)
+        : null,
       avgCompletionTurns: round(metrics.avgCompletionTurns - previousMetrics.avgCompletionTurns, 2),
       timeToFirstValidEditMinutes: round(metrics.timeToFirstValidEditMinutes - previousMetrics.timeToFirstValidEditMinutes, 2),
       reworkRate: round(metrics.reworkRate - previousMetrics.reworkRate),
@@ -2034,9 +2050,21 @@ statsRouter.get('/kpi', async (c) => {
       buckets.set(day, arr);
     }
 
-    const trendDaily = Array.from(buckets.entries())
-      .sort((a, b) => a[0].localeCompare(b[0]))
+    const trendEntries = Array.from(buckets.entries())
+      .sort((a, b) => a[0].localeCompare(b[0]));
+    const trendHelpfulness = new Map(await Promise.all(trendEntries.map(async ([date]) => {
+      const dayStart = new Date(`${date}T00:00:00.000Z`);
+      const dayEnd = new Date(dayStart.getTime() + 24 * 60 * 60 * 1000);
+      const stats = await memoryService.getHelpfulnessStats(dayStart, dayEnd);
+      return [date, stats] as const;
+    })));
+
+    const trendDaily = trendEntries
       .map(([date, dayEvents]) => {
+        const dayHelpfulness = trendHelpfulness.get(date);
+        const dayUsefulRecallRate = dayHelpfulness && dayHelpfulness.totalEvaluated > 0
+          ? round(safeRatio(dayHelpfulness.helpful, dayHelpfulness.totalEvaluated))
+          : null;
         const dayPrompts = dayEvents.filter((e) => e.eventType === 'user_prompt');
         const dayPromptCount = dayPrompts.length;
         const dayMemoryHit = dayPrompts.filter((p) => (p.metadata as any)?.adherence?.checked).length;
@@ -2088,7 +2116,7 @@ statsRouter.get('/kpi', async (c) => {
         return {
           date,
           memoryHitRate: round(safeRatio(dayMemoryHit, dayPromptCount)),
-          usefulRecallRate,
+          usefulRecallRate: dayUsefulRecallRate,
           reworkRate: round(safeRatio(dayReworkCount, dayEditActions.length)),
           postChangeFailureRate: round(safeRatio(dayFailedTests.length, dayTests.length)),
           avgCompletionTurns: round(safeRatio(dayTurnsTotal, dayTurnsSamples), 2)
@@ -2096,7 +2124,7 @@ statsRouter.get('/kpi', async (c) => {
       });
 
     const alerts: Array<{ metric: string; level: 'warn'; message: string; value: number; threshold: number }> = [];
-    if (metrics.usefulRecallRate < thresholds.usefulRecallRateMin) {
+    if (currentUsefulRecallAvailable && metrics.usefulRecallRate < thresholds.usefulRecallRateMin) {
       alerts.push({ metric: 'usefulRecallRate', level: 'warn', message: 'Useful recall rate is below threshold', value: metrics.usefulRecallRate, threshold: thresholds.usefulRecallRateMin });
     }
     if (metrics.reworkRate > thresholds.reworkRateMax) {
@@ -2117,6 +2145,14 @@ statsRouter.get('/kpi', async (c) => {
       metrics,
       previousMetrics,
       deltas,
+      availability: {
+        usefulRecallRate: {
+          currentEvaluated: currentHelpfulness.totalEvaluated,
+          previousEvaluated: previousHelpfulness.totalEvaluated,
+          currentAvailable: currentUsefulRecallAvailable,
+          previousAvailable: previousUsefulRecallAvailable
+        }
+      },
       trend: {
         daily: trendDaily
       },

--- a/src/apps/server/api/stats.ts
+++ b/src/apps/server/api/stats.ts
@@ -2052,12 +2052,15 @@ statsRouter.get('/kpi', async (c) => {
 
     const trendEntries = Array.from(buckets.entries())
       .sort((a, b) => a[0].localeCompare(b[0]));
-    const trendHelpfulness = new Map(await Promise.all(trendEntries.map(async ([date]) => {
-      const dayStart = new Date(`${date}T00:00:00.000Z`);
-      const dayEnd = new Date(dayStart.getTime() + 24 * 60 * 60 * 1000);
-      const stats = await memoryService.getHelpfulnessStats(dayStart, dayEnd);
-      return [date, stats] as const;
-    })));
+    const trendStart = new Date(now - trendWindowMs);
+    trendStart.setUTCHours(0, 0, 0, 0);
+    const trendEnd = new Date(now);
+    trendEnd.setUTCHours(0, 0, 0, 0);
+    trendEnd.setUTCDate(trendEnd.getUTCDate() + 1);
+    const trendHelpfulness = new Map(
+      (await memoryService.getHelpfulnessStatsByDay(trendStart, trendEnd))
+        .map((stats) => [stats.date, stats] as const)
+    );
 
     const trendDaily = trendEntries
       .map(([date, dayEvents]) => {

--- a/src/core/engine/retrieval-analytics-service.ts
+++ b/src/core/engine/retrieval-analytics-service.ts
@@ -53,6 +53,16 @@ export interface HelpfulnessStats {
   groundedCount?: number;
 }
 
+export interface DailyHelpfulnessStats {
+  date: string;
+  avgScore: number;
+  totalEvaluated: number;
+  totalRetrievals: number;
+  helpful: number;
+  neutral: number;
+  unhelpful: number;
+}
+
 export interface UsefulnessEvidenceMatch {
   memorySnippet: string;
   responseSnippet: string;
@@ -153,6 +163,7 @@ export interface RetrievalAnalyticsStore {
   getUnevaluatedSessions(currentSessionId: string, limit?: number): Promise<string[]>;
   getHelpfulMemories(limit?: number): Promise<HelpfulMemory[]>;
   getHelpfulnessStats(since?: Date, until?: Date): Promise<HelpfulnessStats>;
+  getHelpfulnessStatsByDay?(since: Date, until: Date): Promise<DailyHelpfulnessStats[]>;
   getUsefulnessHistory?(options?: UsefulnessHistoryOptions): Promise<UsefulnessHistoryEntry[]>;
 }
 
@@ -217,6 +228,11 @@ export class RetrievalAnalyticsService {
   async getHelpfulnessStats(since?: Date, until?: Date): Promise<HelpfulnessStats> {
     await this.deps.initialize();
     return this.deps.retrievalStore.getHelpfulnessStats(since, until);
+  }
+
+  async getHelpfulnessStatsByDay(since: Date, until: Date): Promise<DailyHelpfulnessStats[]> {
+    await this.deps.initialize();
+    return this.deps.retrievalStore.getHelpfulnessStatsByDay?.(since, until) || [];
   }
 
   /**

--- a/src/core/engine/retrieval-analytics-service.ts
+++ b/src/core/engine/retrieval-analytics-service.ts
@@ -152,7 +152,7 @@ export interface RetrievalAnalyticsStore {
   evaluateSessionHelpfulness(sessionId: string): Promise<void>;
   getUnevaluatedSessions(currentSessionId: string, limit?: number): Promise<string[]>;
   getHelpfulMemories(limit?: number): Promise<HelpfulMemory[]>;
-  getHelpfulnessStats(since?: Date): Promise<HelpfulnessStats>;
+  getHelpfulnessStats(since?: Date, until?: Date): Promise<HelpfulnessStats>;
   getUsefulnessHistory?(options?: UsefulnessHistoryOptions): Promise<UsefulnessHistoryEntry[]>;
 }
 
@@ -214,9 +214,9 @@ export class RetrievalAnalyticsService {
     return this.deps.retrievalStore.getHelpfulMemories(limit);
   }
 
-  async getHelpfulnessStats(since?: Date): Promise<HelpfulnessStats> {
+  async getHelpfulnessStats(since?: Date, until?: Date): Promise<HelpfulnessStats> {
     await this.deps.initialize();
-    return this.deps.retrievalStore.getHelpfulnessStats(since);
+    return this.deps.retrievalStore.getHelpfulnessStats(since, until);
   }
 
   /**

--- a/src/core/engine/retrieval-services.ts
+++ b/src/core/engine/retrieval-services.ts
@@ -141,6 +141,7 @@ export {
 } from './retrieval-analytics-service.js';
 export type {
   AccessedMemory,
+  DailyHelpfulnessStats,
   HelpfulMemory,
   HelpfulnessStats,
   RetrievalAnalyticsServiceDeps,

--- a/src/core/sqlite-event-store.ts
+++ b/src/core/sqlite-event-store.ts
@@ -2702,7 +2702,7 @@ export class SQLiteEventStore {
   /**
    * Get helpfulness statistics for dashboard
    */
-  async getHelpfulnessStats(since?: Date): Promise<{
+  async getHelpfulnessStats(since?: Date, until?: Date): Promise<{
     avgScore: number;
     totalEvaluated: number;
     totalRetrievals: number;
@@ -2716,12 +2716,21 @@ export class SQLiteEventStore {
     await this.initialize();
 
     const sinceIso = since?.toISOString();
-    const evaluatedWhere = sinceIso
-      ? `WHERE measured_at IS NOT NULL AND datetime(created_at) >= datetime(?)`
-      : `WHERE measured_at IS NOT NULL`;
-    const totalWhere = sinceIso
-      ? `WHERE datetime(created_at) >= datetime(?)`
-      : ``;
+    const untilIso = until?.toISOString();
+    const timeClauses: string[] = [];
+    const timeParams: string[] = [];
+    if (sinceIso) {
+      timeClauses.push('datetime(created_at) >= datetime(?)');
+      timeParams.push(sinceIso);
+    }
+    if (untilIso) {
+      timeClauses.push('datetime(created_at) < datetime(?)');
+      timeParams.push(untilIso);
+    }
+    const timeWhere = timeClauses.length > 0 ? `WHERE ${timeClauses.join(' AND ')}` : '';
+    const evaluatedWhere = timeClauses.length > 0
+      ? `WHERE measured_at IS NOT NULL AND ${timeClauses.join(' AND ')}`
+      : 'WHERE measured_at IS NOT NULL';
 
     // Read-only dashboards can open legacy DBs where the grounding-column
     // migration never ran; degrade to zeros instead of failing the query.
@@ -2743,13 +2752,13 @@ export class SQLiteEventStore {
          ${groundingSelect}
        FROM memory_helpfulness
        ${evaluatedWhere}`,
-      sinceIso ? [sinceIso] : []
+      timeParams
     );
 
     const totalRow = sqliteGet<Record<string, unknown>>(
       this.db,
-      `SELECT COUNT(*) as total FROM memory_helpfulness ${totalWhere}`,
-      sinceIso ? [sinceIso] : []
+      `SELECT COUNT(*) as total FROM memory_helpfulness ${timeWhere}`,
+      timeParams
     );
 
     return {

--- a/src/core/sqlite-event-store.ts
+++ b/src/core/sqlite-event-store.ts
@@ -2775,6 +2775,54 @@ export class SQLiteEventStore {
   }
 
   /**
+   * Aggregate helpfulness by UTC day with one range scan.
+   *
+   * Both legacy SQLite timestamps (`YYYY-MM-DD HH:mm:ss`) and current ISO
+   * timestamps share a sortable `YYYY-MM-DD` prefix. Date-only boundaries
+   * therefore preserve compatibility while allowing idx_helpfulness_created_at
+   * to serve the range predicate (unlike datetime(created_at)).
+   */
+  async getHelpfulnessStatsByDay(since: Date, until: Date): Promise<Array<{
+    date: string;
+    avgScore: number;
+    totalEvaluated: number;
+    totalRetrievals: number;
+    helpful: number;
+    neutral: number;
+    unhelpful: number;
+  }>> {
+    await this.initialize();
+    const sinceDay = since.toISOString().slice(0, 10);
+    const untilDay = until.toISOString().slice(0, 10);
+    const rows = sqliteAll<Record<string, unknown>>(
+      this.db,
+      `SELECT
+         substr(created_at, 1, 10) AS date,
+         AVG(CASE WHEN measured_at IS NOT NULL THEN helpfulness_score END) AS avg_score,
+         SUM(CASE WHEN measured_at IS NOT NULL THEN 1 ELSE 0 END) AS total_evaluated,
+         COUNT(*) AS total_retrievals,
+         SUM(CASE WHEN measured_at IS NOT NULL AND helpfulness_score >= 0.7 THEN 1 ELSE 0 END) AS helpful,
+         SUM(CASE WHEN measured_at IS NOT NULL AND helpfulness_score >= 0.4 AND helpfulness_score < 0.7 THEN 1 ELSE 0 END) AS neutral,
+         SUM(CASE WHEN measured_at IS NOT NULL AND helpfulness_score < 0.4 THEN 1 ELSE 0 END) AS unhelpful
+       FROM memory_helpfulness
+       WHERE created_at >= ? AND created_at < ?
+       GROUP BY substr(created_at, 1, 10)
+       ORDER BY date ASC`,
+      [sinceDay, untilDay]
+    );
+
+    return rows.map((row) => ({
+      date: String(row.date || ''),
+      avgScore: Math.round(((row.avg_score as number) || 0) * 100) / 100,
+      totalEvaluated: (row.total_evaluated as number) || 0,
+      totalRetrievals: (row.total_retrievals as number) || 0,
+      helpful: (row.helpful as number) || 0,
+      neutral: (row.neutral as number) || 0,
+      unhelpful: (row.unhelpful as number) || 0
+    }));
+  }
+
+  /**
    * Per-question usefulness history: each retrieval query (or session-start
    * injection batch) with the memories it injected, their measured
    * helpfulness, content grounding, and evidence snippets. Powers the

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -618,8 +618,8 @@ export class MemoryService {
   /**
    * Get helpfulness statistics for dashboard
    */
-  async getHelpfulnessStats(since?: Date): Promise<HelpfulnessStats> {
-    return this.retrievalAnalyticsService.getHelpfulnessStats(since);
+  async getHelpfulnessStats(since?: Date, until?: Date): Promise<HelpfulnessStats> {
+    return this.retrievalAnalyticsService.getHelpfulnessStats(since, until);
   }
 
   /**

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -55,6 +55,7 @@ import {
 import { createMemoryServiceRegistry } from './memory-service-registry.js';
 import {
   type AccessedMemory,
+  type DailyHelpfulnessStats,
   type HelpfulMemory,
   type HelpfulnessStats,
   type RecordQueryTraceInput,
@@ -620,6 +621,11 @@ export class MemoryService {
    */
   async getHelpfulnessStats(since?: Date, until?: Date): Promise<HelpfulnessStats> {
     return this.retrievalAnalyticsService.getHelpfulnessStats(since, until);
+  }
+
+  /** Get one aggregate per UTC day using a single indexed range query. */
+  async getHelpfulnessStatsByDay(since: Date, until: Date): Promise<DailyHelpfulnessStats[]> {
+    return this.retrievalAnalyticsService.getHelpfulnessStatsByDay(since, until);
   }
 
   /**

--- a/tests/apps/dashboard-project-detail-ui.test.ts
+++ b/tests/apps/dashboard-project-detail-ui.test.ts
@@ -81,6 +81,8 @@ describe('dashboard project detail card', () => {
     expect(card.innerHTML).toContain('shop-app');
     expect(card.innerHTML).toContain('42 events');
     expect(card.innerHTML).toContain('7 sessions');
+    expect(card.innerHTML).toContain('stored');
+    expect(card.innerHTML).not.toContain('> active<');
     expect(card.innerHTML).toContain('31 vectors');
     expect(card.innerHTML).toContain('37.0% selection');
     expect(card.innerHTML).toContain('3 pending');

--- a/tests/apps/dashboard-usefulness-stats.test.ts
+++ b/tests/apps/dashboard-usefulness-stats.test.ts
@@ -86,13 +86,14 @@ function loadOverviewWithElements(elements: Record<string, TestElement>, files =
     ? ', renderUsefulnessHistory, updateOverviewUsefulnessStrip'
     : '';
   vm.runInNewContext(
-    `${source}\n;globalThis.__dashboardTestHooks = { state, updateMemoryUsefulnessUI, updateRetrievalTraceUI${usefulnessHooks} };`,
+    `${source}\n;globalThis.__dashboardTestHooks = { state, updateMemoryUsefulnessUI, updateRetrievalTraceUI, updateKpiCardsUI${usefulnessHooks} };`,
     context
   );
   return (context as unknown as { __dashboardTestHooks: {
     state: Record<string, any>;
     updateMemoryUsefulnessUI: () => void;
     updateRetrievalTraceUI: () => void;
+    updateKpiCardsUI: () => void;
     renderUsefulnessHistory: () => void;
     updateOverviewUsefulnessStrip: () => void;
   }}).__dashboardTestHooks;
@@ -271,13 +272,13 @@ describe('dashboard memory usefulness stats', () => {
     mocks.service.getRecentRetrievalTraces.mockResolvedValue([]);
     const zeroRes = await createApp().request('/api/stats/usefulness?window=24h');
     const zeroBody = await zeroRes.json();
-    expect(zeroBody.score).toEqual({ value: 0, label: 'low', confidence: 0.3 });
+    expect(zeroBody.score).toEqual({ value: null, label: 'unknown', confidence: 0.3, status: 'insufficient-data' });
 
     mocks.service.getEventsAfter.mockResolvedValue([]);
     mocks.service.getRecentRetrievalTraces.mockResolvedValue([]);
     const emptyRes = await createApp().request('/api/stats/usefulness?window=24h');
     const emptyBody = await emptyRes.json();
-    expect(emptyBody.score).toEqual({ value: 0, label: 'unknown', confidence: 0 });
+    expect(emptyBody.score).toEqual({ value: null, label: 'unknown', confidence: 0, status: 'insufficient-data' });
   });
 
   it('returns per-question evidence history without rewritten query text', async () => {
@@ -855,6 +856,58 @@ describe('dashboard memory usefulness stats', () => {
     expect(elements['overview-usefulness-metrics'].innerHTML).toContain('55%');
     expect(elements['overview-usefulness-metrics'].innerHTML).toContain('42');
     expect(elements['overview-usefulness-note'].textContent).toContain('good');
+  });
+
+  it('renders insufficient outcome evidence without a misleading numeric score', () => {
+    const elements = {
+      'overview-usefulness-score': new TestElement(),
+      'overview-usefulness-note': new TestElement(),
+      'overview-usefulness-metrics': new TestElement(),
+    };
+    const hooks = loadOverviewWithElements(elements, ['state.js', 'views.js', 'overview.js', 'usefulness.js']);
+
+    hooks.state.memoryUsefulness = {
+      window: '7d',
+      score: { value: null, label: 'unknown', confidence: 0.4, status: 'insufficient-data' },
+      metrics: { memoryHitRate: 1, retrievalUsageRate: 1 },
+      counts: { retrievalQueries: 4, totalEvaluated: 0 },
+      diagnostics: [],
+    };
+
+    hooks.updateOverviewUsefulnessStrip();
+
+    expect(elements['overview-usefulness-score'].textContent).toBe('-');
+    expect(elements['overview-usefulness-score'].className).toContain('score-unknown');
+    expect(elements['overview-usefulness-note'].textContent).toContain('Insufficient outcome evidence');
+    expect(elements['overview-usefulness-metrics'].innerHTML).toContain('<strong>n/a</strong> helpfulness');
+    expect(elements['overview-usefulness-metrics'].innerHTML).toContain('<strong>n/a</strong> grounding');
+  });
+
+  it('renders unevaluated Useful Recall KPI as unavailable instead of zero percent', () => {
+    const elements = {
+      'kpi-useful-recall': new TestElement(),
+      'kpi-useful-recall-delta': new TestElement(),
+      'kpi-completion-turns': new TestElement(),
+      'kpi-rework-rate': new TestElement(),
+      'kpi-failure-rate': new TestElement(),
+      'kpi-completion-turns-delta': new TestElement(),
+      'kpi-rework-rate-delta': new TestElement(),
+      'kpi-failure-rate-delta': new TestElement(),
+      'kpi-alerts': new TestElement(),
+    };
+    const hooks = loadOverviewWithElements(elements);
+    hooks.state.kpi = {
+      metrics: { usefulRecallRate: 0, avgCompletionTurns: 1, reworkRate: 0, postChangeFailureRate: 0 },
+      deltas: { usefulRecallRate: null, avgCompletionTurns: 0, reworkRate: 0, postChangeFailureRate: 0 },
+      availability: { usefulRecallRate: { currentAvailable: false, previousAvailable: false } },
+      alerts: [],
+    };
+
+    hooks.updateKpiCardsUI();
+
+    expect(elements['kpi-useful-recall'].textContent).toBe('-');
+    expect(elements['kpi-useful-recall-delta'].textContent).toBe('No evaluated recalls');
+    expect(elements['kpi-alerts'].innerHTML).toContain('No KPI alerts');
   });
 
   it('renders the usefulness score and component percentages in the overview dashboard', () => {

--- a/tests/apps/dashboard-usefulness-stats.test.ts
+++ b/tests/apps/dashboard-usefulness-stats.test.ts
@@ -910,6 +910,32 @@ describe('dashboard memory usefulness stats', () => {
     expect(elements['kpi-alerts'].innerHTML).toContain('No KPI alerts');
   });
 
+  it('explains when only the prior Useful Recall window lacks evaluations', () => {
+    const elements = {
+      'kpi-useful-recall': new TestElement(),
+      'kpi-useful-recall-delta': new TestElement(),
+      'kpi-completion-turns': new TestElement(),
+      'kpi-rework-rate': new TestElement(),
+      'kpi-failure-rate': new TestElement(),
+      'kpi-completion-turns-delta': new TestElement(),
+      'kpi-rework-rate-delta': new TestElement(),
+      'kpi-failure-rate-delta': new TestElement(),
+      'kpi-alerts': new TestElement(),
+    };
+    const hooks = loadOverviewWithElements(elements);
+    hooks.state.kpi = {
+      metrics: { usefulRecallRate: 0.75, avgCompletionTurns: 1, reworkRate: 0, postChangeFailureRate: 0 },
+      deltas: { usefulRecallRate: null, avgCompletionTurns: 0, reworkRate: 0, postChangeFailureRate: 0 },
+      availability: { usefulRecallRate: { currentAvailable: true, previousAvailable: false } },
+      alerts: [],
+    };
+
+    hooks.updateKpiCardsUI();
+
+    expect(elements['kpi-useful-recall'].textContent).toBe('75.0%');
+    expect(elements['kpi-useful-recall-delta'].textContent).toBe('No prior-window evaluations');
+  });
+
   it('renders the usefulness score and component percentages in the overview dashboard', () => {
     const elements = {
       'memory-usefulness-score': new TestElement(),

--- a/tests/apps/dashboard-ux-shell.test.ts
+++ b/tests/apps/dashboard-ux-shell.test.ts
@@ -14,10 +14,14 @@ describe('dashboard UX shell affordances', () => {
 
   it('contains narrow-screen guards for header and usefulness layout', () => {
     const css = readFileSync(join(process.cwd(), 'src/apps/dashboard/style.css'), 'utf-8');
-    expect(css).toContain('@media (max-width: 600px)');
-    expect(css).toContain('.top-header {\n    flex-direction: column;');
-    expect(css).toContain('.search-wrapper {\n    width: 100% !important;');
-    expect(css).toContain('.usefulness-strip {\n    flex-direction: column;');
+    const mobileStart = css.indexOf('@media (max-width: 600px)');
+    const mobileEnd = css.indexOf('/* ==========================================', mobileStart);
+    expect(mobileStart).toBeGreaterThanOrEqual(0);
+    expect(mobileEnd).toBeGreaterThan(mobileStart);
+    const mobileCss = css.slice(mobileStart, mobileEnd);
+    expect(mobileCss).toMatch(/\.top-header\s*\{[^}]*flex-direction:\s*column/);
+    expect(mobileCss).toMatch(/\.search-wrapper\s*\{[^}]*width:\s*100%\s*!important/);
+    expect(mobileCss).toMatch(/\.usefulness-strip\s*\{[^}]*flex-direction:\s*column/);
   });
 
   it('declares global project scope context and empty-state containers in the dashboard shell', () => {

--- a/tests/apps/dashboard-ux-shell.test.ts
+++ b/tests/apps/dashboard-ux-shell.test.ts
@@ -4,6 +4,22 @@ import { join } from 'node:path';
 import * as vm from 'node:vm';
 
 describe('dashboard UX shell affordances', () => {
+  it('labels scope and session totals without implying an all-project aggregate or liveness', () => {
+    const html = readFileSync(join(process.cwd(), 'src/apps/dashboard/index.html'), 'utf-8');
+    expect(html).toContain('Global Store');
+    expect(html).toContain('Stored Sessions');
+    expect(html).not.toContain('All (Global)');
+    expect(html).not.toContain('Active Sessions');
+  });
+
+  it('contains narrow-screen guards for header and usefulness layout', () => {
+    const css = readFileSync(join(process.cwd(), 'src/apps/dashboard/style.css'), 'utf-8');
+    expect(css).toContain('@media (max-width: 600px)');
+    expect(css).toContain('.top-header {\n    flex-direction: column;');
+    expect(css).toContain('.search-wrapper {\n    width: 100% !important;');
+    expect(css).toContain('.usefulness-strip {\n    flex-direction: column;');
+  });
+
   it('declares global project scope context and empty-state containers in the dashboard shell', () => {
     const html = readFileSync(join(process.cwd(), 'src/apps/dashboard/index.html'), 'utf-8');
 

--- a/tests/apps/project-detail-api.test.ts
+++ b/tests/apps/project-detail-api.test.ts
@@ -41,7 +41,7 @@ vi.mock('../../src/services/memory-service.js', async (importOriginal) => {
   };
 });
 
-const { projectsRouter } = await import('../../src/apps/server/api/projects.js');
+const { projectsRouter, inferCanonicalProjectPath, selectPreferredProjectPath } = await import('../../src/apps/server/api/projects.js');
 
 function createApp() {
   const app = new Hono();
@@ -119,5 +119,13 @@ describe('project detail dashboard API', () => {
     ]) {
       expect(serialized).not.toContain(privateSentinel);
     }
+  });
+
+  it('prefers a canonical checkout path over a newer worktree alias for the same hash', () => {
+    expect(selectPreferredProjectPath([
+      { projectPath: '/repos/shop/.aplus/worktrees/task-1', registeredAt: '2026-06-03T00:00:00Z' },
+      { projectPath: '/repos/shop', registeredAt: '2026-06-01T00:00:00Z' },
+    ])).toBe('/repos/shop');
+    expect(inferCanonicalProjectPath('/repos/shop/.aplus/worktrees/task-1')).toBe('/repos/shop');
   });
 });

--- a/tests/apps/stats-api-lightweight.test.ts
+++ b/tests/apps/stats-api-lightweight.test.ts
@@ -190,5 +190,64 @@ describe('stats API lightweight read paths', () => {
     const cutoff = mocks.service.getEventsAfter.mock.calls[0][0];
     expect(typeof cutoff).toBe('string');
     expect(new Date(cutoff).getTime()).toBeLessThan(Date.now());
+    expect(mocks.service.getHelpfulnessStats).toHaveBeenCalledTimes(2);
+    const [currentSince, currentUntil] = mocks.service.getHelpfulnessStats.mock.calls[0];
+    const [previousSince, previousUntil] = mocks.service.getHelpfulnessStats.mock.calls[1];
+    expect(previousUntil.getTime()).toBe(currentSince.getTime());
+    expect(currentUntil.getTime() - currentSince.getTime()).toBe(7 * 24 * 60 * 60 * 1000);
+    expect(previousSince).toBeInstanceOf(Date);
+  });
+
+  it('GET /api/stats/kpi uses distinct helpfulness windows for current, previous, and daily trend', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-08T12:00:00.000Z'));
+    try {
+      mocks.service.getEventsAfter.mockResolvedValue([
+        { id: 'p1', eventType: 'user_prompt', sessionId: 's1', timestamp: new Date('2026-05-08T10:00:00.000Z'), content: 'prompt', metadata: {} }
+      ]);
+      mocks.service.getHelpfulnessStats
+        .mockResolvedValueOnce({ totalEvaluated: 2, helpful: 1 })
+        .mockResolvedValueOnce({ totalEvaluated: 2, helpful: 2 })
+        .mockResolvedValueOnce({ totalEvaluated: 4, helpful: 3 });
+
+      const res = await createApp().request('/api/stats/kpi?project=abc12345&window=7d');
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.metrics.usefulRecallRate).toBe(0.5);
+      expect(body.previousMetrics.usefulRecallRate).toBe(1);
+      expect(body.deltas.usefulRecallRate).toBe(-0.5);
+      expect(body.availability.usefulRecallRate).toEqual({
+        currentEvaluated: 2,
+        previousEvaluated: 2,
+        currentAvailable: true,
+        previousAvailable: true,
+      });
+      expect(body.trend.daily[0].usefulRecallRate).toBe(0.75);
+      expect(mocks.service.getHelpfulnessStats).toHaveBeenCalledTimes(3);
+      expect(mocks.service.getHelpfulnessStats.mock.calls[2]).toEqual([
+        new Date('2026-05-08T00:00:00.000Z'),
+        new Date('2026-05-09T00:00:00.000Z')
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('GET /api/stats/kpi distinguishes missing recall evaluations from a measured zero', async () => {
+    mocks.service.getEventsAfter.mockResolvedValue([
+      { id: 'p1', eventType: 'user_prompt', sessionId: 's1', timestamp: new Date(), content: 'prompt', metadata: {} }
+    ]);
+    mocks.service.getHelpfulnessStats.mockResolvedValue({ totalEvaluated: 0, helpful: 0 });
+
+    const res = await createApp().request('/api/stats/kpi?project=abc12345&window=7d');
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.metrics.usefulRecallRate).toBe(0);
+    expect(body.deltas.usefulRecallRate).toBeNull();
+    expect(body.availability.usefulRecallRate.currentAvailable).toBe(false);
+    expect(body.trend.daily[0].usefulRecallRate).toBeNull();
+    expect(body.alerts.some((alert: any) => alert.metric === 'usefulRecallRate')).toBe(false);
   });
 });

--- a/tests/apps/stats-api-lightweight.test.ts
+++ b/tests/apps/stats-api-lightweight.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => {
     getEventsByLevel: vi.fn(),
     getMostAccessedMemories: vi.fn(),
     getHelpfulnessStats: vi.fn(),
+    getHelpfulnessStatsByDay: vi.fn(),
     getHelpfulMemories: vi.fn(),
     getRecentRetrievalTraces: vi.fn(),
     getEndlessModeStatus: vi.fn()
@@ -75,6 +76,7 @@ describe('stats API lightweight read paths', () => {
     mocks.service.getEventsByLevel.mockReset().mockResolvedValue([]);
     mocks.service.getMostAccessedMemories.mockReset().mockResolvedValue([]);
     mocks.service.getHelpfulnessStats.mockReset().mockResolvedValue({ avgScore: 0, totalEvaluated: 0, totalRetrievals: 0, helpful: 0, neutral: 0, unhelpful: 0 });
+    mocks.service.getHelpfulnessStatsByDay.mockReset().mockResolvedValue([]);
     mocks.service.getHelpfulMemories.mockReset().mockResolvedValue([]);
     mocks.service.getRecentRetrievalTraces.mockReset().mockResolvedValue([]);
     mocks.service.getEndlessModeStatus.mockReset().mockResolvedValue({ mode: 'session', continuityScore: 0, workingSetSize: 0, consolidatedCount: 0 });
@@ -207,8 +209,10 @@ describe('stats API lightweight read paths', () => {
       ]);
       mocks.service.getHelpfulnessStats
         .mockResolvedValueOnce({ totalEvaluated: 2, helpful: 1 })
-        .mockResolvedValueOnce({ totalEvaluated: 2, helpful: 2 })
-        .mockResolvedValueOnce({ totalEvaluated: 4, helpful: 3 });
+        .mockResolvedValueOnce({ totalEvaluated: 2, helpful: 2 });
+      mocks.service.getHelpfulnessStatsByDay.mockResolvedValue([
+        { date: '2026-05-08', totalEvaluated: 4, helpful: 3 }
+      ]);
 
       const res = await createApp().request('/api/stats/kpi?project=abc12345&window=7d');
       const body = await res.json();
@@ -224,11 +228,12 @@ describe('stats API lightweight read paths', () => {
         previousAvailable: true,
       });
       expect(body.trend.daily[0].usefulRecallRate).toBe(0.75);
-      expect(mocks.service.getHelpfulnessStats).toHaveBeenCalledTimes(3);
-      expect(mocks.service.getHelpfulnessStats.mock.calls[2]).toEqual([
-        new Date('2026-05-08T00:00:00.000Z'),
+      expect(mocks.service.getHelpfulnessStats).toHaveBeenCalledTimes(2);
+      expect(mocks.service.getHelpfulnessStatsByDay).toHaveBeenCalledTimes(1);
+      expect(mocks.service.getHelpfulnessStatsByDay).toHaveBeenCalledWith(
+        new Date('2026-04-08T00:00:00.000Z'),
         new Date('2026-05-09T00:00:00.000Z')
-      ]);
+      );
     } finally {
       vi.useRealTimers();
     }
@@ -239,6 +244,9 @@ describe('stats API lightweight read paths', () => {
       { id: 'p1', eventType: 'user_prompt', sessionId: 's1', timestamp: new Date(), content: 'prompt', metadata: {} }
     ]);
     mocks.service.getHelpfulnessStats.mockResolvedValue({ totalEvaluated: 0, helpful: 0 });
+    mocks.service.getHelpfulnessStatsByDay.mockResolvedValue([
+      { date: new Date().toISOString().slice(0, 10), totalEvaluated: 0, helpful: 0 }
+    ]);
 
     const res = await createApp().request('/api/stats/kpi?project=abc12345&window=7d');
     const body = await res.json();

--- a/tests/core/usefulness-history.test.ts
+++ b/tests/core/usefulness-history.test.ts
@@ -62,6 +62,34 @@ describe('usefulness evidence history (store integration)', () => {
 
     expect(firstDay).toMatchObject({ totalRetrievals: 1, totalEvaluated: 1, helpful: 1, unhelpful: 0 });
     expect(secondDay).toMatchObject({ totalRetrievals: 1, totalEvaluated: 1, helpful: 0, unhelpful: 1 });
+
+    // Legacy rows used SQLite's space-separated datetime format. The daily
+    // range query must aggregate both formats while retaining indexable raw
+    // created_at bounds.
+    const legacyId = await appendEvent(store, 'agent_response', 'old', 'Legacy memory', new Date('2026-01-01T00:00:00Z'));
+    await store.recordRetrieval(legacyId, 's3', 0.9, 'legacy');
+    const legacyDb = new Database(dbPath);
+    legacyDb.prepare(`UPDATE memory_helpfulness SET created_at = ?, measured_at = ?, helpfulness_score = ? WHERE session_id = ?`)
+      .run('2026-01-02 18:00:00', '2026-01-02 18:05:00', 0.8, 's3');
+    legacyDb.close();
+
+    const daily = await store.getHelpfulnessStatsByDay(
+      new Date('2026-01-01T00:00:00.000Z'),
+      new Date('2026-01-03T00:00:00.000Z')
+    );
+    expect(daily).toEqual([
+      expect.objectContaining({ date: '2026-01-01', totalRetrievals: 1, totalEvaluated: 1, helpful: 1 }),
+      expect.objectContaining({ date: '2026-01-02', totalRetrievals: 2, totalEvaluated: 2, helpful: 1, unhelpful: 1 }),
+    ]);
+    const planDb = new Database(dbPath);
+    const queryPlan = planDb.prepare(`EXPLAIN QUERY PLAN
+      SELECT substr(created_at, 1, 10), COUNT(*)
+      FROM memory_helpfulness
+      WHERE created_at >= ? AND created_at < ?
+      GROUP BY substr(created_at, 1, 10)`)
+      .all('2026-01-01', '2026-01-03') as Array<{ detail: string }>;
+    planDb.close();
+    expect(queryPlan.map((step) => step.detail).join(' ')).toContain('idx_helpfulness_created_at');
     await store.close();
   });
 

--- a/tests/core/usefulness-history.test.ts
+++ b/tests/core/usefulness-history.test.ts
@@ -36,6 +36,35 @@ async function appendEvent(
 }
 
 describe('usefulness evidence history (store integration)', () => {
+  it('supports a half-open helpfulness time range for KPI comparisons', async () => {
+    const dbPath = tempDbPath();
+    const store = new SQLiteEventStore(dbPath);
+    await store.initialize();
+    const memoryId = await appendEvent(store, 'agent_response', 'old', 'Reusable memory', new Date('2026-01-01T00:00:00Z'));
+    await store.recordRetrieval(memoryId, 's1', 0.9, 'first');
+    await store.recordRetrieval(memoryId, 's2', 0.9, 'second');
+
+    const db = new Database(dbPath);
+    db.prepare(`UPDATE memory_helpfulness SET created_at = ?, measured_at = ?, helpfulness_score = ? WHERE session_id = ?`)
+      .run('2026-01-01T12:00:00.000Z', '2026-01-01T12:05:00.000Z', 1, 's1');
+    db.prepare(`UPDATE memory_helpfulness SET created_at = ?, measured_at = ?, helpfulness_score = ? WHERE session_id = ?`)
+      .run('2026-01-02T12:00:00.000Z', '2026-01-02T12:05:00.000Z', 0.2, 's2');
+    db.close();
+
+    const firstDay = await store.getHelpfulnessStats(
+      new Date('2026-01-01T00:00:00.000Z'),
+      new Date('2026-01-02T00:00:00.000Z')
+    );
+    const secondDay = await store.getHelpfulnessStats(
+      new Date('2026-01-02T00:00:00.000Z'),
+      new Date('2026-01-03T00:00:00.000Z')
+    );
+
+    expect(firstDay).toMatchObject({ totalRetrievals: 1, totalEvaluated: 1, helpful: 1, unhelpful: 0 });
+    expect(secondDay).toMatchObject({ totalRetrievals: 1, totalEvaluated: 1, helpful: 0, unhelpful: 1 });
+    await store.close();
+  });
+
   it('links question -> injected memory -> grounded helpfulness with evidence', async () => {
     const store = new SQLiteEventStore(tempDbPath());
     await store.initialize();


### PR DESCRIPTION
## Summary

- add a reviewed spec for dashboard reliability and memory utilization
- calculate useful recall for the current, previous, and daily windows instead of reusing all-time data
- distinguish missing outcome evidence from measured zeroes in the API and dashboard
- clarify Global Store and Stored Sessions scope labels
- filter invalid/empty project stores and prefer canonical checkout paths over worktree aliases
- remove narrow-screen horizontal overflow

## Review follow-up

During final review, the Useful Recall KPI still rendered zero percent and a threshold warning when no recalls had been evaluated. This PR now exposes availability metadata, renders the KPI as unavailable, leaves missing trend points null, and suppresses false low-recall alerts.

## Verification

- `npm run verify` (172 files, 1090 tests passed; lint 0 errors / 44 existing warnings)
- `npm run build`
- `npm run smoke:dashboard`
- `npm run check:architecture`
- `git diff --check`
- desktop and 390px dashboard browser QA; no horizontal overflow or console errors