### PR TITLE
fix(scripts): 병합 시 고아 자식 행 방지 + 수동 귀속 옵션

### DIFF
--- a/scripts/consolidate-orphaned-stores.mjs
+++ b/scripts/consolidate-orphaned-stores.mjs
@@ -12,6 +12,11 @@
  *
  *   node scripts/consolidate-orphaned-stores.mjs
  *   node scripts/consolidate-orphaned-stores.mjs --hash ad83c813 --apply
+ *
+ * A store with no session rows has nothing to resolve from; name its owner
+ * yourself to merge it anyway:
+ *
+ *   node scripts/consolidate-orphaned-stores.mjs --hash ed6a6cfd --target 6ab6d837 --apply
  */
 import fs from 'node:fs';
 import os from 'node:os';
@@ -36,7 +41,7 @@ const PROJECTS_ROOT = process.env.CLAUDE_MEMORY_PROJECTS_ROOT
 const MERGED_TABLES = ['events', 'sessions', 'memory_levels', 'event_dedup'];
 
 function parseArgs(argv) {
-  const result = { apply: false, hashes: [], keepSource: false };
+  const result = { apply: false, hashes: [], keepSource: false, target: null };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === '--apply') result.apply = true;
@@ -45,6 +50,10 @@ function parseArgs(argv) {
       result.hashes.push(String(argv[i += 1]).trim().toLowerCase());
     } else if (arg.startsWith('--hash=')) {
       result.hashes.push(arg.slice('--hash='.length).trim().toLowerCase());
+    } else if (arg === '--target' && i + 1 < argv.length) {
+      result.target = String(argv[i += 1]).trim().toLowerCase();
+    } else if (arg.startsWith('--target=')) {
+      result.target = arg.slice('--target='.length).trim().toLowerCase();
     }
   }
   return result;
@@ -111,6 +120,35 @@ function checkoutOwningWorktree(projectPath) {
     if (fs.existsSync(checkout)) return checkout;
   }
   return null;
+}
+
+/**
+ * Stores named explicitly by the operator, merged into a target they chose.
+ *
+ * Automatic resolution reads the project path off the `sessions` table, and
+ * some stores hold events with no session rows at all — nothing to resolve
+ * from, however obvious the owner is from the events themselves. Rather than
+ * guess inside the tool, this lets a human state the attribution and still
+ * merge through the same audited path.
+ */
+function explicitOrphans(hashes, target) {
+  if (!fs.existsSync(path.join(PROJECTS_ROOT, target, 'events.sqlite'))) {
+    throw new Error(`target store ${target} has no events.sqlite`);
+  }
+
+  return hashes.map((dir) => {
+    if (dir === target) throw new Error(`source and target are the same store: ${dir}`);
+    const dbPath = path.join(PROJECTS_ROOT, dir, 'events.sqlite');
+    if (!fs.existsSync(dbPath)) throw new Error(`source store ${dir} has no events.sqlite`);
+
+    const db = new Database(dbPath, { readonly: true });
+    const projectPath = dominantProjectPath(db);
+    const events = countRows(db, 'events');
+    const sessions = countRows(db, 'sessions');
+    db.close();
+
+    return { dir, target, projectPath: projectPath ?? '(no recorded path — attributed manually)', events, sessions };
+  });
 }
 
 /** Stores whose recorded path now hashes somewhere else, or is gone entirely. */
