### PR TITLE
fix(release): provenance가 요구하는 repository 메타데이터 추가

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -90,6 +90,12 @@ jobs:
       - name: Guard against self-dependency
         run: node scripts/guard-release-artifact.cjs self-dependency
 
+      # npm only reports a repository/provenance mismatch after the tarball is
+      # uploaded and the provenance statement is in the public transparency
+      # log, so catching it here saves a whole release run.
+      - name: Guard provenance repository match
+        run: node scripts/guard-release-artifact.cjs provenance
+
       - name: Audit production dependencies
         run: npm audit --omit=dev
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,14 @@
   ],
   "author": "Buzzni",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/buzzni/claude-memory-layer.git"
+  },
+  "homepage": "https://github.com/buzzni/claude-memory-layer#readme",
+  "bugs": {
+    "url": "https://github.com/buzzni/claude-memory-layer/issues"
+  },
   "engines": {
     "node": ">=20.19.0"
   },

--- a/scripts/guard-release-artifact.cjs
+++ b/scripts/guard-release-artifact.cjs
@@ -7,6 +7,7 @@
  *
  * Usage:
  *   node scripts/guard-release-artifact.cjs self-dependency
+ *   node scripts/guard-release-artifact.cjs provenance
  *   node scripts/guard-release-artifact.cjs tarball <npm-pack-dry-run-json>
  *
  * Exits non-zero and prints what failed; prints a JSON summary on success.
@@ -63,6 +64,33 @@ function guardSelfDependency() {
 }
 
 /**
+ * npm rejects a provenance-signed publish whose package.json `repository.url`
+ * does not match the repository the signature was minted from. The registry
+ * only reports that after the tarball has been uploaded and the provenance
+ * statement written to the public transparency log, so the failure costs a
+ * full release run — v2.2.3's first attempt died exactly here with an empty
+ * `repository.url`. Checking it before publish makes that a five-second
+ * failure instead.
+ */
+function guardProvenance() {
+  const pkg = readPackageJson();
+  const url = pkg.repository && (typeof pkg.repository === 'string' ? pkg.repository : pkg.repository.url);
+  if (!url) fail('package.json has no repository.url; npm provenance requires it');
+
+  // GITHUB_REPOSITORY is "owner/name"; only set inside Actions.
+  const ghRepo = process.env.GITHUB_REPOSITORY;
+  if (ghRepo) {
+    const expected = `https://github.com/${ghRepo}`;
+    const normalized = url.replace(/^git\+/, '').replace(/\.git$/, '');
+    if (normalized !== expected) {
+      fail(`repository.url is "${normalized}", expected "${expected}" — provenance would be rejected`);
+    }
+  }
+
+  console.log(JSON.stringify({ check: 'provenance', repository: url, matchedAgainst: ghRepo || null, ok: true }));
+}
+
+/**
  * Files that must never reach the registry: sources and tests (the package
  * ships `dist/` only), and any local state that a developer machine
  * accumulates — stores, caches, evaluation qrels, stray tarballs.
@@ -97,6 +125,9 @@ const [command, ...rest] = process.argv.slice(2);
 switch (command) {
   case 'self-dependency':
     guardSelfDependency();
+    break;
+  case 'provenance':
+    guardProvenance();
     break;
   case 'tarball':
     guardTarball(rest[0]);


### PR DESCRIPTION
v2.2.3 첫 자동 배포가 마지막 단계에서 실패했습니다. 가드 11개는 전부 통과했고 publish에서만 죽었습니다.

```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/claude-memory-layer
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "", expected to match
"https://github.com/buzzni/claude-memory-layer" from provenance
```

`package.json`에 `repository`가 아예 없었습니다. 지금까지의 배포는 provenance 없이 로컬에서 나갔기 때문에 드러나지 않던 문제입니다.

**레지스트리에는 아무것도 남지 않았습니다** — `npm view claude-memory-layer version` 은 여전히 `2.2.2`이고 `2.2.3`은 404입니다. 버전을 올릴 필요 없이 태그만 다시 밀면 됩니다.

## 변경

1. `repository` / `homepage` / `bugs` 추가 (npm 패키지 페이지 링크도 이제 제대로 걸립니다)
2. **provenance 가드 추가** — npm은 타르볼 업로드와 provenance 서명이 공개 투명성 로그에 기록된 *뒤에야* 이 불일치를 알려줍니다. 사후에 알면 릴리스 한 회차를 통째로 날리므로, 배포 전에 잡습니다.
   - CI(`GITHUB_REPOSITORY` 존재): 실제 저장소와 대조
   - 로컬: 필드 존재 여부만 확인

## 검증

```
로컬              → ok
GITHUB_REPOSITORY=buzzni/claude-memory-layer → ok
GITHUB_REPOSITORY=someone/else               → exit 1
  ERROR: repository.url is "...buzzni/claude-memory-layer",
         expected "...someone/else" — provenance would be rejected
```

`npm install --package-lock-only` 결과 `package-lock.json`은 영향 없음 → `npm ci` 정상.

머지 후 `v2.2.3` 태그를 이 커밋으로 옮겨 재배포합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)