### PR TITLE
[behavioral] SessionStart 주입에서 요약 우선 랭킹 제거 (v2.2.3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-memory-layer",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-memory-layer",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-memory-layer",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Project-scoped memory layer for Claude Code, Codex, Hermes, MCP, and dashboards",
   "main": "dist/index.js",
   "bin": {

--- a/src/adapters/claude/hooks/session-start.ts
+++ b/src/adapters/claude/hooks/session-start.ts
@@ -26,7 +26,7 @@ const CORE_MEMORY_BLOCK_LABELS: Record<CoreMemoryBlock['blockKey'], string> = {
 };
 
 /**
- * Injection tiers for the session-start lane, best first.
+ * Event types worth injecting at session start.
  *
  * Unlike the prompt lane there is no query here, so candidates cannot be
  * scored — the only lever is which event types are worth injecting at all.
@@ -38,11 +38,36 @@ const CORE_MEMORY_BLOCK_LABELS: Record<CoreMemoryBlock['blockKey'], string> = {
  *   session_summary    13 injections, content_overlap_score 0.063
  *
  * tool_observation and user_prompt never grounded a single response, so they
- * are excluded rather than ranked. Summaries come first because they are the
- * only events written as durable outcomes; a raw agent_response is a snapshot
- * of one turn.
+ * are excluded. The remaining two are NOT ranked against each other by type —
+ * see SESSION_START_MAX_SUMMARIES for why.
  */
 const SESSION_START_TIERS: EventType[] = ['session_summary', 'agent_response'];
+
+/**
+ * How many of the injected memories may be session summaries.
+ *
+ * This used to be unbounded, with event type as the *primary* sort key and
+ * session_summary ranked above agent_response — on the theory that summaries
+ * are durable outcomes while a response is a snapshot of one turn. A store
+ * always has more than three summaries inside the scan window, so in practice
+ * that meant agent_response was never injected at all.
+ *
+ * Measured across six active stores, that ranking cut session-start grounding
+ * by an order of magnitude:
+ *
+ *   before (recency-led, mostly agent_response)  150 scored, overlap 0.0810, 12.0% grounded
+ *   after  (type-led, entirely session_summary)   87 scored, overlap 0.0084,  1.1% grounded
+ *
+ * The reason shows up immediately in the injected text. An agent_response
+ * carries the concrete tokens the next prompt reuses — file paths, PR numbers,
+ * branch names, HEAD SHAs — and scored 0.53-0.94. A summary is abstract prose
+ * ("- 결정: ... / - 제약: ...") that shares almost no literal token with what
+ * the user types next, and scored 0.
+ *
+ * Summaries still earn one slot: they are the only thing that survives a
+ * session boundary intact. They just cannot crowd out the grounded type.
+ */
+const SESSION_START_MAX_SUMMARIES = 1;
 
 /** Per-type excerpt budgets. Summaries carry decisions, so they get more room. */
 const SESSION_START_EXCERPT_BUDGET: Partial<Record<EventType, number>> = {
@@ -62,33 +87,64 @@ const SESSION_START_MAX_MEMORIES = 3;
 const SESSION_START_SCAN_WINDOW = 60;
 
 /**
+ * Collapses a memory to a comparison key so the same outcome is not injected
+ * twice. Summaries get regenerated (Stop hook, then the crash backfill) and
+ * land as distinct events with byte-identical text, which showed up in
+ * production as the same bullet repeated back-to-back in one recap.
+ */
+function dedupeKeyFor(event: MemoryEvent): string {
+  return event.content.trim().replace(/\s+/g, ' ').slice(0, 200);
+}
+
+/**
  * Picks what to inject at session start.
  *
  * This lane used to take the 3 most recent events of any type. Because
  * tool_observation is ~84% of everything stored, recency alone meant the
  * recap was mostly raw `{"toolName":...}` JSON truncated mid-token — 118
  * such injections grounded exactly nothing.
+ *
+ * Selection is recency-first within the injectable types, with summaries
+ * capped (see SESSION_START_MAX_SUMMARIES) rather than ranked above responses.
  */
 export function selectSessionStartMemories(events: MemoryEvent[], limit: number): MemoryEvent[] {
   const usable = events.filter((event) => (
     SESSION_START_TIERS.includes(event.eventType)
     // The rule-based generator emits a table of contents ("Session with N
     // prompts. Topics discussed: ...") rather than an outcome. The prompt lane
-    // already excludes it; this lane must too or it outranks real summaries on
-    // type alone.
+    // already excludes it; this lane must too or it takes the summary slot away
+    // from a real one.
     && !(event.eventType === 'session_summary' && isPromptOnlySessionSummary(event.content))
     && event.content.trim().length > 0
   ));
 
-  return usable
+  const byRecency = usable
     .map((event, index) => ({ event, index }))
     .sort((a, b) => (
-      (SESSION_START_TIERS.indexOf(a.event.eventType) - SESSION_START_TIERS.indexOf(b.event.eventType))
-      || (b.event.timestamp.getTime() - a.event.timestamp.getTime())
+      (b.event.timestamp.getTime() - a.event.timestamp.getTime())
       || (a.index - b.index)
-    ))
-    .slice(0, limit)
-    .map((item) => item.event);
+    ));
+
+  const selected: MemoryEvent[] = [];
+  const seen = new Set<string>();
+  let summaries = 0;
+
+  for (const { event } of byRecency) {
+    if (selected.length >= limit) break;
+    if (event.eventType === 'session_summary') {
+      if (summaries >= SESSION_START_MAX_SUMMARIES) continue;
+      summaries += 1;
+    }
+    const key = dedupeKeyFor(event);
+    if (seen.has(key)) {
+      if (event.eventType === 'session_summary') summaries -= 1;
+      continue;
+    }
+    seen.add(key);
+    selected.push(event);
+  }
+
+  return selected;
 }
 
 /**

--- a/tests/adapters/claude-hook-session-start.test.ts
+++ b/tests/adapters/claude-hook-session-start.test.ts
@@ -118,7 +118,11 @@ describe('selectSessionStartMemories', () => {
     expect(selected.map((e) => e.eventType)).toEqual(['agent_response']);
   });
 
-  it('prefers a real session_summary over a more recent agent_response', () => {
+  it('does not rank a session_summary above a more recent agent_response', () => {
+    // Type used to be the primary sort key, which put summaries first
+    // unconditionally. Measured across six stores that dropped session-start
+    // grounding from 0.0810 to 0.0084: the concrete tokens the next prompt
+    // reuses live in the response, not in the summary's abstract bullets.
     const selected = selectSessionStartMemories(
       [
         event('agent_response', 'Renamed the helper to resolveHashBasisPath.', '2026-08-06T10:00:00.000Z'),
@@ -127,10 +131,73 @@ describe('selectSessionStartMemories', () => {
       2
     );
 
-    expect(selected.map((e) => e.eventType)).toEqual(['session_summary', 'agent_response']);
+    expect(selected.map((e) => e.eventType)).toEqual(['agent_response', 'session_summary']);
   });
 
-  it('orders newest first inside the same tier', () => {
+  it('keeps at most one session_summary so summaries cannot crowd out responses', () => {
+    // A real store always holds more than `limit` summaries inside the scan
+    // window, so an uncapped summary preference meant agent_response was never
+    // injected at all.
+    const selected = selectSessionStartMemories(
+      [
+        event('session_summary', '- 결정: A', '2026-08-06T10:00:00.000Z'),
+        event('session_summary', '- 결정: B', '2026-08-05T10:00:00.000Z'),
+        event('session_summary', '- 결정: C', '2026-08-04T10:00:00.000Z'),
+        event('agent_response', 'PR #1693 리뷰 완료. HEAD c0ffee12.', '2026-08-03T10:00:00.000Z'),
+        event('agent_response', 'outbox lock was never released.', '2026-08-02T10:00:00.000Z')
+      ],
+      3
+    );
+
+    expect(selected.map((e) => e.eventType)).toEqual([
+      'session_summary',
+      'agent_response',
+      'agent_response'
+    ]);
+    expect(selected[0].content).toBe('- 결정: A');
+  });
+
+  it('still injects the summary when it is the only usable memory', () => {
+    const selected = selectSessionStartMemories(
+      [event('session_summary', '- 결정: 워크트리 해시를 메인 체크아웃으로 리다이렉트', '2026-08-01T10:00:00.000Z')],
+      3
+    );
+
+    expect(selected.map((e) => e.eventType)).toEqual(['session_summary']);
+  });
+
+  it('drops a duplicate memory rather than injecting the same bullet twice', () => {
+    // The same outcome gets stored more than once (a Stop-hook write and the
+    // crash backfill land as distinct events with byte-identical text).
+    // Observed in production as one bullet repeated back-to-back in a recap.
+    const selected = selectSessionStartMemories(
+      [
+        event('agent_response', 'Root cause: the outbox lock was never released.', '2026-08-06T10:00:00.000Z'),
+        event('agent_response', 'Root cause: the outbox lock was never released.', '2026-08-05T10:00:00.000Z'),
+        event('agent_response', 'distinct finding', '2026-08-04T10:00:00.000Z')
+      ],
+      3
+    );
+
+    expect(selected.map((e) => e.content)).toEqual([
+      'Root cause: the outbox lock was never released.',
+      'distinct finding'
+    ]);
+  });
+
+  it('treats memories that differ only in whitespace as duplicates', () => {
+    const selected = selectSessionStartMemories(
+      [
+        event('agent_response', 'Root cause:  the  lock leaked.', '2026-08-06T10:00:00.000Z'),
+        event('agent_response', 'Root cause: the lock leaked.\n', '2026-08-05T10:00:00.000Z')
+      ],
+      3
+    );
+
+    expect(selected).toHaveLength(1);
+  });
+
+  it('orders newest first', () => {
     const selected = selectSessionStartMemories(
       [
         event('agent_response', 'older finding', '2026-08-01T10:00:00.000Z'),


### PR DESCRIPTION
## 문제

전역 설치본(v2.2.2) 실사용 데이터를 감사하다 발견했습니다. SessionStart 주입의 grounding이 붕괴해 있었습니다.

`selectSessionStartMemories`에서 이벤트 **타입이 1순위 정렬 키**였고 `session_summary`가 `agent_response`보다 위였습니다. 그런데 실제 스토어는 스캔 윈도우(60건) 안에 요약이 항상 3개를 넘습니다. 즉 **`agent_response`가 구조적으로 단 한 번도 주입될 수 없었습니다.**

## 측정

활성 스토어 6곳, `memory_helpfulness`의 `content_overlap_score` (NULL 제외):

| 구간 | source | 측정건수 | avg overlap | 양성률 |
|---|---|---:|---:|---:|
| ~07-31 | session_start | 1206 | 0.0280 | 4.3% |
| 08-01~05 | session_start | 417 | 0.0533 | 7.9% |
| 08-06~직전 | session_start | 150 | 0.0810 | 12.0% |
| **이후** | **session_start** | **87** | **0.0084** | **1.1%** |
| 08-06~직전 | user_prompt | 209 | 0.1917 | 30.1% |
| 이후 | user_prompt | 138 | 0.1867 | 26.8% |

`user_prompt` 리트리벌 경로는 변동이 없습니다. 회귀는 `session_start` 레인에만 발생했습니다.

## 원인

주입 텍스트를 직접 보면 바로 드러납니다.

- **이전** — `agent_response` 원문: `PR #1693 리뷰 완료... 워크트리: /Users/.../pr-1693-review (브랜치 pr-1693-review, HEAD c...)` → overlap **0.81~0.94**
- **이후** — `session_summary` 불릿: `- 결정: seq 하트비트 게이트 도입 / - 실패: ... / - 제약: ...` → overlap **0**

다음 프롬프트가 재사용하는 구체 토큰(파일 경로·PR 번호·브랜치·HEAD SHA)은 응답 원문에 있지 요약의 추상 산문에는 없습니다. "상위 티어 메모리가 더 좋은 주입"이라는 가정이 grounding을 깎은 사례입니다.

## 변경

- 정렬을 **최신순 단일 기준**으로 되돌림 (타입 정렬 키 제거)
- 요약은 순위가 아니라 **1건 쿼터**(`SESSION_START_MAX_SUMMARIES`)로 제한 — 세션 경계를 넘어 살아남는 요약의 가치는 유지하되 grounded 타입을 밀어내지 못하게
- **중복 주입 제거** — Stop 훅 기록과 크래시 백필이 같은 텍스트를 별개 이벤트로 남겨, 한 recap에 같은 불릿이 연속 2회 나오던 사례를 두 프로젝트에서 확인

## 검증

- 전체 스위트 **184파일 / 1,181테스트 통과**
- 패치된 훅 스모크 테스트: 요약 1건 + `agent_response` 형태로 정상 주입 확인
- 다른 훅 번들 5개는 v2.2.2 전역 설치본과 바이트 단위 동일 — 이 변경만 격리됨

## 효과 판정

배포 후 며칠 뒤 아래 쿼리로 `session_start`의 overlap이 0.05 이상 회복하는지로 판정합니다. 생성률·저장률 같은 프록시 지표로 판정하지 않습니다.

```sql
SELECT source, AVG(content_overlap_score)
FROM memory_helpfulness
WHERE content_overlap_score IS NOT NULL AND created_at > ?
GROUP BY source;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)