### PR TITLE
ci: 태그 푸시로 npm 배포하는 워크플로 추가

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,150 @@
+name: Publish to npm
+
+# Triggered by a `v<semver>` tag, matching the tags scripts/release-npm.sh has
+# always created. The tag's version MUST equal package.json's version or the
+# job fails before publishing — that check is the whole point of tagging
+# rather than publishing from a branch.
+#
+# Release flow:
+#   1. Merge the change to main (CI must be green).
+#   2. Bump the version on main: `npm version <patch|minor|major> --no-git-tag-version`
+#      and commit as `chore(release): v<version>`.
+#   3. `git tag v<version> && git push origin v<version>`.
+#
+# scripts/release-npm.sh remains the local path; it runs the same guards plus a
+# managed-embedding-backend audit that needs the real postinstall download.
+#
+# Setup (already done): Settings → Secrets and variables → Actions →
+# NPM_TOKEN = an npm automation token allowed to publish this package.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  # Lets a failed publish be retried against an existing tag without having to
+  # delete and re-push it.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing v<semver> tag to publish'
+        required: true
+
+concurrency:
+  group: publish-npm-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: verify · pack · publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write # npm provenance
+    env:
+      # The isolated embedding backend downloads models over the network on
+      # postinstall. CI never exercises it, and letting it run would make every
+      # release depend on a model host being up.
+      CLAUDE_MEMORY_LAYER_SKIP_EMBEDDING_POSTINSTALL: '1'
+      ONNXRUNTIME_NODE_INSTALL_CUDA: skip
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify tag matches package version
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          RAW_TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          TAG="${RAW_TAG#v}"
+          if [ "$VERSION" != "$TAG" ]; then
+            echo "::error::tag/version mismatch — tag=$TAG package.json=$VERSION"
+            exit 1
+          fi
+          echo "OK — publishing $VERSION from tag v$TAG"
+
+      - name: Verify version is not already published
+        run: |
+          NAME="$(node -p "require('./package.json').name")"
+          VERSION="$(node -p "require('./package.json').version")"
+          if npm view "$NAME@$VERSION" version >/dev/null 2>&1; then
+            echo "::error::$NAME@$VERSION already exists on npm; versions are immutable"
+            exit 1
+          fi
+
+      # The recurring failure mode for this package (see CLAUDE.md): a self
+      # dependency gets restored from package-lock.json on the next install and
+      # ships a cyclic tree.
+      - name: Guard against self-dependency
+        run: node scripts/guard-release-artifact.cjs self-dependency
+
+      - name: Audit production dependencies
+        run: npm audit --omit=dev
+
+      - name: Typecheck · lint · test · build
+        run: npm run prepublishOnly
+
+      - name: Architecture import boundaries
+        run: npm run check:architecture
+
+      - name: Guard tarball contents
+        run: |
+          npm pack --dry-run --json > /tmp/pack-dry-run.json
+          node scripts/guard-release-artifact.cjs tarball /tmp/pack-dry-run.json
+
+      - name: Pack release tarball
+        id: pack
+        run: |
+          TARBALL="$(npm pack --silent --pack-destination "$RUNNER_TEMP")"
+          echo "tarball=$RUNNER_TEMP/$TARBALL" >> "$GITHUB_OUTPUT"
+          ls -la "$RUNNER_TEMP/$TARBALL"
+
+      # Publishing the exact tarball that was just guarded, rather than letting
+      # npm re-pack at publish time, keeps what was inspected and what ships
+      # identical.
+      - name: Publish to npm
+        run: npm publish "${{ steps.pack.outputs.tarball }}" --access public --tag latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: 'true'
+
+      - name: Verify registry propagation
+        run: |
+          NAME="$(node -p "require('./package.json').name")"
+          VERSION="$(node -p "require('./package.json').version")"
+          for attempt in $(seq 1 20); do
+            TARBALL_URL="$(npm view "$NAME@$VERSION" dist.tarball 2>/dev/null || true)"
+            if [ -n "$TARBALL_URL" ] && curl -fsI "$TARBALL_URL" >/dev/null; then
+              echo "published: $TARBALL_URL"
+              exit 0
+            fi
+            echo "waiting for npm propagation ($attempt/20)"
+            sleep 15
+          done
+          echo "::error::$NAME@$VERSION did not propagate"
+          exit 1
+
+      # A fresh install from the registry catches packaging faults the local
+      # tree hides — a missing `files` entry, or a bin that is not executable.
+      - name: Fresh-install smoke test
+        run: |
+          NAME="$(node -p "require('./package.json').name")"
+          VERSION="$(node -p "require('./package.json').version")"
+          WORKDIR="$(mktemp -d)"
+          cd "$WORKDIR"
+          npm init -y >/dev/null
+          npm install "$NAME@$VERSION"
+          node -e "const p=require('$WORKDIR/node_modules/$NAME/package.json'); console.log(JSON.stringify({name:p.name,version:p.version,bin:p.bin},null,2))"
+          ./node_modules/.bin/claude-memory-layer --version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,8 +23,27 @@ npm list claude-memory-layer
 ```
 
 ## npm Publish Workflow
-1. Self-dependency 확인: `npm list claude-memory-layer` → `(empty)` 확인
-2. 버전 업데이트: package.json 직접 수정 또는 `npm version patch`
-3. 빌드: `npm run build`
-4. 배포: `npm publish --otp=<코드>`
+
+기본 경로는 **태그 푸시 → GitHub Actions**다. 로컬에서 `npm publish`를 직접 실행하지 말 것 — OTP 없이 재현 가능하고, provenance가 붙고, 가드가 항상 동일하게 돌아간다.
+
+1. 변경사항을 main에 머지 (CI 통과 필수)
+2. main에서 버전 올리고 커밋:
+   ```bash
+   npm version <patch|minor|major> --no-git-tag-version
+   git commit -am "chore(release): v$(node -p "require('./package.json').version")"
+   git push origin main
+   ```
+3. 태그 푸시 → 배포가 자동 시작됨:
+   ```bash
+   git tag "v$(node -p "require('./package.json').version")"
+   git push origin "v$(node -p "require('./package.json').version")"
+   ```
+4. 진행 확인: `gh run watch` 또는 Actions 탭의 "Publish to npm"
 5. 확인: `npm view claude-memory-layer versions`
+
+`.github/workflows/publish-npm.yml`이 배포 전에 강제하는 것: 태그와 package.json 버전 일치, 이미 배포된 버전인지, self-dependency, `npm audit --omit=dev`, typecheck·lint·test·build, 아키텍처 경계, 타르볼 내용물. 배포 후에는 레지스트리 전파와 신규 설치 스모크 테스트까지 확인한다. 실패한 배포는 태그를 지웠다 다시 만들 필요 없이 `workflow_dispatch`로 재실행하면 된다.
+
+### 로컬 배포 (예외 경로)
+`npm run release:npm -- --otp=<코드>` 는 위 가드에 더해 관리형 임베딩 백엔드 audit까지 수행한다(실제 postinstall 다운로드가 필요해 CI에서는 못 도는 검사). 백엔드 패키징을 건드렸을 때만 이 경로를 쓸 것.
+
+두 경로 모두 `scripts/guard-release-artifact.cjs`의 동일한 가드를 호출한다.

--- a/scripts/guard-release-artifact.cjs
+++ b/scripts/guard-release-artifact.cjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * Release artifact guards, shared by scripts/release-npm.sh and the
+ * publish-npm workflow so a local release and a tag-triggered release enforce
+ * the same rules. Previously these lived only as heredocs inside the shell
+ * script, which meant CI had no way to run them.
+ *
+ * Usage:
+ *   node scripts/guard-release-artifact.cjs self-dependency
+ *   node scripts/guard-release-artifact.cjs tarball <npm-pack-dry-run-json>
+ *
+ * Exits non-zero and prints what failed; prints a JSON summary on success.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+function fail(message) {
+  console.error(`ERROR: ${message}`);
+  process.exit(1);
+}
+
+function readPackageJson() {
+  return JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+}
+
+/**
+ * Self-dependency has been reintroduced repeatedly by `npm install` restoring
+ * it from package-lock.json, so it is checked on both files rather than
+ * package.json alone — a lock entry survives a hand-edit of package.json and
+ * puts the cycle straight back on the next install.
+ */
+function guardSelfDependency() {
+  const pkg = readPackageJson();
+  const fields = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'];
+  const offenders = fields.filter((field) => (
+    pkg[field] && Object.prototype.hasOwnProperty.call(pkg[field], pkg.name)
+  ));
+  if (offenders.length) {
+    fail(`self dependency on ${pkg.name} in package.json: ${offenders.join(', ')}`);
+  }
+
+  const lockPath = path.join(ROOT, 'package-lock.json');
+  if (fs.existsSync(lockPath)) {
+    const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+    const rootEntry = lock.packages && lock.packages[''];
+    const lockOffenders = rootEntry
+      ? fields.filter((field) => (
+        rootEntry[field] && Object.prototype.hasOwnProperty.call(rootEntry[field], pkg.name)
+      ))
+      : [];
+    if (lockOffenders.length) {
+      fail(`self dependency on ${pkg.name} in package-lock.json: ${lockOffenders.join(', ')}`);
+    }
+    if (lock.packages && lock.packages[`node_modules/${pkg.name}`]) {
+      fail(`package-lock.json contains a nested node_modules/${pkg.name} entry (self dependency)`);
+    }
+  }
+
+  console.log(JSON.stringify({ check: 'self-dependency', name: pkg.name, version: pkg.version, ok: true }));
+}
+
+/**
+ * Files that must never reach the registry: sources and tests (the package
+ * ships `dist/` only), and any local state that a developer machine
+ * accumulates — stores, caches, evaluation qrels, stray tarballs.
+ */
+const FORBIDDEN_IN_TARBALL = /(^|\/)\.claude-memory(\/|$)|(^|\/)graphify-out(\/|$)|cache|qrels|\.db$|\.sqlite|\.tgz$|^tests\/|^src\/|^specs\//;
+
+function guardTarball(packJsonPath) {
+  if (!packJsonPath) fail('usage: guard-release-artifact.cjs tarball <npm-pack-dry-run-json>');
+  const parsed = JSON.parse(fs.readFileSync(packJsonPath, 'utf8'));
+  const data = Array.isArray(parsed) ? parsed[0] : parsed;
+  if (!data || !Array.isArray(data.files)) fail(`unrecognised npm pack JSON in ${packJsonPath}`);
+
+  const suspicious = data.files
+    .map((file) => file.path)
+    .filter((filePath) => FORBIDDEN_IN_TARBALL.test(filePath));
+
+  console.log(JSON.stringify({
+    check: 'tarball',
+    name: data.name,
+    version: data.version,
+    filename: data.filename,
+    fileCount: data.files.length,
+    packageSize: data.size,
+    unpackedSize: data.unpackedSize,
+    suspicious
+  }, null, 2));
+
+  if (suspicious.length) fail(`${suspicious.length} forbidden file(s) would be published`);
+}
+
+const [command, ...rest] = process.argv.slice(2);
+switch (command) {
+  case 'self-dependency':
+    guardSelfDependency();
+    break;
+  case 'tarball':
+    guardTarball(rest[0]);
+    break;
+  default:
+    fail('usage: guard-release-artifact.cjs <self-dependency|tarball> [args]');
+}

--- a/scripts/release-npm.sh
+++ b/scripts/release-npm.sh
@@ -183,16 +183,7 @@ printf 'npm user: %s\n' "$NPM_USER"
 printf 'npm registry: %s\n' "$(npm config get registry)"
 
 log "Checking package metadata and self-dependency"
-node <<'NODE'
-const pkg = require('./package.json');
-const fields = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'];
-const offenders = fields.filter((field) => pkg[field] && Object.prototype.hasOwnProperty.call(pkg[field], pkg.name));
-if (offenders.length) {
-  console.error(`Self dependency detected for ${pkg.name} in: ${offenders.join(', ')}`);
-  process.exit(1);
-}
-console.log(JSON.stringify({ name: pkg.name, version: pkg.version, bin: pkg.bin, files: pkg.files }, null, 2));
-NODE
+node scripts/guard-release-artifact.cjs self-dependency
 
 log "Bumping version: ${OLD_VERSION} -> ${BUMP}"
 npm version "$BUMP" --no-git-tag-version >/dev/null
@@ -228,24 +219,7 @@ npm run prepublishOnly
 log "Checking npm tarball contents with npm pack --dry-run"
 PACK_JSON="$(mktemp)"
 npm pack --dry-run --json >"$PACK_JSON"
-node - "$PACK_JSON" <<'NODE'
-const fs = require('fs');
-const packPath = process.argv[2];
-const data = JSON.parse(fs.readFileSync(packPath, 'utf8'))[0];
-const suspicious = data.files
-  .map((file) => file.path)
-  .filter((path) => /(^|\/)\.claude-memory(\/|$)|(^|\/)graphify-out(\/|$)|cache|qrels|\.db$|\.sqlite|\.tgz$|^tests\/|^src\/|^specs\//.test(path));
-console.log(JSON.stringify({
-  name: data.name,
-  version: data.version,
-  filename: data.filename,
-  fileCount: data.files.length,
-  packageSize: data.size,
-  unpackedSize: data.unpackedSize,
-  suspicious,
-}, null, 2));
-if (suspicious.length) process.exit(1);
-NODE
+node scripts/guard-release-artifact.cjs tarball "$PACK_JSON"
 
 log "Scanning release diff for credential-shaped values"
 node <<'NODE'


### PR DESCRIPTION
`NPM_TOKEN` 시크릿이 등록되어 있어, `buzzni/happy`의 `publish-happy-cli.yml`과 같은 방식으로 배포를 CI로 옮깁니다.

## 왜

로컬 `npm publish`는 OTP를 손으로 넣어야 하고, 릴리스 가드가 실제로 도는지는 실행한 사람에게 달려 있었습니다. 태그를 밀면 배포되도록 옮기면 OTP가 사라지고, provenance가 붙고, 가드가 항상 같은 순서로 돕니다.

## 트리거

`v<semver>` 태그 푸시. `scripts/release-npm.sh`가 원래 만들던 태그 형식 그대로입니다.

```bash
npm version patch --no-git-tag-version
git commit -am "chore(release): v2.2.4" && git push origin main
git tag v2.2.4 && git push origin v2.2.4
```

태그와 `package.json` 버전이 다르면 **배포 전에** 실패합니다. 실패한 배포는 태그를 지웠다 다시 만들 필요 없이 `workflow_dispatch`로 재실행할 수 있습니다.

## 가드는 새로 만들지 않았습니다

`scripts/release-npm.sh` 안에 heredoc으로만 있어 **CI에서 돌릴 방법이 없던** 검사들을 `scripts/guard-release-artifact.cjs`로 꺼내 양쪽이 공유하게 했습니다.

self-dependency 가드는 `package-lock.json`까지 봅니다 — `package.json`만 고쳐도 다음 install 때 lock에서 복원되는 게 이 저장소의 반복 실패 모드입니다 (CLAUDE.md에 기록된 항목).

| 시점 | 검사 |
|---|---|
| 배포 전 | 태그·버전 일치 / 기존 버전 중복 / self-dependency / `npm audit --omit=dev` / typecheck·lint·test·build / 아키텍처 경계 / 타르볼 내용물 |
| 배포 | 검사한 **그 타르볼**을 publish (publish 시점 재pack 방지) |
| 배포 후 | 레지스트리 전파 확인 / 신규 설치 스모크 테스트 |

## 로컬 경로는 남겨둡니다

`npm run release:npm` 은 관리형 임베딩 백엔드 audit을 수행하는데, 실제 postinstall 다운로드가 필요해 CI에서는 돌릴 수 없습니다. 백엔드 패키징을 건드렸을 때 쓰는 예외 경로로 CLAUDE.md에 명시했습니다.

## 검증

- 가드 스크립트 양방향 확인 — 정상 통과, self-dependency 주입 시 exit 1
- `npm audit --omit=dev` → 0 vulnerabilities
- `npm run check:architecture` → 통과
- 타르볼 가드 → 57 파일, suspicious 0
- 워크플로 YAML 파싱 및 `bash -n` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)