### PR TITLE
fix(mcp): projectPath 생략 시 서버 cwd로 프로젝트 자동 해석

### DIFF
--- a/src/extensions/mcp/handlers.ts
+++ b/src/extensions/mcp/handlers.ts
@@ -82,6 +82,67 @@ type ToolResult = CallToolResult;
 
 type MemoryToolArgs = Record<string, unknown>;
 
+/**
+ * Cached because the MCP server's cwd is fixed for the life of the process —
+ * the client sets it at spawn — and resolving it shells out to git.
+ */
+let autoProjectPathCache: { cwd: string; resolved: string | null } | undefined;
+
+/**
+ * The project this MCP server was spawned for, inferred from its own cwd.
+ *
+ * Callers that omit `projectPath` used to land on the global store, which
+ * nothing in a hook-driven deployment ever writes to — every hook writes to a
+ * per-project store. A search without the argument therefore returned nothing
+ * while the project store held thousands of events, and the caller had no
+ * signal that it had queried the wrong place.
+ *
+ * cwd is a sound signal here: clients spawn one stdio server per session with
+ * cwd set to that session's directory. `hashProjectPath` already folds
+ * worktrees and subdirectories onto the main checkout, so any cwd inside a
+ * repository lands on exactly the store the hooks write to.
+ *
+ * Returns null unless a store already exists. That guard matters:
+ * `getMemoryServiceForProject` creates a store for whatever path it is given,
+ * so an unguarded fallback would litter `projects/` with empty stores for
+ * every non-project directory an MCP server happens to start in.
+ */
+function resolveAutoProjectPath(): string | null {
+  const cwd = process.cwd();
+  if (autoProjectPathCache?.cwd === cwd) return autoProjectPathCache.resolved;
+
+  let resolved: string | null = null;
+  try {
+    if (existsSync(path.join(getProjectStoragePath(cwd), 'events.sqlite'))) {
+      resolved = cwd;
+    }
+  } catch {
+    // Unreadable cwd or a git invocation that fails: fall back to global
+    // rather than failing the tool call.
+  }
+
+  autoProjectPathCache = { cwd, resolved };
+  return resolved;
+}
+
+/**
+ * Fills in `projectPath` from the server's cwd when the caller omitted it.
+ *
+ * Applied once at the entry point rather than at each use, because several
+ * tools read `args.projectPath` independently (the perspective validator, the
+ * import guard, the import handler); resolving in one place keeps them from
+ * disagreeing about which project a single call is about.
+ *
+ * An explicitly supplied value is never overridden, including a relative one —
+ * that stays an error rather than being silently replaced.
+ */
+export function withAutoProjectPath(args: Record<string, unknown>): Record<string, unknown> {
+  if (hasSuppliedArg(args, 'projectPath')) return args;
+  const autoPath = resolveAutoProjectPath();
+  if (!autoPath) return args;
+  return { ...args, projectPath: autoPath };
+}
+
 function resolveMemoryService(args: MemoryToolArgs): MemoryService {
   const projectPath = typeof args.projectPath === 'string' ? args.projectPath.trim() : '';
   if (projectPath.length > 0) {
@@ -123,12 +184,15 @@ function validateMemContextPackPerspectiveArgs(args: Record<string, unknown>): v
 
 export async function handleToolCall(
   name: string,
-  args: Record<string, unknown>
+  rawArgs: Record<string, unknown>
 ): Promise<ToolResult> {
   try {
     if (name === 'external-market-context') {
-      return await handleExternalMarketContext(args);
+      return await handleExternalMarketContext(rawArgs);
     }
+
+    // Every memory tool below shares one project, so resolve it once here.
+    const args = withAutoProjectPath(rawArgs);
 
     if (name === 'mem-context-pack' && hasMemContextPackPerspectiveArgs(args)) {
       validateMemContextPackPerspectiveArgs(args);
@@ -794,10 +858,18 @@ async function handlePerspectiveObservationDelete(context: MemoryOperationContex
   };
 }
 
+/**
+ * Still strict: by the time this runs, withAutoProjectPath has already filled
+ * in the cwd-derived path when one was available, so reaching the throw means
+ * neither the caller nor the environment identified a project.
+ */
 function requiredProjectPath(args: Record<string, unknown>): string {
   const projectPath = optionalString(args.projectPath);
   if (!projectPath || !isAbsoluteProjectPath(projectPath)) {
-    throw new Error('memory operation tools require an explicit absolute projectPath');
+    throw new Error(
+      'memory operation tools require an explicit absolute projectPath '
+      + `(no memory store exists for the server working directory "${process.cwd()}")`
+    );
   }
   return projectPath;
 }

--- a/tests/extensions/mcp-auto-project-path.test.ts
+++ b/tests/extensions/mcp-auto-project-path.test.ts
@@ -1,0 +1,137 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Callers that omit `projectPath` used to be routed to the global store, which
+ * nothing writes to in a hook-driven install — every hook writes per-project.
+ * These tests pin the cwd-derived fallback that replaced it, and the guard
+ * that keeps it from inventing stores for non-project directories.
+ *
+ * `getProjectStoragePath` is mocked so store existence is decided inside a
+ * temp directory. The real implementation resolves under the developer's
+ * `~/.claude-code/memory`, and a test must not create anything there.
+ */
+
+const mocks = vi.hoisted(() => {
+  function createService() {
+    return {
+      initialize: vi.fn(async () => undefined),
+      getStats: vi.fn(async () => ({ totalEvents: 0, vectorCount: 0 })),
+      getDistinctSessionCount: vi.fn(async () => 0),
+      getEventTypeCounts: vi.fn(async () => []),
+      getOutboxStats: vi.fn(async () => ({
+        embedding: { pending: 0, processing: 0, failed: 0, total: 0, stuckProcessing: 0, oldestProcessingAgeMs: null },
+        vector: { pending: 0, processing: 0, failed: 0, total: 0, stuckProcessing: 0, oldestProcessingAgeMs: null }
+      }))
+    };
+  }
+
+  return {
+    defaultService: createService(),
+    projectService: createService(),
+    getDefaultMemoryService: vi.fn(),
+    getMemoryServiceForProject: vi.fn(),
+    // Counts store-location lookups so the caching test can assert the
+    // resolver runs once per cwd rather than once per tool call.
+    getProjectStoragePath: vi.fn(),
+    // Set per test: maps a cwd to the directory that would hold its store.
+    storageRoot: { value: '' }
+  };
+});
+
+vi.mock('../../src/services/memory-service.js', () => ({
+  getDefaultMemoryService: mocks.getDefaultMemoryService,
+  getMemoryServiceForProject: mocks.getMemoryServiceForProject
+}));
+
+vi.mock('../../src/core/registry/project-path.js', () => ({
+  getProjectStoragePath: mocks.getProjectStoragePath,
+  hashProjectPath: (projectPath: string) => encodeURIComponent(projectPath).slice(0, 8)
+}));
+
+function storageDirFor(projectPath: string): string {
+  return path.join(mocks.storageRoot.value, encodeURIComponent(projectPath));
+}
+
+const { handleToolCall } = await import('../../src/extensions/mcp/handlers.js');
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cml-auto-project-'));
+mocks.storageRoot.value = tmpRoot;
+
+afterAll(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+/**
+ * Each test uses a distinct cwd on purpose: the resolver caches per cwd for
+ * the life of the process (the server's cwd never changes), so reusing one
+ * would leak the previous test's answer.
+ */
+let cwdSeq = 0;
+function useCwd(options: { withStore: boolean }): string {
+  cwdSeq += 1;
+  const cwd = path.join(tmpRoot, 'cwd', `project-${cwdSeq}`);
+  fs.mkdirSync(cwd, { recursive: true });
+  if (options.withStore) {
+    const storeDir = storageDirFor(cwd);
+    fs.mkdirSync(storeDir, { recursive: true });
+    fs.writeFileSync(path.join(storeDir, 'events.sqlite'), '');
+  }
+  vi.spyOn(process, 'cwd').mockReturnValue(cwd);
+  return cwd;
+}
+
+describe('MCP projectPath auto-resolution from cwd', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mocks.getDefaultMemoryService.mockReset().mockReturnValue(mocks.defaultService);
+    mocks.getMemoryServiceForProject.mockReset().mockReturnValue(mocks.projectService);
+    mocks.getProjectStoragePath.mockReset().mockImplementation(storageDirFor);
+  });
+
+  it('routes to the project store for the cwd when projectPath is omitted', async () => {
+    const cwd = useCwd({ withStore: true });
+
+    await handleToolCall('mem-stats', {});
+
+    expect(mocks.getMemoryServiceForProject).toHaveBeenCalledWith(cwd);
+    expect(mocks.getDefaultMemoryService).not.toHaveBeenCalled();
+  });
+
+  it('stays on the global store when the cwd has no store, rather than creating one', async () => {
+    useCwd({ withStore: false });
+
+    await handleToolCall('mem-stats', {});
+
+    // getMemoryServiceForProject creates a store for whatever path it gets, so
+    // never reaching it is the point: a server started outside a project must
+    // not litter projects/ with empty stores.
+    expect(mocks.getMemoryServiceForProject).not.toHaveBeenCalled();
+    expect(mocks.getDefaultMemoryService).toHaveBeenCalledTimes(1);
+  });
+
+  it('never overrides an explicitly supplied projectPath', async () => {
+    useCwd({ withStore: true });
+
+    await handleToolCall('mem-stats', { projectPath: '/explicit/project' });
+
+    expect(mocks.getMemoryServiceForProject).toHaveBeenCalledWith('/explicit/project');
+  });
+
+  it('resolves once per cwd instead of on every tool call', async () => {
+    // Resolution shells out to git via hashProjectPath, so repeating it for
+    // every call would tax a long-lived server for no new information — its
+    // cwd cannot change.
+    const cwd = useCwd({ withStore: true });
+
+    await handleToolCall('mem-stats', {});
+    await handleToolCall('mem-stats', {});
+    await handleToolCall('mem-stats', {});
+
+    expect(mocks.getProjectStoragePath).toHaveBeenCalledTimes(1);
+    expect(mocks.getMemoryServiceForProject).toHaveBeenCalledTimes(3);
+    expect(mocks.getMemoryServiceForProject).toHaveBeenNthCalledWith(3, cwd);
+  });
+});

--- a/tests/extensions/mcp-project-aware-tools.test.ts
+++ b/tests/extensions/mcp-project-aware-tools.test.ts
@@ -1,3 +1,5 @@
+import os from 'node:os';
+import path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => {
@@ -501,8 +503,18 @@ describe('MCP project-aware memory tools', () => {
     expect(mocks.projectService.getRecentEvents).not.toHaveBeenCalled();
   });
 
-  it('falls back to the global memory service when projectPath is absent', async () => {
-    await handleToolCall('mem-stats', {});
+  it('falls back to the global memory service when projectPath is absent and cwd has no store', async () => {
+    // cwd is pinned to a directory that cannot have a memory store, so the
+    // assertion is about the fallback itself rather than about whichever
+    // project the test runner happened to start in. Auto-resolution from cwd
+    // is covered in mcp-auto-project-path.test.ts.
+    const cwdSpy = vi.spyOn(process, 'cwd')
+      .mockReturnValue(path.join(os.tmpdir(), `cml-no-store-${process.pid}-${Date.now()}`));
+    try {
+      await handleToolCall('mem-stats', {});
+    } finally {
+      cwdSpy.mockRestore();
+    }
 
     expect(mocks.getDefaultMemoryService).toHaveBeenCalledTimes(1);
     expect(mocks.getMemoryServiceForProject).not.toHaveBeenCalled();


### PR DESCRIPTION
## 문제

`projectPath`를 생략한 MCP 호출은 **전역 스토어**로 갔습니다. 그런데 훅 기반 설치에서 전역 스토어에 쓰는 주체가 없습니다 — SessionStart/PostToolUse/Stop 전부 **프로젝트별 스토어**에 씁니다.

같은 순간, 같은 질의:

| 호출 | 스토어 | 결과 |
|---|---|---|
| `mem-search("SessionStart 주입 랭킹")` | global | **0건** |
| `mem-search(..., projectPath=".../claude-memory-layer")` | project:73c3b2b0 | **3건** (0.97/0.91/0.88) |
| `mem-stats()` | global | 이벤트 **4건** |
| `mem-stats(projectPath=...)` | project:73c3b2b0 | 이벤트 **1,534건** |

호출자에게 "빈 스토어를 조회했다"는 신호가 전혀 없었습니다. CLI는 `-p`가 사실상 필수라 이 함정이 없고, **MCP만 조용히 폴백**했습니다.

## 왜 cwd가 올바른 신호인가

실행 중인 MCP 프로세스 17개의 cwd를 직접 확인했습니다 — 전부 해당 세션의 프로젝트 디렉터리였습니다(Claude Code·Codex·Hermes 모두 세션마다 stdio 서버를 띄우며 cwd를 잡아줌).

`hashProjectPath`가 이미 `git rev-parse --git-common-dir`로 **워크트리와 하위 디렉터리를 메인 체크아웃으로 접어주므로**, 저장소 안 어느 경로에서 시작하든 훅이 쓰는 그 스토어에 정확히 도달합니다.

## 안전장치 — 스토어가 이미 있을 때만

`getMemoryServiceForProject`는 **주어진 경로에 스토어를 만들어 버립니다.** 가드가 없으면 프로젝트가 아닌 디렉터리에서 뜬 서버마다 `projects/`에 빈 스토어가 쌓입니다. 그래서 `events.sqlite`가 이미 존재할 때만 적용하고, 아니면 기존대로 전역으로 갑니다.

## 진입점에서 한 번만 해석

여러 도구가 `args.projectPath`를 각자 읽습니다(perspective 검증기, import 가드, import 핸들러). 분산해서 고치면 **한 호출 안에서 서로 다른 프로젝트를 가리킬 수 있어서**, `handleToolCall` 진입점에서 한 번 정규화합니다.

명시적으로 준 값은 상대경로여도 덮지 않습니다 — 조용히 교체하지 않고 그대로 에러로 남깁니다.

## 검증 — 빌드한 MCP를 실제로 spawn

| cwd | args | 결과 |
|---|---|---|
| `~/workspace/claude-memory-layer` | `{}` | `project:73c3b2b0`, 1570건 ✅ |
| 위의 **워크트리** | `{}` | `project:73c3b2b0`, 1570건 ✅ (동일 스토어로 수렴) |
| 스토어 없는 임시 디렉터리 | `{}` | `global`, 4건 ✅ (폴백 유지) |
| 워크트리 | `{projectPath}` | `project:73c3b2b0` ✅ (명시값 우선) |

빈 스토어 생성 없음도 확인 — `projects/` 디렉터리 수 91개 유지.

## 테스트

새 파일 `tests/extensions/mcp-auto-project-path.test.ts` — 스토어 존재 시 프로젝트 라우팅, 미존재 시 전역 폴백(+ 스토어 미생성), 명시값 우선, cwd당 1회만 해석(캐싱).

기존 `'falls back to the global memory service when projectPath is absent'` 테스트는 **환경 의존이 됩니다** — 테스트 러너의 cwd가 실제 프로젝트면 자동 해석이 걸립니다. cwd를 스토어가 있을 수 없는 임시 경로로 고정해 결정적으로 만들었습니다.

전체: typecheck 클린, lint 0 errors, **185파일 / 1,185테스트 통과**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)