### PR TITLE
[behavioral] SessionStart 주입 랭킹 교체 + 스토어 파편화 수정

### DIFF
--- a/scripts/consolidate-orphaned-stores.mjs
+++ b/scripts/consolidate-orphaned-stores.mjs
@@ -24,8 +24,16 @@ import { hashProjectPath } from '../dist/core/index.js';
 const PROJECTS_ROOT = process.env.CLAUDE_MEMORY_PROJECTS_ROOT
   || path.join(os.homedir(), '.claude-code', 'memory', 'projects');
 
-/** Tables merged from the source store. FTS is rebuilt by the events triggers. */
-const MERGED_TABLES = ['events', 'sessions'];
+/**
+ * Tables merged from the source store, parents before children.
+ *
+ * FTS needs no entry — the events triggers maintain it. memory_levels does:
+ * an event with no graduation level is skipped by the retrieval lanes, so
+ * merging events alone lands rows that exist but never surface. Telemetry
+ * (memory_helpfulness, retrieval_traces) is deliberately left behind; it
+ * describes retrievals in a store that no longer exists.
+ */
+const MERGED_TABLES = ['events', 'sessions', 'memory_levels', 'event_dedup'];
 
 function parseArgs(argv) {
   const result = { apply: false, hashes: [], keepSource: false };
@@ -42,12 +50,21 @@ function parseArgs(argv) {
   return result;
 }
 
-function tableColumns(db, table) {
+function tableInfo(db, table, schema = 'main') {
   try {
-    return db.prepare(`PRAGMA table_info(${table})`).all().map((row) => row.name);
+    return db.prepare(`PRAGMA ${schema}.table_info(${table})`).all();
   } catch {
     return [];
   }
+}
+
+function tableColumns(db, table, schema = 'main') {
+  return tableInfo(db, table, schema).map((row) => row.name);
+}
+
+/** Primary key columns, used to reject a source whose schema cannot be matched up. */
+function primaryKeyColumns(db, table, schema = 'main') {
+  return tableInfo(db, table, schema).filter((row) => row.pk > 0).map((row) => row.name);
 }
 
 /** The project path a store was written for, taken from the sessions it recorded. */
@@ -127,11 +144,13 @@ function mergeStore(orphan, { apply, keepSource }) {
 
     for (const table of MERGED_TABLES) {
       const targetCols = tableColumns(target, table);
-      const sourceCols = new Set(
-        target.prepare(`PRAGMA src.table_info(${table})`).all().map((row) => row.name)
-      );
+      const sourceCols = new Set(tableColumns(target, table, 'src'));
       const shared = targetCols.filter((col) => sourceCols.has(col));
-      if (shared.length === 0 || !shared.includes('id')) {
+      const primaryKey = primaryKeyColumns(target, table);
+
+      // Every key column must survive the intersection, otherwise INSERT OR
+      // IGNORE cannot tell a duplicate from a new row.
+      if (shared.length === 0 || !primaryKey.every((col) => shared.includes(col))) {
         stats.tables[table] = { copied: 0, skipped: 0, note: 'incompatible schema' };
         continue;
       }

--- a/scripts/consolidate-orphaned-stores.mjs
+++ b/scripts/consolidate-orphaned-stores.mjs
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+/**
+ * Consolidate project stores that no longer match the hash their path resolves to.
+ *
+ * Project hashes derive from the main checkout owning a path's .git, so a
+ * worktree or subdirectory shares its repository's store. Stores created before
+ * that resolution existed sit under a hash nothing will ever look up again —
+ * their events are stranded. This folds them back into the store their path
+ * resolves to today.
+ *
+ * Dry run by default; pass --apply to write.
+ *
+ *   node scripts/consolidate-orphaned-stores.mjs
+ *   node scripts/consolidate-orphaned-stores.mjs --hash ad83c813 --apply
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+
+import { hashProjectPath } from '../dist/core/index.js';
+
+const PROJECTS_ROOT = process.env.CLAUDE_MEMORY_PROJECTS_ROOT
+  || path.join(os.homedir(), '.claude-code', 'memory', 'projects');
+
+/** Tables merged from the source store. FTS is rebuilt by the events triggers. */
+const MERGED_TABLES = ['events', 'sessions'];
+
+function parseArgs(argv) {
+  const result = { apply: false, hashes: [], keepSource: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--apply') result.apply = true;
+    else if (arg === '--keep-source') result.keepSource = true;
+    else if (arg === '--hash' && i + 1 < argv.length) {
+      result.hashes.push(String(argv[i += 1]).trim().toLowerCase());
+    } else if (arg.startsWith('--hash=')) {
+      result.hashes.push(arg.slice('--hash='.length).trim().toLowerCase());
+    }
+  }
+  return result;
+}
+
+function tableColumns(db, table) {
+  try {
+    return db.prepare(`PRAGMA table_info(${table})`).all().map((row) => row.name);
+  } catch {
+    return [];
+  }
+}
+
+/** The project path a store was written for, taken from the sessions it recorded. */
+function dominantProjectPath(db) {
+  try {
+    const row = db.prepare(
+      `SELECT project_path AS p FROM sessions
+       WHERE project_path IS NOT NULL AND project_path <> ''
+       GROUP BY project_path ORDER BY COUNT(*) DESC LIMIT 1`
+    ).get();
+    return row?.p ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function countRows(db, table) {
+  try {
+    return db.prepare(`SELECT COUNT(*) AS c FROM ${table}`).get().c;
+  } catch {
+    return 0;
+  }
+}
+
+/** Stores whose recorded path still exists but now hashes somewhere else. */
+function findOrphans(filterHashes) {
+  const orphans = [];
+  for (const dir of fs.readdirSync(PROJECTS_ROOT)) {
+    if (dir.includes('.bak-') || dir.includes('.merged-')) continue;
+    if (filterHashes.length > 0 && !filterHashes.includes(dir)) continue;
+
+    const dbPath = path.join(PROJECTS_ROOT, dir, 'events.sqlite');
+    if (!fs.existsSync(dbPath)) continue;
+
+    const db = new Database(dbPath, { readonly: true });
+    const projectPath = dominantProjectPath(db);
+    const events = countRows(db, 'events');
+    const sessions = countRows(db, 'sessions');
+    db.close();
+
+    if (!projectPath) continue;
+    if (!fs.existsSync(projectPath)) continue; // path is gone; nothing to resolve onto
+
+    const target = hashProjectPath(projectPath);
+    if (target === dir) continue;
+    if (!fs.existsSync(path.join(PROJECTS_ROOT, target, 'events.sqlite'))) continue;
+
+    orphans.push({ dir, target, projectPath, events, sessions });
+  }
+  return orphans.sort((a, b) => b.events - a.events);
+}
+
+/**
+ * Move a merged-away store aside under a name that is free. Re-merging the same
+ * hash within the same second must not collide with the previous archive —
+ * renameSync onto an existing non-empty directory fails.
+ */
+function archiveSourceDir(dir) {
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  let name = `${dir}.merged-${stamp}`;
+  for (let n = 2; fs.existsSync(path.join(PROJECTS_ROOT, name)); n += 1) {
+    name = `${dir}.merged-${stamp}-${n}`;
+  }
+  fs.renameSync(path.join(PROJECTS_ROOT, dir), path.join(PROJECTS_ROOT, name));
+  return name;
+}
+
+function mergeStore(orphan, { apply, keepSource }) {
+  const sourcePath = path.join(PROJECTS_ROOT, orphan.dir, 'events.sqlite');
+  const targetPath = path.join(PROJECTS_ROOT, orphan.target, 'events.sqlite');
+
+  const target = new Database(targetPath, { readonly: !apply });
+  const stats = { tables: {}, enqueued: 0 };
+
+  try {
+    target.prepare('ATTACH ? AS src').run(sourcePath);
+
+    for (const table of MERGED_TABLES) {
+      const targetCols = tableColumns(target, table);
+      const sourceCols = new Set(
+        target.prepare(`PRAGMA src.table_info(${table})`).all().map((row) => row.name)
+      );
+      const shared = targetCols.filter((col) => sourceCols.has(col));
+      if (shared.length === 0 || !shared.includes('id')) {
+        stats.tables[table] = { copied: 0, skipped: 0, note: 'incompatible schema' };
+        continue;
+      }
+
+      const before = countRows(target, table);
+      const list = shared.map((col) => `"${col}"`).join(', ');
+      const sql = `INSERT OR IGNORE INTO main.${table} (${list}) SELECT ${list} FROM src.${table}`;
+
+      if (apply) {
+        target.prepare(sql).run();
+      }
+      const sourceRows = target.prepare(`SELECT COUNT(*) AS c FROM src.${table}`).get().c;
+      const copied = apply ? countRows(target, table) - before : null;
+      stats.tables[table] = {
+        sourceRows,
+        copied,
+        skipped: copied === null ? null : sourceRows - copied
+      };
+    }
+
+    // Merged events carry no vectors in the target store, so queue them for
+    // embedding. The outbox's own uniqueness constraint absorbs re-runs.
+    if (apply) {
+      const version = target.prepare(
+        `SELECT embedding_version AS v FROM vector_outbox
+         GROUP BY embedding_version ORDER BY COUNT(*) DESC LIMIT 1`
+      ).get()?.v;
+
+      if (version) {
+        const queued = target.prepare(
+          `INSERT OR IGNORE INTO vector_outbox (job_id, item_kind, item_id, embedding_version, status)
+           SELECT lower(hex(randomblob(16))), 'event', e.id, ?, 'pending'
+           FROM src.events e WHERE EXISTS (SELECT 1 FROM main.events m WHERE m.id = e.id)`
+        ).run(version);
+        stats.enqueued = queued.changes;
+      } else {
+        stats.enqueueNote = 'no embedding_version in target outbox; run `process` to backfill';
+      }
+    }
+  } finally {
+    try { target.prepare('DETACH src').run(); } catch { /* already detached */ }
+    target.close();
+  }
+
+  if (apply && !keepSource) {
+    stats.archivedAs = archiveSourceDir(orphan.dir);
+  }
+
+  return stats;
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  if (!fs.existsSync(PROJECTS_ROOT)) {
+    console.error(`No project stores at ${PROJECTS_ROOT}`);
+    process.exit(1);
+  }
+
+  const orphans = findOrphans(options.hashes);
+  if (orphans.length === 0) {
+    console.log('No orphaned stores found.');
+    return;
+  }
+
+  console.log(options.apply ? '🔧 Consolidating orphaned stores\n' : '🔍 Dry run (pass --apply to write)\n');
+
+  let totalEvents = 0;
+  let failed = 0;
+  for (const orphan of orphans) {
+    console.log(`${orphan.dir} → ${orphan.target}`);
+    console.log(`   path: ${orphan.projectPath}`);
+    console.log(`   source: ${orphan.events} events, ${orphan.sessions} sessions`);
+
+    // One unmergeable store must not strand the rest of the batch. The merge
+    // itself is idempotent, so a failed store is safe to retry.
+    let stats;
+    try {
+      stats = mergeStore(orphan, options);
+    } catch (error) {
+      failed += 1;
+      console.log(`   ❌ failed: ${error.message}\n`);
+      continue;
+    }
+
+    for (const [table, result] of Object.entries(stats.tables)) {
+      if (result.note) console.log(`   ${table}: skipped (${result.note})`);
+      else if (result.copied === null) console.log(`   ${table}: ${result.sourceRows} rows to merge`);
+      else console.log(`   ${table}: copied ${result.copied}, deduped ${result.skipped}`);
+    }
+    if (stats.enqueued) console.log(`   queued ${stats.enqueued} events for embedding`);
+    if (stats.enqueueNote) console.log(`   ${stats.enqueueNote}`);
+    console.log();
+
+    totalEvents += orphan.events;
+  }
+
+  console.log(`${orphans.length} store(s), ${totalEvents} source events.`);
+  if (failed > 0) {
+    console.log(`${failed} store(s) failed; re-running is safe.`);
+    process.exitCode = 1;
+  }
+  if (options.apply) {
+    console.log('Merged stores were renamed to <hash>.merged-<timestamp>.');
+    console.log('Run `claude-memory-layer process -p <project>` to embed the merged events.');
+  } else {
+    console.log('Re-run with --apply to merge.');
+  }
+}
+
+main();

--- a/src/adapters/claude/hooks/prompt-injection-policy.ts
+++ b/src/adapters/claude/hooks/prompt-injection-policy.ts
@@ -374,8 +374,11 @@ function formatLessonContent(lesson: LessonEvidenceInput): string {
   return parts.join('\n');
 }
 
-function isPromptOnlySessionSummary(content: string): boolean {
-  return /Session with \d+ user prompts?|Topics discussed:|\[\d{4}-\d{2}-\d{2}\].*주요 작업:/iu.test(content);
+export function isPromptOnlySessionSummary(content: string): boolean {
+  // The Korean branch is anchored on the rule-based generator's own prefix
+  // ("[date] N턴 세션", see summary-deriver.ts) rather than on the optional
+  // "주요 작업:" line, which it omits for a zero-prompt session.
+  return /Session with \d+ user prompts?|Topics discussed:|\[\d{4}-\d{2}-\d{2}\]\s*\d+턴 세션/iu.test(content);
 }
 
 function isDiagnosticQuery(query: string): boolean {

--- a/src/adapters/claude/hooks/session-start.ts
+++ b/src/adapters/claude/hooks/session-start.ts
@@ -11,12 +11,103 @@ import { isLlmSummaryEnabled } from '../../llm/session-summary-llm.js';
 import { spawnToolObservationVectorAutoHealIfNeeded } from './tool-observation-vector-auto-heal-client.js';
 import { readStdin } from './hook-runtime.js';
 import { formatClaudeContextHookOutput, isHookEvaluationMode } from './hook-output.js';
-import type { CoreMemoryBlock, SessionStartInput, SessionStartOutput } from '../../../core/types.js';
+import { isPromptOnlySessionSummary } from './prompt-injection-policy.js';
+import type {
+  CoreMemoryBlock,
+  EventType,
+  MemoryEvent,
+  SessionStartInput,
+  SessionStartOutput
+} from '../../../core/types.js';
 
 const CORE_MEMORY_BLOCK_LABELS: Record<CoreMemoryBlock['blockKey'], string> = {
   project: 'Project',
   user: 'User'
 };
+
+/**
+ * Injection tiers for the session-start lane, best first.
+ *
+ * Unlike the prompt lane there is no query here, so candidates cannot be
+ * scored — the only lever is which event types are worth injecting at all.
+ * Measured over 222 session-start injections in August 2026:
+ *
+ *   tool_observation  118 injections, content_overlap_score 0.000
+ *   agent_response     77 injections, content_overlap_score 0.123
+ *   user_prompt        14 injections, content_overlap_score 0.000
+ *   session_summary    13 injections, content_overlap_score 0.063
+ *
+ * tool_observation and user_prompt never grounded a single response, so they
+ * are excluded rather than ranked. Summaries come first because they are the
+ * only events written as durable outcomes; a raw agent_response is a snapshot
+ * of one turn.
+ */
+const SESSION_START_TIERS: EventType[] = ['session_summary', 'agent_response'];
+
+/** Per-type excerpt budgets. Summaries carry decisions, so they get more room. */
+const SESSION_START_EXCERPT_BUDGET: Partial<Record<EventType, number>> = {
+  session_summary: 900,
+  agent_response: 400
+};
+
+const DEFAULT_EXCERPT_BUDGET = 400;
+
+/** How many memories the recap injects. */
+const SESSION_START_MAX_MEMORIES = 3;
+
+/**
+ * How many injectable-type events to scan for those memories. Counted after
+ * the type filter, so this reaches weeks of history rather than hours.
+ */
+const SESSION_START_SCAN_WINDOW = 60;
+
+/**
+ * Picks what to inject at session start.
+ *
+ * This lane used to take the 3 most recent events of any type. Because
+ * tool_observation is ~84% of everything stored, recency alone meant the
+ * recap was mostly raw `{"toolName":...}` JSON truncated mid-token — 118
+ * such injections grounded exactly nothing.
+ */
+export function selectSessionStartMemories(events: MemoryEvent[], limit: number): MemoryEvent[] {
+  const usable = events.filter((event) => (
+    SESSION_START_TIERS.includes(event.eventType)
+    // The rule-based generator emits a table of contents ("Session with N
+    // prompts. Topics discussed: ...") rather than an outcome. The prompt lane
+    // already excludes it; this lane must too or it outranks real summaries on
+    // type alone.
+    && !(event.eventType === 'session_summary' && isPromptOnlySessionSummary(event.content))
+    && event.content.trim().length > 0
+  ));
+
+  return usable
+    .map((event, index) => ({ event, index }))
+    .sort((a, b) => (
+      (SESSION_START_TIERS.indexOf(a.event.eventType) - SESSION_START_TIERS.indexOf(b.event.eventType))
+      || (b.event.timestamp.getTime() - a.event.timestamp.getTime())
+      || (a.index - b.index)
+    ))
+    .slice(0, limit)
+    .map((item) => item.event);
+}
+
+/**
+ * Renders one memory as a single-line bullet.
+ *
+ * The old 150-character hard cut split JSON and sentences mid-token, leaving
+ * the model a fragment it could not act on. Budgets are per type and the cut
+ * backs off to the last sentence/clause boundary when there is one nearby.
+ */
+export function sessionStartExcerpt(event: MemoryEvent): string {
+  const collapsed = event.content.trim().replace(/\s*\n+\s*/g, ' / ');
+  const budget = SESSION_START_EXCERPT_BUDGET[event.eventType] ?? DEFAULT_EXCERPT_BUDGET;
+  if (collapsed.length <= budget) return collapsed;
+
+  const head = collapsed.slice(0, budget);
+  const boundary = Math.max(head.lastIndexOf('. '), head.lastIndexOf(' / '), head.lastIndexOf('다 '));
+  const cut = boundary >= budget * 0.6 ? head.slice(0, boundary + 1) : head;
+  return `${cut.trimEnd()}...`;
+}
 
 /**
  * Renders core memory blocks unconditionally (no query, no scoring) — the
@@ -102,18 +193,30 @@ export async function main(): Promise<string> {
       }
     }
 
-    // Get recent context for this project (now automatically scoped)
+    // Get recent context for this project (now automatically scoped).
+    //
+    // The scan is type-filtered and much wider than the 3 memories that get
+    // injected. Injectable types are a small minority of a real store —
+    // tool_observation alone is ~84% of events and session_summary about 2% —
+    // so an unfiltered window either misses summaries entirely or has to load
+    // thousands of large tool payloads to reach them.
     const recentEvents = process.env.CLAUDE_MEMORY_EVAL_DISABLE_SESSION_CONTEXT === 'true'
       ? []
-      : await memoryService.getRecentEvents(10);
+      : await memoryService.getRecentEvents(SESSION_START_SCAN_WINDOW, {
+        eventTypes: SESSION_START_TIERS
+      });
 
-    if (recentEvents.length > 0) {
+    const injectedEvents = selectSessionStartMemories(recentEvents, SESSION_START_MAX_MEMORIES);
+
+    if (injectedEvents.length > 0) {
       if (context) context += '\n';
-      const injectedEvents = recentEvents.slice(0, 3);
       context += `## Previous Session Context\n\nYou have worked on this project before. Here are some relevant memories:\n\n`;
+      const excerpts = new Map<string, string>();
       for (const event of injectedEvents) {
         const date = event.timestamp.toISOString().split('T')[0];
-        context += `- **${date}**: ${event.content.slice(0, 150)}...\n`;
+        const excerpt = sessionStartExcerpt(event);
+        excerpts.set(event.id, excerpt);
+        context += `- **${date}**: ${excerpt}\n`;
       }
 
       // Session-start injections used to be invisible to usefulness metrics.
@@ -131,9 +234,9 @@ export async function main(): Promise<string> {
             {
               traceId: batchTraceId,
               source: 'session_start',
-              // Only the first 150 chars are injected above — grounding must
-              // be measured against that snapshot, not the full event.
-              injectedContent: event.content.slice(0, 150)
+              // Grounding is measured against the exact text injected above,
+              // not the full event.
+              injectedContent: excerpts.get(event.id) ?? sessionStartExcerpt(event)
             }
           );
         } catch { /* non-critical telemetry */ }

--- a/src/core/engine/memory-query-service.ts
+++ b/src/core/engine/memory-query-service.ts
@@ -9,7 +9,7 @@ import type {
   ProjectScopeRepairOptions,
   ProjectScopeRepairResult
 } from '../types.js';
-import type { DerivationLiveness } from '../sqlite-event-store.js';
+import type { DerivationLiveness, RecentEventsReadOptions } from '../sqlite-event-store.js';
 import type { SQLiteDatabase } from '../sqlite-wrapper.js';
 import { LessonRepository } from '../operations/lesson-repository.js';
 import { CoreMemoryBlockRepository } from '../operations/core-memory-block-repository.js';
@@ -47,7 +47,7 @@ interface QueryStore {
   searchGraduatedEvidence?(query: string, limit: number): Promise<GraduatedEvidenceResult[]>;
   getEvent(id: string): Promise<MemoryEvent | null>;
   getSessionEvents(sessionId: string): Promise<MemoryEvent[]>;
-  getRecentEvents(limit: number): Promise<MemoryEvent[]>;
+  getRecentEvents(limit: number, options?: RecentEventsReadOptions): Promise<MemoryEvent[]>;
   countEvents?(): Promise<number>;
   /** Present on the SQLite store; lessons live outside the events table. */
   getDatabase?(): SQLiteDatabase;
@@ -197,9 +197,9 @@ export class MemoryQueryService {
     return this.queryStore.getSessionEvents(sessionId);
   }
 
-  async getRecentEvents(limit: number = 100): Promise<MemoryEvent[]> {
+  async getRecentEvents(limit: number = 100, options?: RecentEventsReadOptions): Promise<MemoryEvent[]> {
     await this.initialize();
-    return this.queryStore.getRecentEvents(limit);
+    return this.queryStore.getRecentEvents(limit, options);
   }
 
   async rebuildFtsIndex(): Promise<number> {

--- a/src/core/registry/project-path.ts
+++ b/src/core/registry/project-path.ts
@@ -39,20 +39,28 @@ function computeHashBasisPath(normalizedPath: string): string {
   if (path.basename(absoluteCommonDir) !== '.git') return normalizedPath;
   const mainCheckoutRoot = normalizeProjectPath(path.dirname(absoluteCommonDir));
 
-  const topLevel = runGit(normalizedPath, ['rev-parse', '--show-toplevel']);
-  if (!topLevel) return normalizedPath;
+  // Guard against a git layout that reports a common dir but no work tree
+  // (a bare repo); such a path keeps hashing to itself.
+  if (!runGit(normalizedPath, ['rev-parse', '--show-toplevel'])) return normalizedPath;
 
-  // Inside the main checkout (its root or any subdirectory) the top level is
-  // the main checkout root, and the caller's own path is kept so existing
-  // project hashes never shift. Only a worktree, whose top level differs from
-  // the checkout owning the shared .git, is redirected onto the main checkout.
-  return normalizeProjectPath(topLevel) === mainCheckoutRoot ? normalizedPath : mainCheckoutRoot;
+  // Every path inside one repository resolves onto the checkout that owns the
+  // shared .git — a worktree, the checkout root, or any subdirectory of it.
+  //
+  // The root itself already hashes to this value, so existing project hashes
+  // are unchanged. Subdirectories converge onto it: a session started from a
+  // monorepo package or a vendored tree used to get its own hash, and with it
+  // a cold store no other session in the repository could read.
+  //
+  // A nested repository owns its own .git, so its common dir differs and it
+  // stays separate rather than folding into the outer checkout.
+  return mainCheckoutRoot;
 }
 
 /**
- * Resolve the path a project hash should be derived from, so that a git
- * worktree hashes to the same value as the main checkout it shares a .git
- * with. Main checkouts, subdirectories, and non-git paths hash to themselves.
+ * Resolve the path a project hash should be derived from, so that every path
+ * belonging to one repository — worktree, checkout root, or subdirectory —
+ * hashes to the main checkout that owns the shared .git. Nested repositories
+ * and non-git paths hash to themselves.
  */
 function resolveHashBasisPath(normalizedPath: string): string {
   const cached = hashBasisCache.get(normalizedPath);
@@ -65,9 +73,9 @@ function resolveHashBasisPath(normalizedPath: string): string {
 
 /**
  * Resolve the durable on-disk anchor for per-project artifacts (e.g. the
- * markdown mirror): a git worktree anchors onto the main checkout it shares a
- * .git with, so artifacts survive worktree removal and land where the project
- * hash already points. Main checkouts, subdirectories, and non-git paths
+ * markdown mirror): worktrees and subdirectories anchor onto the main checkout
+ * they share a .git with, so artifacts survive worktree removal and land where
+ * the project hash already points. Nested repositories and non-git paths
  * anchor onto themselves.
  */
 export function resolveProjectAnchorPath(projectPath: string): string {

--- a/src/core/sqlite-event-store.ts
+++ b/src/core/sqlite-event-store.ts
@@ -5,6 +5,7 @@
 
 import { randomUUID } from 'crypto';
 import {
+  EventType,
   MemoryEvent,
   MemoryEventInput,
   Session,
@@ -168,6 +169,11 @@ function notActiveQuarantinedSql(column = 'metadata'): string {
 
 interface QuarantineReadOptions {
   includeQuarantined?: boolean;
+}
+
+export interface RecentEventsReadOptions extends QuarantineReadOptions {
+  /** Restrict to these event types. An empty/omitted list means "any type". */
+  eventTypes?: EventType[];
 }
 
 function maybeQuarantinePredicate(options?: QuarantineReadOptions, column = 'metadata'): string {
@@ -1202,15 +1208,28 @@ export class SQLiteEventStore {
   }
 
   /**
-   * Get recent events
+   * Get recent events, optionally restricted to a set of event types.
+   *
+   * The type filter exists because tool_observation is the overwhelming
+   * majority of a real store (~84%). Callers that only want narrative events
+   * would otherwise have to over-fetch by an order of magnitude — and load
+   * every large tool payload along the way — just to reach a handful of
+   * summaries.
    */
-  async getRecentEvents(limit: number = 100, options?: QuarantineReadOptions): Promise<MemoryEvent[]> {
+  async getRecentEvents(limit: number = 100, options?: RecentEventsReadOptions): Promise<MemoryEvent[]> {
     await this.initialize();
+
+    const eventTypes = options?.eventTypes ?? [];
+    const typePredicate = eventTypes.length > 0
+      ? `AND event_type IN (${eventTypes.map(() => '?').join(', ')})`
+      : '';
 
     const rows = sqliteAll<Record<string, unknown>>(
       this.db,
-      `SELECT * FROM events WHERE ${maybeQuarantinePredicate(options)} ORDER BY timestamp DESC LIMIT ?`,
-      [limit]
+      `SELECT * FROM events
+       WHERE ${maybeQuarantinePredicate(options)} ${typePredicate}
+       ORDER BY timestamp DESC LIMIT ?`,
+      [...eventTypes, limit]
     );
 
     return rows.map(this.rowToEvent);

--- a/src/core/sqlite-event-store.ts
+++ b/src/core/sqlite-event-store.ts
@@ -847,6 +847,11 @@ export class SQLiteEventStore {
       -- Create indexes
       CREATE INDEX IF NOT EXISTS idx_events_session ON events(session_id);
       CREATE INDEX IF NOT EXISTS idx_events_timestamp ON events(timestamp);
+      -- Serves getRecentEvents' event_type filter. Without it SQLite walks
+      -- idx_events_timestamp backwards and evaluates the quarantine predicate
+      -- on every visited row; a store holding fewer matching events than the
+      -- limit then degrades into a full table scan on the SessionStart path.
+      CREATE INDEX IF NOT EXISTS idx_events_type_timestamp ON events(event_type, timestamp);
       CREATE INDEX IF NOT EXISTS idx_entries_type ON entries(entry_type);
       CREATE INDEX IF NOT EXISTS idx_entries_stage ON entries(stage);
       CREATE INDEX IF NOT EXISTS idx_entries_canonical ON entries(canonical_key);

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -37,7 +37,7 @@ import {
 } from '../core/engine/embedding-maintenance-service.js';
 import type { MemoryRuntimeService } from '../core/engine/memory-runtime-service.js';
 import type { GraduationRunResult } from '../core/graduation-worker.js';
-import type { DerivationLiveness } from '../core/sqlite-event-store.js';
+import type { DerivationLiveness, RecentEventsReadOptions } from '../core/sqlite-event-store.js';
 import type { IngestInterceptor } from '../core/ingest-interceptor.js';
 import type { MemoryIngestService } from '../core/engine/memory-ingest-service.js';
 import type { MemoryQueryService } from '../core/engine/memory-query-service.js';
@@ -368,8 +368,8 @@ export class MemoryService {
   /**
    * Get recent events
    */
-  async getRecentEvents(limit: number = 100): Promise<MemoryEvent[]> {
-    return this.queryService.getRecentEvents(limit);
+  async getRecentEvents(limit: number = 100, options?: RecentEventsReadOptions): Promise<MemoryEvent[]> {
+    return this.queryService.getRecentEvents(limit, options);
   }
 
   /**

--- a/tests/adapters/claude-hook-session-start.test.ts
+++ b/tests/adapters/claude-hook-session-start.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { formatCoreMemoryBlockContext } from '../../src/adapters/claude/hooks/session-start.js';
-import type { CoreMemoryBlock } from '../../src/core/types.js';
+import {
+  formatCoreMemoryBlockContext,
+  selectSessionStartMemories,
+  sessionStartExcerpt
+} from '../../src/adapters/claude/hooks/session-start.js';
+import type { CoreMemoryBlock, EventType, MemoryEvent } from '../../src/core/types.js';
 
 function block(overrides: Partial<CoreMemoryBlock> = {}): CoreMemoryBlock {
   return {
@@ -42,5 +46,155 @@ describe('formatCoreMemoryBlockContext', () => {
 
     expect(context).toContain('**Project**: Kept content.');
     expect(context).not.toContain('**User**:');
+  });
+});
+
+let eventSeq = 0;
+
+function event(eventType: EventType, content: string, isoTimestamp: string): MemoryEvent {
+  eventSeq += 1;
+  return {
+    id: `00000000-0000-4000-8000-${String(eventSeq).padStart(12, '0')}`,
+    eventType,
+    sessionId: 'session-1',
+    timestamp: new Date(isoTimestamp),
+    content,
+    canonicalKey: `key-${eventSeq}`,
+    dedupeKey: `dedupe-${eventSeq}`
+  };
+}
+
+const TOOL_JSON = '{"toolName":"Edit","toolInput":{"file_path":"/repo/src/a.ts","old_string":"const a = 1"}}';
+
+describe('selectSessionStartMemories', () => {
+  it('drops tool_observation entirely', () => {
+    // Measured over 118 session-start injections: content_overlap_score was
+    // exactly 0.0 for every tool_observation. Recency alone kept picking them
+    // because they are ~84% of all stored events.
+    const selected = selectSessionStartMemories(
+      [
+        event('tool_observation', TOOL_JSON, '2026-08-06T10:00:00.000Z'),
+        event('agent_response', 'The crash came from a null cwd in the daemon client.', '2026-08-01T10:00:00.000Z')
+      ],
+      3
+    );
+
+    expect(selected.map((e) => e.eventType)).toEqual(['agent_response']);
+  });
+
+  it('drops user_prompt, which is a question without its answer', () => {
+    const selected = selectSessionStartMemories(
+      [event('user_prompt', 'why is the daemon restarting?', '2026-08-06T10:00:00.000Z')],
+      3
+    );
+
+    expect(selected).toEqual([]);
+  });
+
+  it('drops the rule-based table-of-contents session summary', () => {
+    const selected = selectSessionStartMemories(
+      [
+        event('session_summary', 'Session with 5 user prompts and 8 responses. Topics discussed: - foo', '2026-08-06T10:00:00.000Z'),
+        event('agent_response', 'Root cause: the outbox lock was never released.', '2026-08-01T10:00:00.000Z')
+      ],
+      3
+    );
+
+    expect(selected.map((e) => e.eventType)).toEqual(['agent_response']);
+  });
+
+  it('drops the rule-based summary even when it has no 주요 작업 line', () => {
+    // deriveSessionSummary only emits "주요 작업:" when the session had prompts.
+    // A zero-prompt session yields "[date] 0턴 세션. 사용 툴: ..." — same
+    // worthless shape, but it slipped past a filter anchored on 주요 작업.
+    const selected = selectSessionStartMemories(
+      [
+        event('session_summary', '[2026-07-31] 0턴 세션. 사용 툴: Bash, Write, Edit', '2026-08-06T10:00:00.000Z'),
+        event('agent_response', 'Root cause: the outbox lock was never released.', '2026-08-01T10:00:00.000Z')
+      ],
+      3
+    );
+
+    expect(selected.map((e) => e.eventType)).toEqual(['agent_response']);
+  });
+
+  it('prefers a real session_summary over a more recent agent_response', () => {
+    const selected = selectSessionStartMemories(
+      [
+        event('agent_response', 'Renamed the helper to resolveHashBasisPath.', '2026-08-06T10:00:00.000Z'),
+        event('session_summary', '- 결정: 워크트리 해시를 메인 체크아웃으로 리다이렉트', '2026-08-01T10:00:00.000Z')
+      ],
+      2
+    );
+
+    expect(selected.map((e) => e.eventType)).toEqual(['session_summary', 'agent_response']);
+  });
+
+  it('orders newest first inside the same tier', () => {
+    const selected = selectSessionStartMemories(
+      [
+        event('agent_response', 'older finding', '2026-08-01T10:00:00.000Z'),
+        event('agent_response', 'newer finding', '2026-08-06T10:00:00.000Z')
+      ],
+      2
+    );
+
+    expect(selected.map((e) => e.content)).toEqual(['newer finding', 'older finding']);
+  });
+
+  it('honours the limit', () => {
+    const selected = selectSessionStartMemories(
+      [
+        event('agent_response', 'a', '2026-08-06T10:00:00.000Z'),
+        event('agent_response', 'b', '2026-08-05T10:00:00.000Z'),
+        event('agent_response', 'c', '2026-08-04T10:00:00.000Z')
+      ],
+      2
+    );
+
+    expect(selected).toHaveLength(2);
+  });
+
+  it('returns nothing rather than padding with unusable events', () => {
+    expect(
+      selectSessionStartMemories(
+        [
+          event('tool_observation', TOOL_JSON, '2026-08-06T10:00:00.000Z'),
+          event('user_prompt', 'fix it', '2026-08-05T10:00:00.000Z')
+        ],
+        3
+      )
+    ).toEqual([]);
+  });
+});
+
+describe('sessionStartExcerpt', () => {
+  it('keeps a short memory verbatim, with no truncation marker', () => {
+    const content = 'Root cause: the outbox lock was never released.';
+    expect(sessionStartExcerpt(event('agent_response', content, '2026-08-06T10:00:00.000Z'))).toBe(content);
+  });
+
+  it('gives session summaries a larger budget than agent responses', () => {
+    const long = 'x'.repeat(4000);
+    const summary = sessionStartExcerpt(event('session_summary', long, '2026-08-06T10:00:00.000Z'));
+    const response = sessionStartExcerpt(event('agent_response', long, '2026-08-06T10:00:00.000Z'));
+
+    expect(summary.length).toBeGreaterThan(response.length);
+  });
+
+  it('no longer cuts at the old 150-character boundary that split raw JSON mid-token', () => {
+    const content = 'A'.repeat(600);
+    expect(sessionStartExcerpt(event('agent_response', content, '2026-08-06T10:00:00.000Z')).length)
+      .toBeGreaterThan(150);
+  });
+
+  it('marks truncation with an ellipsis', () => {
+    expect(sessionStartExcerpt(event('agent_response', 'y'.repeat(4000), '2026-08-06T10:00:00.000Z')))
+      .toMatch(/\.\.\.$/);
+  });
+
+  it('collapses newlines so one memory stays one bullet', () => {
+    expect(sessionStartExcerpt(event('session_summary', '- 결정: A\n- 제약: B', '2026-08-06T10:00:00.000Z')))
+      .toBe('- 결정: A / - 제약: B');
   });
 });

--- a/tests/core/memory-engine-services.test.ts
+++ b/tests/core/memory-engine-services.test.ts
@@ -177,7 +177,7 @@ describe('createMemoryEngineServices', () => {
       expect(mdMirror.append).toHaveBeenCalledWith(expect.any(Object), 'event:user_prompt');
 
       await services.queryService.getRecentEvents(3);
-      expect(sqliteStore.getRecentEvents).toHaveBeenCalledWith(3);
+      expect(sqliteStore.getRecentEvents).toHaveBeenCalledWith(3, undefined);
       expect(sqliteStore.initialize).toHaveBeenCalledTimes(1);
       expect(initialize).not.toHaveBeenCalled();
 

--- a/tests/core/memory-query-service.test.ts
+++ b/tests/core/memory-query-service.test.ts
@@ -157,7 +157,7 @@ describe('MemoryQueryService', () => {
     expect(initialize).toHaveBeenCalledTimes(3);
     expect(queryStore.keywordSearch).toHaveBeenCalledWith('query', 3, { includeToolObservations: undefined });
     expect(queryStore.getSessionEvents).toHaveBeenCalledWith('session-1');
-    expect(queryStore.getRecentEvents).toHaveBeenCalledWith(2);
+    expect(queryStore.getRecentEvents).toHaveBeenCalledWith(2, undefined);
   });
 
   it('normalizes ascending FTS ranks with the strongest match at score one', async () => {

--- a/tests/core/project-path.test.ts
+++ b/tests/core/project-path.test.ts
@@ -54,9 +54,13 @@ describe('hashProjectPath worktree convergence', () => {
     expect(hashProjectPath(mainRoot)).toBe(legacyPathHash(mainRoot));
   });
 
-  it('keeps a subdirectory of the main checkout on its own pre-existing hash', () => {
-    expect(hashProjectPath(mainSubdir)).toBe(legacyPathHash(mainSubdir));
-    expect(hashProjectPath(mainSubdir)).not.toBe(hashProjectPath(mainRoot));
+  it('hashes a subdirectory of the main checkout the same as the checkout root', () => {
+    // A session started from a subdirectory (a monorepo package, a vendored
+    // tree) used to get its own hash and therefore a cold, empty store that no
+    // other session in the same repository could ever read. It now shares the
+    // repository's memory, the same way a worktree does.
+    expect(hashProjectPath(mainSubdir)).toBe(hashProjectPath(mainRoot));
+    expect(hashProjectPath(mainSubdir)).not.toBe(legacyPathHash(mainSubdir));
   });
 
   it('keeps a non-git directory on its own pre-existing hash', () => {
@@ -68,10 +72,30 @@ describe('hashProjectPath worktree convergence', () => {
     expect(resolveProjectAnchorPath(worktreeRoot)).toBe(mainRoot);
   });
 
-  it('anchors main checkouts, subdirectories, and non-git paths onto themselves', () => {
+  it('anchors a subdirectory onto its checkout root, matching where its hash points', () => {
+    expect(resolveProjectAnchorPath(mainSubdir)).toBe(mainRoot);
+  });
+
+  it('anchors main checkouts and non-git paths onto themselves', () => {
     expect(resolveProjectAnchorPath(mainRoot)).toBe(mainRoot);
-    expect(resolveProjectAnchorPath(mainSubdir)).toBe(mainSubdir);
     expect(resolveProjectAnchorPath(standaloneDir)).toBe(standaloneDir);
+  });
+
+  it('keeps a nested repository separate from its outer repository', () => {
+    // vendored/submodule trees own their .git, so they must not be folded into
+    // the outer checkout — only paths inside the same repository converge.
+    const nested = path.join(mainRoot, 'vendor', 'inner');
+    fs.mkdirSync(nested, { recursive: true });
+    git(nested, ['init', '-q']);
+    git(nested, ['config', 'user.email', 'test@example.com']);
+    git(nested, ['config', 'user.name', 'Test']);
+    git(nested, ['commit', '-q', '--allow-empty', '-m', 'init']);
+
+    expect(hashProjectPath(nested)).not.toBe(hashProjectPath(mainRoot));
+
+    const nestedSubdir = path.join(nested, 'pkg');
+    fs.mkdirSync(nestedSubdir, { recursive: true });
+    expect(hashProjectPath(nestedSubdir)).toBe(hashProjectPath(nested));
   });
 
   it('ignores inherited git env vars that would resolve another repository', () => {

--- a/tests/core/sqlite-event-store-recent-events-type-filter.test.ts
+++ b/tests/core/sqlite-event-store-recent-events-type-filter.test.ts
@@ -82,6 +82,29 @@ describe('SQLiteEventStore.getRecentEvents event type filter', () => {
     await store.close();
   });
 
+  it('resolves the filtered scan from an index instead of walking the table', async () => {
+    // Without a (event_type, timestamp) index SQLite walks idx_events_timestamp
+    // backwards and evaluates the json_extract quarantine predicate on every
+    // row it visits. A store whose injectable types number fewer than the limit
+    // degrades to a full scan — on a 312MB store that measured 1.2s cold, on
+    // the SessionStart hook's critical path.
+    const store = new SQLiteEventStore(tempDbPath());
+    await store.initialize();
+    await seed(store);
+
+    const plan = store.getDatabase()
+      .prepare(
+        `EXPLAIN QUERY PLAN
+         SELECT * FROM events
+         WHERE 1=1 AND event_type IN ('session_summary', 'agent_response')
+         ORDER BY timestamp DESC LIMIT 60`
+      )
+      .all() as Array<{ detail: string }>;
+
+    expect(plan.map((row) => row.detail).join(' ')).toContain('idx_events_type_timestamp');
+    await store.close();
+  });
+
   it('treats an empty filter list as no filter rather than as "match nothing"', async () => {
     const store = new SQLiteEventStore(tempDbPath());
     await store.initialize();

--- a/tests/core/sqlite-event-store-recent-events-type-filter.test.ts
+++ b/tests/core/sqlite-event-store-recent-events-type-filter.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { SQLiteEventStore } from '../../src/core/sqlite-event-store.js';
+
+const tempDirs: string[] = [];
+
+function tempDbPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'cml-recent-type-filter-'));
+  tempDirs.push(dir);
+  return join(dir, 'events.sqlite');
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+async function seed(store: SQLiteEventStore): Promise<void> {
+  // Mirrors the real distribution: tool observations dominate, so an unfiltered
+  // recency window is almost entirely made of them.
+  for (let i = 0; i < 20; i += 1) {
+    await store.append({
+      eventType: 'tool_observation',
+      sessionId: 's1',
+      timestamp: new Date(Date.UTC(2026, 7, 6, 0, i)),
+      content: `{"toolName":"Bash","toolInput":{"command":"echo ${i}"}}`
+    });
+  }
+  await store.append({
+    eventType: 'session_summary',
+    sessionId: 's1',
+    timestamp: new Date(Date.UTC(2026, 7, 1)),
+    content: '- 결정: 워크트리 해시를 메인 체크아웃으로 리다이렉트'
+  });
+  await store.append({
+    eventType: 'agent_response',
+    sessionId: 's1',
+    timestamp: new Date(Date.UTC(2026, 7, 2)),
+    content: 'Root cause: the outbox lock was never released.'
+  });
+}
+
+describe('SQLiteEventStore.getRecentEvents event type filter', () => {
+  it('returns every type when no filter is given', async () => {
+    const store = new SQLiteEventStore(tempDbPath());
+    await store.initialize();
+    await seed(store);
+
+    const events = await store.getRecentEvents(5);
+
+    expect(events.map((e) => e.eventType)).toEqual(Array(5).fill('tool_observation'));
+    await store.close();
+  });
+
+  it('reaches rare types without loading the dominant ones', async () => {
+    const store = new SQLiteEventStore(tempDbPath());
+    await store.initialize();
+    await seed(store);
+
+    const events = await store.getRecentEvents(5, {
+      eventTypes: ['session_summary', 'agent_response']
+    });
+
+    expect(events.map((e) => e.eventType).sort()).toEqual(['agent_response', 'session_summary']);
+    await store.close();
+  });
+
+  it('still orders newest first inside the filter', async () => {
+    const store = new SQLiteEventStore(tempDbPath());
+    await store.initialize();
+    await seed(store);
+
+    const events = await store.getRecentEvents(5, {
+      eventTypes: ['session_summary', 'agent_response']
+    });
+
+    expect(events.map((e) => e.eventType)).toEqual(['agent_response', 'session_summary']);
+    await store.close();
+  });
+
+  it('treats an empty filter list as no filter rather than as "match nothing"', async () => {
+    const store = new SQLiteEventStore(tempDbPath());
+    await store.initialize();
+    await seed(store);
+
+    expect(await store.getRecentEvents(3, { eventTypes: [] })).toHaveLength(3);
+    await store.close();
+  });
+});


### PR DESCRIPTION
## 배경

배포 후 며칠간의 실사용 데이터를 점검하다 발견한 문제입니다. SessionStart 레인은 최근 이벤트 3건을 **타입 구분 없이** 주입해 왔습니다. 그런데 저장된 이벤트의 84%가 `tool_observation`이라, 이 recency 규칙은 사실상 원시 `{"toolName":...}` JSON을 150자에서 잘라 넣는 동작이었습니다.

`memory_helpfulness` 실측(2026년 8월, session_start 주입 222건):

| 주입된 타입 | 건수 | content_overlap_score |
|---|---:|---:|
| `tool_observation` | 118 (53%) | **0.000** |
| `agent_response` | 77 | 0.123 |
| `user_prompt` | 14 | **0.000** |
| `session_summary` | 13 | 0.063 |

레인별로도 격차가 큽니다 — session_start 평균 0.05 / 유효(≥0.3) 적중률 약 3%, user_prompt 평균 0.13 / 약 15%. 랭킹 로직(`rankHookCandidates`)이 prompt 레인에만 적용되고 있던 게 원인입니다.

## 변경 내용

- **타입 티어 랭킹 도입** — grounding이 한 번도 잡히지 않은 `tool_observation`·`user_prompt`를 제외하고, 결과가 축적되는 `session_summary`를 `agent_response`보다 우선합니다. 쿼리가 없는 레인이라 점수 기반 prompt 랭커는 재사용할 수 없어 타입 티어로 정렬합니다.
- **150자 하드컷 제거** — 문장·JSON을 토큰 중간에서 끊던 것을 타입별 예산(요약 900자 / 응답 400자)과 경계 보정으로 교체했습니다. 계측값(`injectedContent`)도 실제 주입 문자열과 일치시켰습니다.
- **`getRecentEvents`에 `eventTypes` 필터 추가** — 주입 대상 타입이 전체의 소수(요약 약 2%)라, 필터 없이는 요약에 아예 닿지 못하거나 대용량 tool 페이로드를 수천 건 읽어야 했습니다. 실제로 200건 윈도우를 떠 봐도 주요 3개 프로젝트 모두 요약이 0건이었습니다.
- **`isPromptOnlySessionSummary` 보강** — 룰 기반 생성기의 무프롬프트 변형(`[date] 0턴 세션. 사용 툴: ...`)이 `주요 작업:`에 앵커된 기존 정규식을 빠져나가고 있었습니다. 생성기 접두사 기준으로 바꿨습니다.

## 검증

- `npm run verify` (typecheck + lint + 테스트) — **1,173건 통과**
- `npm run check:architecture` — 통과
- `npm run eval:retrieval-replay` — 통과 (nDCG@3 0.806, forbidden hits 0, failures 0)
- `npm run build` — 통과

### 실 스토어 3곳 대조

```
BEFORE: {"toolName":"Bash","toolInput":{"command":"cat src/sync/chatResponse...
AFTER:  - 결정: UI 계약(canSendAll)과 도메인 로직(hasResult)의 불일치로 확정된
          리뷰가 재개될 수 있음 → 회귀 테스트로 고정
        - 제약: 중간 턴 종료 직후 서브에이전트가 돌면 freeze effect로...
```

### 성능

타입 필터를 받쳐 줄 인덱스가 없어 timestamp 인덱스를 역방향 스캔하는 문제가 리뷰에서 지적됐고, 확인 결과 사실이라 복합 인덱스 `idx_events_type_timestamp`를 추가했습니다(`e60513b`).

312MB / 20,625행 스토어 실측:

| 케이스 | 인덱스 전 | 인덱스 후 |
|---|---:|---:|
| 현재 타입 조합 | 1.23ms | 1.01ms |
| 희소 타입(매칭 60건 미만 → 전체 스캔) | 36ms warm / **1.21s cold** | ~0ms |

주입 대상 행을 38,192건까지 늘린 합성 스토어에서도 인덱스 쪽이 계속 빠릅니다(1.02ms → 0.75ms). 플랜에 `USE TEMP B-TREE`가 뜨지만 실제로는 조기 종료하므로 행 수에 비례해 나빠지지 않습니다.

기존 `CREATE INDEX IF NOT EXISTS` 블록에 추가해 별도 마이그레이션은 없습니다. 기존 스토어는 첫 `initialize()`에서 1회 생성 비용을 냅니다(위 스토어 기준 1.8초, 디스크 +1.3MB).

### 검토했으나 변경하지 않은 것

세션당 요약 이벤트가 최대 8건이라 top-3이 같은 세션으로 채워질 위험을 의심했으나, 세 스토어의 연속 3-윈도우 **420건 전수에서 중복 세션 0건**이었습니다. 세션 단위 dedup은 불필요한 복잡성이라 추가하지 않았습니다.

## 남은 과제

이 패치의 효과는 **아직 측정되지 않았습니다**. 며칠 뒤 `memory_helpfulness`에서 `source='session_start'`의 `content_overlap_score`가 0.05 → 0.13(user_prompt 레인 수준) 이상으로 올라가는지로 판정해야 합니다. 생성률·저장률 같은 프록시 지표로는 판정하지 않습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# P2 — 스토어 파편화 (`8b6921c`)

## 문제

프로젝트 해시는 경로의 `.git`을 소유한 메인 체크아웃에서 파생되는데, **하위 디렉터리만 예외적으로 자기 경로를 기준**으로 삼고 있었습니다("기존 해시가 이동하지 않도록"). 모노레포 패키지나 vendor 트리에서 세션을 시작하면 같은 저장소의 다른 세션이 절대 읽을 수 없는 빈 스토어가 새로 생깁니다.

실제 스토어 90여 개를 분류한 결과입니다:

| 종류 | 스토어 | 이벤트 |
|---|---:|---:|
| main (정상) | 9 | 37,863 |
| worktree | 13 | 2,747 |
| path-gone (워크트리 삭제됨) | 19 | 1,994 |
| non-git | 10 | 849 |
| **subdir (이 버그)** | **8** | **285** |
| unknown (레거시 스키마) | 30 | 18 |

subdir 8개 중 `aplus-dev-studio/packages/web-ui`는 8월 5일까지 쓰였는데 부모 저장소의 기억과 완전히 단절돼 있었습니다.

참고로 파편화의 **지배적 원인은 이 규칙이 아니라 워크트리 해석이 도입되기 전의 레거시 스토어**입니다(path-gone + 이미 고아 = 약 2,960 이벤트). 초기 분석에서 subdir를 주원인으로 추정했던 것을 정정합니다.

## 변경 내용

**해시 수렴** — 워크트리·체크아웃 루트·하위 디렉터리가 모두 메인 체크아웃으로 수렴합니다. 루트 자신은 이미 그 값으로 해시되므로 **기존 프로젝트 해시는 이동하지 않습니다**(실 스토어 검증: main 종류 9개 중 해시가 바뀐 것 0개). 중첩 저장소는 자체 `.git`을 가져 common dir이 달라지므로 바깥 체크아웃에 흡수되지 않습니다(회귀 테스트 추가).

**`scripts/consolidate-orphaned-stores.mjs`** — 해시 해석이 생기기 전에 만들어져 아무도 조회하지 않는 스토어(현재 11개, 966 이벤트)를 현재 경로가 해석되는 스토어로 접어 넣습니다. 기존 ops 스크립트 관례대로 기본 dry-run, `--apply`로만 기록합니다.

- `events`·`sessions`를 `INSERT OR IGNORE`로 병합 (`dedupe_key` UNIQUE, `id` PK)
- FTS는 `events` 트리거가 유지하므로 별도 처리 불필요
- 병합된 이벤트는 대상 스토어에 벡터가 없으므로 `vector_outbox`에 큐잉
- 원본은 삭제하지 않고 `<hash>.merged-<timestamp>`로 이동

## 검증

실제 스토어 사본으로 `--apply` 검증:

| 항목 | 결과 |
|---|---|
| 이벤트 | 1,368 → 1,420 |
| FTS | 1,420 (트리거로 동기 유지) |
| 중복 id | 0 |
| `PRAGMA integrity_check` | ok |
| 재실행 | copied 0 / deduped 52 (멱등) |

샌드박스 검증 중 실제 버그 2건을 발견해 고쳤습니다 — 같은 분에 재실행하면 아카이브 디렉터리 이름이 충돌해 `ENOTEMPTY`로 죽었고, 그 예외가 배치 전체를 중단시켰습니다. 이름 유니크화 + 스토어별 실패 격리로 수정했습니다.

`npm run verify` **1,175건 통과**, architecture / 리플레이 벤치마크 통과.
