### PR TITLE
[behavioral] postinstall 전역 설치 설정 상속 문제 수정 (v2.2.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-memory-layer",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-memory-layer",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-memory-layer",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Project-scoped memory layer for Claude Code, Codex, Hermes, MCP, and dashboards",
   "main": "dist/index.js",
   "bin": {

--- a/scripts/postinstall-embedding-backend.cjs
+++ b/scripts/postinstall-embedding-backend.cjs
@@ -120,13 +120,37 @@ function shouldAttemptAutoInstall({ cudaMajor, transformersAvailable, skipReques
   return !skipRequested && (!transformersAvailable || cudaMajor === 11);
 }
 
+/**
+ * npm settings that decide *where* an install lands. The parent `npm install
+ * -g claude-memory-layer` exports these, and a child process inherits them —
+ * which silently put the nested `npm install --prefix <backend>` into global
+ * mode. transformers then landed in <backend>/lib/node_modules (the global
+ * layout) rather than <backend>/node_modules, leaving the backend broken and
+ * every mem-* tool reporting "Required embedding backend is not installed".
+ *
+ * Only location settings are stripped; registry, proxy, and auth settings the
+ * install needs are left alone.
+ */
+const INHERITED_NPM_LOCATION_SETTINGS = [
+  'npm_config_global',
+  'npm_config_location',
+  'npm_config_prefix',
+  'npm_config_local_prefix'
+];
+
 function createRepairEnv(env = process.env) {
-  return {
+  const repairEnv = {
     ...env,
     ONNXRUNTIME_NODE_INSTALL_CUDA: 'skip',
     npm_config_onnxruntime_node_install_cuda: 'skip',
     [REPAIR_GUARD_ENV]: '1'
   };
+
+  for (const setting of INHERITED_NPM_LOCATION_SETTINGS) {
+    delete repairEnv[setting];
+  }
+
+  return repairEnv;
 }
 
 function createNpmInstallArgs(rootDir = process.cwd()) {
@@ -167,7 +191,15 @@ function runPostinstall({
     stdio: 'inherit'
   });
 
-  if (result.error || result.status !== 0) {
+  // A zero exit only says npm ran, not that the backend is usable — an install
+  // that lands in the wrong layout still exits 0. Re-run the health check so a
+  // broken backend is reported here instead of surfacing days later as
+  // "Required embedding backend is not installed" on every mem-* call.
+  const repaired = result.error || result.status !== 0
+    ? false
+    : isEmbeddingBackendAvailableImpl(rootDir, execFileSyncImpl);
+
+  if (!repaired) {
     warn('[claude-memory-layer] Required embedding backend repair failed. Semantic/vector embeddings may be unavailable until you run:');
     warn(`  ONNXRUNTIME_NODE_INSTALL_CUDA=skip npm install -g claude-memory-layer@latest`);
     if (result.error) warn(`  ${result.error.message}`);

--- a/tests/apps/postinstall-embedding-backend.test.ts
+++ b/tests/apps/postinstall-embedding-backend.test.ts
@@ -184,6 +184,54 @@ describe('embedding backend postinstall repair', () => {
     ]);
   });
 
+  it('drops the parent npm run\'s global-install settings from the repair env', () => {
+    // `npm install -g claude-memory-layer` exports its own config to this
+    // script. Inheriting it put the nested `npm install --prefix <backend>`
+    // into global mode, so transformers landed in <backend>/lib/node_modules
+    // (the global layout) instead of <backend>/node_modules and every mem-*
+    // tool failed with "Required embedding backend is not installed".
+    const postinstall = loadPostinstallModule();
+
+    const repairEnv = postinstall.createRepairEnv({
+      npm_config_global: 'true',
+      npm_config_location: 'global',
+      npm_config_prefix: '/Users/someone/.hermes/node',
+      npm_config_local_prefix: '/Users/someone/.hermes/node/lib/node_modules/claude-memory-layer',
+      npm_config_registry: 'https://registry.example.com/',
+      PATH: '/usr/bin'
+    });
+
+    expect(repairEnv.npm_config_global).toBeUndefined();
+    expect(repairEnv.npm_config_location).toBeUndefined();
+    expect(repairEnv.npm_config_prefix).toBeUndefined();
+    expect(repairEnv.npm_config_local_prefix).toBeUndefined();
+
+    // Unrelated npm settings the user needs to reach the registry must survive.
+    expect(repairEnv.npm_config_registry).toBe('https://registry.example.com/');
+    expect(repairEnv.PATH).toBe('/usr/bin');
+    expect(repairEnv.ONNXRUNTIME_NODE_INSTALL_CUDA).toBe('skip');
+  });
+
+  it('reports failure when the install exits 0 but leaves the backend unusable', () => {
+    // The npm child can succeed while installing into the wrong layout, which
+    // is how a broken backend previously passed as "repaired" and stayed
+    // broken until every mem-* tool failed days later.
+    const postinstall = loadPostinstallModule();
+    const warnings: string[] = [];
+
+    const result = postinstall.runPostinstall({
+      rootDir: '/tmp/claude-memory-layer-package',
+      env: {},
+      isEmbeddingBackendAvailableImpl: () => false,
+      spawnSyncImpl: () => ({ status: 0 }),
+      log: () => {},
+      warn: (message: string) => warnings.push(String(message))
+    });
+
+    expect(result).toMatchObject({ attempted: true, success: false });
+    expect(warnings.join('\n')).toMatch(/repair failed|unavailable/i);
+  });
+
   it('treats a resolvable but unloadable backend as unavailable so postinstall can repair it', () => {
     const postinstall = loadPostinstallModule();
 
@@ -217,7 +265,9 @@ describe('embedding backend postinstall repair', () => {
         platform: 'linux',
         arch: 'x64',
         execFileSyncImpl: () => '',
-        isEmbeddingBackendAvailableImpl: () => false,
+        // Unavailable on the pre-check, usable once the repair has run — the
+        // health check is consulted on both sides of the install.
+        isEmbeddingBackendAvailableImpl: () => calls.length > 0,
         spawnSyncImpl: (cmd, args, options) => {
           calls.push({ cmd, args, env: options.env });
           return { status: 0 };


### PR DESCRIPTION
## 문제

`npm install -g claude-memory-layer`는 자신의 npm 설정을 자식 프로세스에 export합니다. postinstall이 이를 그대로 물려받아 중첩된 `npm install --prefix <backend>`가 **전역 모드로 실행**됐습니다.

그 결과 transformers가 `<backend>/node_modules`가 아니라 전역 레이아웃인 `<backend>/lib/node_modules`에 설치되고, 백엔드가 파손된 채 남아 `mem-*` 도구 전체가 `Required embedding backend is not installed`로 죽습니다.

**전역 업데이트마다 재발했고 매번 수동 복구가 필요했습니다.** 실제로 v2.2.1 설치 시점(8/5 22:15)에도 재발해 다음 날까지 세션 요약 생성과 임베딩이 조용히 밀려 있었습니다.

## 변경 내용

**설치 위치 설정만 제거** — `npm_config_global` / `npm_config_location` / `npm_config_prefix` / `npm_config_local_prefix`를 복구 env에서 제거합니다. registry·proxy·auth 설정은 설치에 필요하므로 그대로 둡니다.

**설치 후 헬스체크 추가** — npm이 0으로 종료해도 백엔드가 못 쓰는 상태일 수 있는데, 기존 코드는 종료 코드만 보고 `repaired`를 출력했습니다. 이 조용한 성공 보고가 파손을 며칠간 감춘 원인이라, 설치 후 헬스체크를 다시 돌려 실패를 그 자리에서 보고합니다.

## 검증

전역 모드 env를 재현한 **실제 설치**로 대조했습니다:

| | `node_modules/@huggingface` | `lib/node_modules` (전역 레이아웃) | 출력 |
|---|---|---|---|
| 수정 전 (`origin/main`) | ❌ 없음 | ⚠️ 생성됨 | "repaired" (오보) |
| 수정 후 | ✅ 정상 | 없음 | "repaired" |

`npm run verify` **1,177건 통과** (postinstall 테스트 2건 추가).

## 릴리스

버전을 **2.2.2**로 올렸습니다(동작 수정이므로 patch). self-dependency 없음 확인(`npm list claude-memory-layer` → `(empty)`), lock 파일 동기화 완료.

머지 후 `npm publish`가 필요합니다. 이 수정이 배포되면 **다음 전역 업데이트부터는 수동 복구가 필요 없습니다** — 다만 이번 설치 자체는 아직 구 postinstall(2.2.1)로 실행되므로, 이번 한 번은 기존 복구 절차가 필요할 수 있습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)