### PR TITLE
fix(scripts): 삭제된 워크트리의 고립 스토어도 병합 대상에 포함

### DIFF
--- a/scripts/consolidate-orphaned-stores.mjs
+++ b/scripts/consolidate-orphaned-stores.mjs
@@ -89,7 +89,31 @@ function countRows(db, table) {
   }
 }
 
-/** Stores whose recorded path still exists but now hashes somewhere else. */
+/**
+ * The checkout a deleted worktree path belonged to.
+ *
+ * Worktrees are disposable — they get removed once their branch merges — so
+ * the common orphan is a store whose recorded path no longer exists. Hashing
+ * needs git, and git needs the directory, so those stores could never be
+ * resolved and their events stayed stranded (1,780 events across 10 stores on
+ * one machine).
+ *
+ * The layout itself carries the answer: `<checkout>/.aplus/worktrees/<name>`
+ * and git's own `<checkout>/.git/worktrees/<name>`. Everything before the
+ * marker is the checkout that owned the worktree. Returns null when the path
+ * has no marker or the checkout is gone too — a guess is worse than skipping.
+ */
+function checkoutOwningWorktree(projectPath) {
+  for (const marker of ['/.aplus/worktrees/', '/.git/worktrees/']) {
+    const index = projectPath.indexOf(marker);
+    if (index <= 0) continue;
+    const checkout = projectPath.slice(0, index);
+    if (fs.existsSync(checkout)) return checkout;
+  }
+  return null;
+}
+
+/** Stores whose recorded path now hashes somewhere else, or is gone entirely. */
 function findOrphans(filterHashes) {
   const orphans = [];
   for (const dir of fs.readdirSync(PROJECTS_ROOT)) {
@@ -106,13 +130,22 @@ function findOrphans(filterHashes) {
     db.close();
 
     if (!projectPath) continue;
-    if (!fs.existsSync(projectPath)) continue; // path is gone; nothing to resolve onto
 
-    const target = hashProjectPath(projectPath);
+    // Resolve against the recorded path when it still exists, and against the
+    // checkout that owned it when the worktree has been removed.
+    let resolveFrom = projectPath;
+    let viaCheckout = null;
+    if (!fs.existsSync(projectPath)) {
+      viaCheckout = checkoutOwningWorktree(projectPath);
+      if (!viaCheckout) continue; // path is gone; nothing to resolve onto
+      resolveFrom = viaCheckout;
+    }
+
+    const target = hashProjectPath(resolveFrom);
     if (target === dir) continue;
     if (!fs.existsSync(path.join(PROJECTS_ROOT, target, 'events.sqlite'))) continue;
 
-    orphans.push({ dir, target, projectPath, events, sessions });
+    orphans.push({ dir, target, projectPath, events, sessions, viaCheckout });
   }
   return orphans.sort((a, b) => b.events - a.events);
 }
@@ -223,6 +256,9 @@ function main() {
   for (const orphan of orphans) {
     console.log(`${orphan.dir} → ${orphan.target}`);
     console.log(`   path: ${orphan.projectPath}`);
+    if (orphan.viaCheckout) {
+      console.log(`   worktree removed; resolved via checkout: ${orphan.viaCheckout}`);
+    }
     console.log(`   source: ${orphan.events} events, ${orphan.sessions} sessions`);
 
     // One unmergeable store must not strand the rest of the batch. The merge


### PR DESCRIPTION
## 문제

`consolidate-orphaned-stores.mjs`는 기록된 `project_path`가 **존재할 때만** 병합 대상으로 삼았습니다.

```js
if (!fs.existsSync(projectPath)) continue; // path is gone; nothing to resolve onto
```

그런데 워크트리는 브랜치가 머지되면 정리되는 일회용입니다. **가장 흔한 고립 스토어가 바로 "경로가 사라진" 경우**입니다. 해시 계산에 git이 필요하고 git에는 디렉터리가 필요해서, 이 스토어들은 영영 해석되지 않고 이벤트가 갇혀 있었습니다 — 한 머신에서 10개 스토어 1,780건.

## 해결

경로 구조 자체에 답이 있습니다.

| 레이아웃 | 소유 체크아웃 |
|---|---|
| `<checkout>/.aplus/worktrees/<name>` | 마커 앞부분 |
| `<checkout>/.git/worktrees/<name>` | 마커 앞부분 |

마커가 없거나 체크아웃마저 사라졌으면 `null`을 반환합니다 — 추측하느니 건너뛰는 게 낫습니다.

출력에 근거를 찍습니다:

```
b8c3b297 → 6ab6d837
   path: /Users/justin/workspace/aplus-dev-studio-desktop/.aplus/worktrees/noble-moose-ezjp
   worktree removed; resolved via checkout: /Users/justin/workspace/aplus-dev-studio-desktop
   source: 48 events, 1 sessions
```

## 실측 결과

| | 변경 전 | 변경 후 |
|---|---:|---:|
| 병합 가능 스토어 | 10곳 | **12곳** |
| 병합 이벤트 | 873건 | **1,972건** |

실제 적용 후 전체 미처리 임베딩 백로그가 **858 → 60건(93% 해소)**. 남은 60건은 `/private/tmp/happy-testing-ground-*` 같은 일회성 테스트 디렉터리와 `sessions`에 경로 기록이 없는 스토어(합계 이벤트 35건)라 병합할 부모가 없습니다.

병합된 내용이 실제로 검색되는지 확인했습니다 — 7월 워크트리 세션이 부모 프로젝트 검색에서 스코어 0.900으로 나옵니다. 이관은 `events` + `memory_levels` + 벡터까지 완전합니다(`memory_levels`가 빠지면 검색 레인이 건너뜁니다).

## 안전성

기존 동작 그대로입니다 — dry-run 기본, `--apply` 시 원본은 `<hash>.merged-<timestamp>`로 보존, 멱등적, 중복 제거.

전체: typecheck 클린, lint 0 errors, 185파일 / 1,185테스트 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)