@@ -190,12 +228,25 @@ function mergeStore(orphan, { apply, keepSource }) {
 
       const before = countRows(target, table);
       const list = shared.map((col) => `"${col}"`).join(', ');
-      const sql = `INSERT OR IGNORE INTO main.${table} (${list}) SELECT ${list} FROM src.${table}`;
+
+      // Child rows follow their event. An event whose content already exists
+      // in the target is dropped by INSERT OR IGNORE (dedupe_key collides),
+      // but memory_levels/event_dedup key on event_id alone, so they would
+      // insert anyway and leave rows pointing at an event that is not there.
+      const eventScoped = table === 'memory_levels' || table === 'event_dedup';
+      const guard = eventScoped
+        ? ` WHERE EXISTS (SELECT 1 FROM main.events e WHERE e.id = src.${table}.event_id)`
+        : '';
+      const sql = `INSERT OR IGNORE INTO main.${table} (${list}) SELECT ${list} FROM src.${table}${guard}`;
 
       if (apply) {
         target.prepare(sql).run();
       }
-      const sourceRows = target.prepare(`SELECT COUNT(*) AS c FROM src.${table}`).get().c;
+      // Counted through the same guard, so a dry run predicts what an apply
+      // would actually copy rather than the raw source size.
+      const sourceRows = target
+        .prepare(`SELECT COUNT(*) AS c FROM src.${table}${guard}`)
+        .get().c;
       const copied = apply ? countRows(target, table) - before : null;
       stats.tables[table] = {
         sourceRows,
@@ -243,7 +294,21 @@ function main() {
     process.exit(1);
   }
 
-  const orphans = findOrphans(options.hashes);
+  if (options.target && options.hashes.length === 0) {
+    console.error('--target requires at least one --hash');
+    process.exit(1);
+  }
+
+  let orphans;
+  try {
+    orphans = options.target
+      ? explicitOrphans(options.hashes, options.target)
+      : findOrphans(options.hashes);
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+
   if (orphans.length === 0) {
     console.log('No orphaned stores found.');
     return;


### PR DESCRIPTION
고립 스토어를 정리하다 실제로 부딪힌 두 문제입니다.

## 1. 고아 자식 행 (버그)

자식 테이블이 부모와 무관하게 삽입되고 있었습니다.

이미 타깃에 같은 내용이 있는 이벤트는 `dedupe_key` 충돌로 `INSERT OR IGNORE`에 걸려 버려집니다. 그런데 `memory_levels`·`event_dedup`은 `event_id`만 키로 쓰기 때문에 **그대로 들어가서 존재하지 않는 이벤트를 가리키는 행이 남습니다.**

실측으로 확인했습니다 — 병합 한 건에서:

```
ed6a6cfd -> 6ab6d837 | 이벤트 0/2 | 등급 2/2   ← 이벤트는 중복 제거됐는데 등급만 들어감
타깃 6ab6d837 고아 memory_levels: 2
```

(내용 유실은 아니었습니다. 원본 2건 모두 `dedupe_key`·`content` 완전일치로 타깃에 이미 존재했습니다.)

수정 후:

```
events: copied 0, deduped 2
memory_levels: copied 0, deduped 0
고아 memory_levels: 0
```

**dry-run 예측치**도 같은 가드를 통과시켜 셉니다. 이전에는 원본 크기를 그대로 보고해서 `memory_levels: 2 rows to merge`라고 해놓고 실제로는 0건이 복사됐습니다.

## 2. 수동 귀속 `--target`

자동 해석은 `sessions` 테이블의 `project_path`를 읽는데, **세션 행이 아예 없고 `events`만 있는 스토어**가 있습니다. 이벤트 내용상 소유자가 명백해도(파일 경로가 전부 한 프로젝트를 가리켜도) 해석할 근거가 없어 영영 병합되지 않았습니다.

도구가 내용을 보고 추측하게 만드는 건 위험합니다. 대신 사람이 귀속을 지정하고, **동일한 병합 경로를 그대로 타도록** 했습니다.

```bash
node scripts/consolidate-orphaned-stores.mjs --hash ed6a6cfd --target 6ab6d837 --apply
```

가드:

| 입력 | 결과 |
|---|---|
| `--target` 단독 | `--target requires at least one --hash` |
| 출발지 == 목적지 | `source and target are the same store: ...` |
| 목적지 스토어 없음 | `target store deadbeef has no events.sqlite` |

출력에 `path: (no recorded path — attributed manually)`로 자동이 아님을 드러냅니다.

## 실측

이 옵션으로 세션 행이 없던 9개 스토어(이벤트 14건)를 소유 프로젝트로 병합했고, 그 과정에서 1번 버그가 드러났습니다. 정리 후 전 스토어 고아 행 0, 대상 스토어 5곳 `PRAGMA integrity_check` 전부 `ok`.

전체: typecheck 클린, lint 0 errors, 185파일 / 1,185테스트 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)