### PR TITLE
fix: 마크다운 미러를 워크트리 대신 메인 체크아웃에 기록

### DIFF
--- a/src/core/engine/memory-engine-services.ts
+++ b/src/core/engine/memory-engine-services.ts
@@ -13,6 +13,7 @@ import type { EventStore } from '../event-store.js';
 import { createGraduationPipeline, type GraduationPipeline } from '../graduation.js';
 import { getDefaultMatcher, type Matcher } from '../matcher.js';
 import { MarkdownMirror } from '../md-mirror.js';
+import { resolveProjectAnchorPath } from '../registry/project-path.js';
 import type { Retriever } from '../retriever.js';
 import { SQLiteEventStore } from '../sqlite-event-store.js';
 import type { MemoryOperationsConfig, ToolObservationPayload } from '../types.js';
@@ -109,7 +110,7 @@ export function createMemoryEngineServices(options: MemoryEngineServicesOptions)
     : (factories.getDefaultEmbedder ?? getDefaultEmbedder)();
   const matcher = (factories.getDefaultMatcher ?? getDefaultMatcher)();
   const mdMirror = (factories.createMarkdownMirror ?? defaultCreateMarkdownMirror)(
-    options.cwd ?? process.cwd()
+    resolveProjectAnchorPath(options.cwd ?? process.cwd())
   );
   const graduation = (factories.createGraduationPipeline ?? defaultCreateGraduationPipeline)(
     sqliteStore as unknown as EventStore

--- a/src/core/registry/project-path.ts
+++ b/src/core/registry/project-path.ts
@@ -64,6 +64,17 @@ function resolveHashBasisPath(normalizedPath: string): string {
 }
 
 /**
+ * Resolve the durable on-disk anchor for per-project artifacts (e.g. the
+ * markdown mirror): a git worktree anchors onto the main checkout it shares a
+ * .git with, so artifacts survive worktree removal and land where the project
+ * hash already points. Main checkouts, subdirectories, and non-git paths
+ * anchor onto themselves.
+ */
+export function resolveProjectAnchorPath(projectPath: string): string {
+  return resolveHashBasisPath(normalizeProjectPath(projectPath));
+}
+
+/**
  * Generate a stable 8-character hash from a normalized project path.
  */
 export function hashProjectPath(projectPath: string): string {

--- a/tests/core/project-path.test.ts
+++ b/tests/core/project-path.test.ts
@@ -6,7 +6,7 @@ import * as path from 'node:path';
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { hashProjectPath } from '../../src/core/registry/project-path.js';
+import { hashProjectPath, resolveProjectAnchorPath } from '../../src/core/registry/project-path.js';
 
 function git(cwd: string, args: string[]): void {
   execFileSync('git', args, { cwd, stdio: 'ignore' });
@@ -62,6 +62,16 @@ describe('hashProjectPath worktree convergence', () => {
   it('keeps a non-git directory on its own pre-existing hash', () => {
     expect(hashProjectPath(standaloneDir)).toBe(legacyPathHash(standaloneDir));
     expect(hashProjectPath(standaloneDir)).not.toBe(hashProjectPath(mainRoot));
+  });
+
+  it('anchors a worktree onto its main checkout for durable per-project artifacts', () => {
+    expect(resolveProjectAnchorPath(worktreeRoot)).toBe(mainRoot);
+  });
+
+  it('anchors main checkouts, subdirectories, and non-git paths onto themselves', () => {
+    expect(resolveProjectAnchorPath(mainRoot)).toBe(mainRoot);
+    expect(resolveProjectAnchorPath(mainSubdir)).toBe(mainSubdir);
+    expect(resolveProjectAnchorPath(standaloneDir)).toBe(standaloneDir);
   });
 
   it('ignores inherited git env vars that would resolve another repository', () => {


### PR DESCRIPTION
## 문제

프로젝트 해시는 워크트리를 메인 체크아웃으로 리다이렉트해 이벤트 스토어가 통합되는데, 마크다운 미러만 cwd 기준이라 `.aplus/worktrees/<name>/memory/`에 흩어져 기록되고 워크트리 삭제 시 함께 유실됐다.

aplus-dev-studio 실측: DB에는 20일치 6,506 이벤트가 있는데 메인 체크아웃 `memory/`에는 8일치만 존재. 나머지는 30개 이상의 워크트리 디렉터리에 분산돼 있었다.

## 수정

해시 계산에 쓰던 리다이렉트 규칙을 공개 함수 `resolveProjectAnchorPath`로 노출하고 미러 루트에 적용한다. 메인 체크아웃·서브디렉터리·비git 경로는 기존과 동일하게 자기 자신에 앵커되므로 기존 해시와 미러 위치는 변하지 않는다.

## 검증

- TDD Red→Green: 워크트리는 메인 체크아웃에 앵커, 나머지 3종 경로는 자기 자신에 앵커
- 전체 테스트 1,155건·typecheck·lint 통과
- 실환경: DB에서 미러를 재생성해 20일치 78파일이 메인 체크아웃 한 곳에 모이는 것 확인

## 참고: 이 브랜치에 있던 임베딩 CJS interop 수정은 제외됨

같은 버그를 고치는 `e4020dc`(`normalizeTransformersNamespace`)가 먼저 main에 머지돼 기능적으로 중복이라 rebase 중 드롭했다. 함께 있던 통합 테스트도 폐기했는데, vitest 모듈 러너가 CJS를 자체 interop해 named export로 노출하기 때문에 **버그를 유발하는 네임스페이스 형태가 테스트 안에서 재현되지 않아** 수정 유무와 무관하게 통과하는 테스트였다. main의 유닛 테스트가 로직을 덮고 있다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)