### PR TITLE
feat(memory): actor-scoped shared asset reads

### DIFF
--- a/docs/memory-asset-permissions.md
+++ b/docs/memory-asset-permissions.md
@@ -18,9 +18,11 @@ There are no implicit write permissions and no deny ACLs in this phase. An
 empty explicit grant replaces the previous set and acts as an auditable
 revocation. A disabled binding likewise removes binding-based read access.
 
-`shared` currently means that the asset is eligible for a future shared-store
-integration. The MCP handlers still require an absolute project path and open
-only that project's SQLite store, so it does not bypass project isolation.
+`shared` makes a canonical asset eligible for the explicit
+`mem-shared-asset-get` flow described below. It does not by itself bypass
+project isolation: the requester and named source actor must share an explicit
+principal mapping, and the source project's registration, lifecycle, and read
+policy are revalidated for every cross-project read.
 
 ## Storage
 

--- a/docs/memory-asset-permissions.md
+++ b/docs/memory-asset-permissions.md
@@ -134,6 +134,9 @@ principal id:
 actor gets `linked: false` and an empty result; it never falls back to the
 unscoped shared-store search. Relinking the same local actor replaces its old
 principal, so the prior principal immediately loses that project's entries.
+Link, relink, and unlink transitions are recorded atomically in the shared
+store's `shared_actor_identity_audit` table with their before/after principal
+values.
 
 The mapping is a local shared-store membership record, not an external identity
 provider or a grant to canonical memory assets. In particular, it cannot make a
@@ -166,7 +169,9 @@ The MCP shared-actor tools use `~/.claude-code/memory/shared` by default. Set
 `CLAUDE_MEMORY_SHARED_STORAGE_PATH` to an absolute path to use a different
 shared-store location (for example, an isolated test or a separately managed
 local store). Relative values are rejected rather than resolved from the MCP
-server working directory.
+server working directory. Only `mem-shared-actor-link` creates a missing shared
+store; status, search, unlink, and canonical asset reads return their empty or
+unlinked result without creating one.
 
 ## Dashboard shared-actor management
 

--- a/docs/memory-asset-permissions.md
+++ b/docs/memory-asset-permissions.md
@@ -89,8 +89,29 @@ A staged migration is therefore:
 2. Restart the MCP server with `registered` and make clients pass `requesterActorId`.
 3. Register any records created during migration, verify grants/bindings, then restart with `strict`.
 
+## Binding-driven injection
+
+Canonical content is injected only through an enabled actor binding once
+enforcement is active. Read visibility or a read grant alone does not cause
+automatic injection. The shared selector is used by core-memory SessionStart,
+curated-lesson prompt retrieval, and MCP context packs.
+
+Hooks use `actor_id` when the host provides it, otherwise the server-owned
+`CLAUDE_MEMORY_ACTOR_ID`. Context-pack callers pass `requesterActorId`. In
+`registered` and `strict` modes, a missing actor fails closed: hooks inject no
+canonical content and context-pack reports that `requesterActorId` is required.
+
+- `direct`: inject the full canonical block or lesson.
+- `summary`: inject a bounded core-memory summary or the lesson trigger and first two steps.
+- `reference`: inject only a reference hint; it never includes canonical body text.
+- `tool`: never auto-inject; it remains available for an explicit tool lookup.
+
+In `registered` mode, unregistered records retain legacy injection while a
+valid registered record needs an enabled binding. In `strict`, only valid,
+enabled bindings inject. Binding priority orders selected registered assets;
+legacy output order remains unchanged.
+
 ## Follow-up integration order
 
-1. Feed enabled bindings into session-start and context-pack injection lanes.
-2. Add a cross-project shared-store adapter only after actor identity mapping is explicit.
-3. Add teams/roles or deny ACLs only when a concrete multi-user requirement cannot be represented by ownership, visibility, bindings, and explicit grants.
+1. Add a cross-project shared-store adapter only after actor identity mapping is explicit.
+2. Add teams/roles or deny ACLs only when a concrete multi-user requirement cannot be represented by ownership, visibility, bindings, and explicit grants.

--- a/docs/memory-asset-permissions.md
+++ b/docs/memory-asset-permissions.md
@@ -65,9 +65,32 @@ event ids and core-memory text remain exclusively in their canonical tables.
 If a deterministic id is already used for a different source, sync reports a
 conflict and does not overwrite it.
 
+## Canonical handler enforcement
+
+Lesson list/save and core-memory get/update handlers read the server-owned
+`CLAUDE_MEMORY_ASSET_PERMISSION_MODE` setting. Callers cannot select or
+downgrade this mode in an MCP request.
+
+- `legacy` (default): preserve existing behavior while catalog registration is rolled out.
+- `registered`: require `requesterActorId`; enforce permissions for validly registered assets and retain legacy access only for records that have not been registered yet.
+- `strict`: require `requesterActorId`; deny access to unregistered records as well as registered records without the requested permission.
+
+An invalid setting fails closed with a configuration error instead of falling
+back to `legacy`. Deterministic-id conflicts are denied in both enforcement
+modes. Read handlers omit inaccessible records, while write handlers return a
+generic permission denial. In enforcement modes, the write audit `actor` must
+match `requesterActorId` so callers cannot attribute an authorized mutation to
+another principal. New lessons cannot be created in `strict` mode;
+create and catalog them before the final mode transition.
+
+A staged migration is therefore:
+
+1. Keep `legacy`, run `mem-asset-catalog-sync` in preview mode, resolve conflicts, then apply.
+2. Restart the MCP server with `registered` and make clients pass `requesterActorId`.
+3. Register any records created during migration, verify grants/bindings, then restart with `strict`.
+
 ## Follow-up integration order
 
-1. Gate registered lesson/core-memory read and update handlers through this permission service while preserving a deliberate legacy migration mode.
-2. Feed enabled bindings into session-start and context-pack injection lanes.
-3. Add a cross-project shared-store adapter only after actor identity mapping is explicit.
-4. Add teams/roles or deny ACLs only when a concrete multi-user requirement cannot be represented by ownership, visibility, bindings, and explicit grants.
+1. Feed enabled bindings into session-start and context-pack injection lanes.
+2. Add a cross-project shared-store adapter only after actor identity mapping is explicit.
+3. Add teams/roles or deny ACLs only when a concrete multi-user requirement cannot be represented by ownership, visibility, bindings, and explicit grants.

--- a/docs/memory-asset-permissions.md
+++ b/docs/memory-asset-permissions.md
@@ -48,10 +48,26 @@ to avoid disclosing private asset existence. Denied `check` calls likewise use
 the same generic decision for missing and inaccessible assets. Updates can include
 `expectedVersion` for optimistic concurrency control.
 
+## Canonical catalog registration
+
+`mem-asset-catalog-sync` bridges existing project lessons and core-memory
+blocks into the permission registry without moving or copying their content.
+It is preview-only by default. Passing `apply: true` creates only missing
+assets as `private`, with `requesterActorId` as owner.
+
+Deterministic ids keep reruns idempotent:
+
+- `lesson:<lessonId>`
+- `core_memory_block:<project|user>`
+
+Each registered asset stores only that canonical id in `sourceRefs`. Evidence
+event ids and core-memory text remain exclusively in their canonical tables.
+If a deterministic id is already used for a different source, sync reports a
+conflict and does not overwrite it.
+
 ## Follow-up integration order
 
-1. Register existing lessons and core-memory blocks as assets without changing their canonical tables.
-2. Gate their read/update handlers through this permission service.
-3. Feed enabled bindings into session-start and context-pack injection lanes.
-4. Add a cross-project shared-store adapter only after actor identity mapping is explicit.
-5. Add teams/roles or deny ACLs only when a concrete multi-user requirement cannot be represented by ownership, visibility, bindings, and explicit grants.
+1. Gate registered lesson/core-memory read and update handlers through this permission service while preserving a deliberate legacy migration mode.
+2. Feed enabled bindings into session-start and context-pack injection lanes.
+3. Add a cross-project shared-store adapter only after actor identity mapping is explicit.
+4. Add teams/roles or deny ACLs only when a concrete multi-user requirement cannot be represented by ownership, visibility, bindings, and explicit grants.

--- a/docs/memory-asset-permissions.md
+++ b/docs/memory-asset-permissions.md
@@ -111,7 +111,38 @@ valid registered record needs an enabled binding. In `strict`, only valid,
 enabled bindings inject. Binding priority orders selected registered assets;
 legacy output order remains unchanged.
 
+## Actor-scoped shared troubleshooting search
+
+The first cross-project adapter is intentionally limited to the existing
+verified troubleshooting store. It is opt-in and does not change legacy
+`includeShared` retrieval, canonical asset lookup, or automatic injection.
+
+Before `mem-shared-search` can return an entry, the requester must link its
+project-local actor id in every participating project to the same opaque shared
+principal id:
+
+1. Call `mem-shared-actor-link` with an absolute `projectPath`,
+   `requesterActorId`, and `sharedPrincipalId` in project A.
+2. Repeat it in project B with the same `sharedPrincipalId` only when the two
+   local actors represent the same principal.
+3. Call `mem-shared-search` from either linked project. Results are restricted
+   to entries whose `sourceProjectHash` belongs to that principal's linked
+   project set.
+
+`mem-shared-actor-status` shows whether the current local actor is linked, and
+`mem-shared-actor-unlink` removes only that project/actor mapping. An unlinked
+actor gets `linked: false` and an empty result; it never falls back to the
+unscoped shared-store search. Relinking the same local actor replaces its old
+principal, so the prior principal immediately loses that project's entries.
+
+The mapping is a local shared-store membership record, not an external identity
+provider or a grant to canonical memory assets. In particular, it cannot make a
+private lesson/core-memory block readable, bindable, or injectable across
+projects. A future canonical-asset sharing phase must separately validate the
+source project's asset permission policy.
+
 ## Follow-up integration order
 
-1. Add a cross-project shared-store adapter only after actor identity mapping is explicit.
+1. Add source-project canonical-asset permission validation before exposing any
+   `shared` memory asset through the cross-project adapter.
 2. Add teams/roles or deny ACLs only when a concrete multi-user requirement cannot be represented by ownership, visibility, bindings, and explicit grants.

--- a/docs/memory-asset-permissions.md
+++ b/docs/memory-asset-permissions.md
@@ -168,6 +168,19 @@ shared-store location (for example, an isolated test or a separately managed
 local store). Relative values are rejected rather than resolved from the MCP
 server working directory.
 
+## Dashboard shared-actor management
+
+The dashboard's **Configuration → Shared Actor Access** card can inspect the
+mapping status for a selected project and local actor id, then remove that
+mapping if needed. It reports only whether the mapping exists and the number
+of projects linked to it; it never returns the opaque shared-principal value.
+The browser retains the entered actor id locally for convenience, but it never
+stores or accepts a shared-principal value. Creating or relinking mappings
+remains an explicit `mem-shared-actor-link` MCP operation.
+
+If no shared-store database exists yet, a dashboard status check reports the
+actor as unlinked and does not create the store.
+
 ## Follow-up integration order
 
 1. Add teams/roles or deny ACLs only when a concrete multi-user requirement

--- a/docs/memory-asset-permissions.md
+++ b/docs/memory-asset-permissions.md
@@ -162,6 +162,12 @@ The response intentionally does not perform an automatic bind or injection.
 `private`, `project`, inactive, conflicting, missing, or unlinked assets return
 the same `found: false` shape, preventing source asset existence disclosure.
 
+The MCP shared-actor tools use `~/.claude-code/memory/shared` by default. Set
+`CLAUDE_MEMORY_SHARED_STORAGE_PATH` to an absolute path to use a different
+shared-store location (for example, an isolated test or a separately managed
+local store). Relative values are rejected rather than resolved from the MCP
+server working directory.
+
 ## Follow-up integration order
 
 1. Add teams/roles or deny ACLs only when a concrete multi-user requirement

--- a/docs/memory-asset-permissions.md
+++ b/docs/memory-asset-permissions.md
@@ -138,11 +138,32 @@ principal, so the prior principal immediately loses that project's entries.
 The mapping is a local shared-store membership record, not an external identity
 provider or a grant to canonical memory assets. In particular, it cannot make a
 private lesson/core-memory block readable, bindable, or injectable across
-projects. A future canonical-asset sharing phase must separately validate the
-source project's asset permission policy.
+projects.
+
+## Shared canonical asset reads
+
+`mem-shared-asset-get` is a read-only, explicit lookup for one source project's
+canonical lesson or core-memory block. It requires both `sourceProjectPath` and
+`sourceActorId`; the source actor must be linked to the same shared principal
+as the requester. The caller cannot obtain content by merely knowing a project
+path or an asset id.
+
+The adapter then opens the source project's SQLite database read-only and fails
+closed unless all of these conditions hold at lookup time:
+
+1. The source asset has the deterministic canonical registration for the
+   requested lesson/block.
+2. Its lifecycle status is `active` and its visibility is `shared`.
+3. The named source actor has `read` access under the source project's asset
+   policy.
+4. The referenced canonical lesson/block still exists in that same project.
+
+The response intentionally does not perform an automatic bind or injection.
+`private`, `project`, inactive, conflicting, missing, or unlinked assets return
+the same `found: false` shape, preventing source asset existence disclosure.
 
 ## Follow-up integration order
 
-1. Add source-project canonical-asset permission validation before exposing any
-   `shared` memory asset through the cross-project adapter.
-2. Add teams/roles or deny ACLs only when a concrete multi-user requirement cannot be represented by ownership, visibility, bindings, and explicit grants.
+1. Add teams/roles or deny ACLs only when a concrete multi-user requirement
+   cannot be represented by ownership, visibility, bindings, and explicit
+   grants.

--- a/docs/memory-asset-permissions.md
+++ b/docs/memory-asset-permissions.md
@@ -1,0 +1,57 @@
+# Memory asset permissions
+
+The first permission layer is intentionally project-local and actor-based. It
+does not introduce users, teams, sessions, or a second identity provider. It
+reuses the existing perspective-memory actor id as its principal.
+
+## Policy order
+
+Permission checks are deterministic and use this order:
+
+1. The asset owner has `read`, `write`, `bind`, and `grant`.
+2. `project` and `shared` visibility grant `read` only.
+3. An enabled actor binding grants `read` only.
+4. An explicit actor grant supplies only its listed permissions.
+5. Everything else is denied.
+
+There are no implicit write permissions and no deny ACLs in this phase. An
+empty explicit grant replaces the previous set and acts as an auditable
+revocation. A disabled binding likewise removes binding-based read access.
+
+`shared` currently means that the asset is eligible for a future shared-store
+integration. The MCP handlers still require an absolute project path and open
+only that project's SQLite store, so it does not bypass project isolation.
+
+## Storage
+
+- `memory_assets`: owner, lifecycle, visibility, version, and canonical source references
+- `memory_asset_bindings`: actor injection mode, priority, and enabled state
+- `memory_asset_grants`: full replacement permission set per asset/actor
+- `memory_governance_audit`: create, update, bind, and grant/revoke history
+
+Asset content is not copied into the registry. `source_refs_json` points to the
+canonical event, lesson, skill, wiki, or code-graph subsystem.
+
+## MCP operations
+
+- `mem-asset-create`
+- `mem-asset-get`
+- `mem-asset-list`
+- `mem-asset-update`
+- `mem-asset-bind`
+- `mem-asset-grant-set`
+- `mem-asset-check`
+
+Every operation requires an absolute `projectPath` and a `requesterActorId`.
+Unauthorized `get` calls use the same `found: false` response as missing assets
+to avoid disclosing private asset existence. Denied `check` calls likewise use
+the same generic decision for missing and inaccessible assets. Updates can include
+`expectedVersion` for optimistic concurrency control.
+
+## Follow-up integration order
+
+1. Register existing lessons and core-memory blocks as assets without changing their canonical tables.
+2. Gate their read/update handlers through this permission service.
+3. Feed enabled bindings into session-start and context-pack injection lanes.
+4. Add a cross-project shared-store adapter only after actor identity mapping is explicit.
+5. Add teams/roles or deny ACLs only when a concrete multi-user requirement cannot be represented by ownership, visibility, bindings, and explicit grants.

--- a/src/adapters/claude/hooks/session-start.ts
+++ b/src/adapters/claude/hooks/session-start.ts
@@ -9,6 +9,10 @@ import { registerSession } from '../../../core/registry/session-registry.js';
 import { ensureDaemonRunning, scheduleSessionSummary } from './semantic-daemon-client.js';
 import { isLlmSummaryEnabled } from '../../llm/session-summary-llm.js';
 import { spawnToolObservationVectorAutoHealIfNeeded } from './tool-observation-vector-auto-heal-client.js';
+import {
+  resolveCanonicalMemoryActorId,
+  type CanonicalMemoryInjection
+} from '../../../core/operations/canonical-memory-injection-service.js';
 import { readStdin } from './hook-runtime.js';
 import { formatClaudeContextHookOutput, isHookEvaluationMode } from './hook-output.js';
 import { isPromptOnlySessionSummary } from './prompt-injection-policy.js';
@@ -170,15 +174,32 @@ export function sessionStartExcerpt(event: MemoryEvent): string {
  * Letta-style "always in context" section. Empty/missing blocks are skipped
  * silently so an unused block never pads out the context with nothing.
  */
-export function formatCoreMemoryBlockContext(blocks: CoreMemoryBlock[]): string {
-  const nonEmpty = blocks.filter((block) => block.content.trim().length > 0);
+export function formatCoreMemoryBlockContext(
+  blocks: Array<CoreMemoryBlock | CanonicalMemoryInjection<CoreMemoryBlock>>
+): string {
+  const injected = blocks.map((item): CanonicalMemoryInjection<CoreMemoryBlock> => (
+    'value' in item
+      ? item
+      : { value: item, injectionMode: 'direct', priority: 0 }
+  ));
+  const nonEmpty = injected.filter(({ value }) => value.content.trim().length > 0);
   if (nonEmpty.length === 0) return '';
 
   let context = '## Core Memory\n\n';
-  for (const block of nonEmpty) {
-    context += `**${CORE_MEMORY_BLOCK_LABELS[block.blockKey]}**: ${block.content.trim()}\n\n`;
+  for (const { value: block, injectionMode } of nonEmpty) {
+    const content = injectionMode === 'direct'
+      ? block.content.trim()
+      : injectionMode === 'summary'
+        ? compactCoreMemorySummary(block.content)
+        : `[reference: use mem-core-block-get for ${block.blockKey} block]`;
+    context += `**${CORE_MEMORY_BLOCK_LABELS[block.blockKey]}**: ${content}\n\n`;
   }
   return context.trimEnd() + '\n';
+}
+
+function compactCoreMemorySummary(content: string): string {
+  const normalized = content.trim().replace(/\s+/g, ' ');
+  return normalized.length <= 320 ? normalized : `${normalized.slice(0, 317)}...`;
 }
 
 export async function main(): Promise<string> {
@@ -236,13 +257,15 @@ export async function main(): Promise<string> {
       }
     }
 
-    // Core memory blocks are unconditional (no query, no scoring) and are
-    // curated by the agent itself via mem-core-block-update, so they come
-    // first — ahead of the incidental recent-events recap below.
+    // Core memory blocks remain a no-query/no-scoring lane and come before
+    // incidental recent events. Once asset enforcement is enabled, the
+    // service filters this lane through the active actor binding.
     let context = '';
     if (process.env.CLAUDE_MEMORY_EVAL_DISABLE_SESSION_CONTEXT !== 'true') {
       try {
-        const coreBlocks = await memoryService.getCoreMemoryBlocks();
+        const coreBlocks = await memoryService.getCoreMemoryBlockInjections(
+          resolveCanonicalMemoryActorId(input.actor_id)
+        );
         context = formatCoreMemoryBlockContext(coreBlocks);
       } catch {
         // Core memory injection is supplementary; never fail session start over it.

--- a/src/adapters/claude/hooks/user-prompt-submit.ts
+++ b/src/adapters/claude/hooks/user-prompt-submit.ts
@@ -24,6 +24,7 @@ import { retrieveSemanticMemories, scheduleSemanticGraduation } from './semantic
 import { readStdin, readNumberEnv } from './hook-runtime.js';
 import { formatClaudeContextHookOutput, isHookEvaluationMode } from './hook-output.js';
 import { applyPrivacyFilter } from '../../../core/privacy/index.js';
+import { resolveCanonicalMemoryActorId } from '../../../core/operations/canonical-memory-injection-service.js';
 import {
   filterHookInjectableMemories,
   getHookInjectionPolicy,
@@ -514,15 +515,19 @@ export async function main(): Promise<string> {
       // Curated lesson lane. Lessons are not events, so no other lane can ever
       // surface them; without this the lesson feature is write-only.
       try {
-        const lessons = await memoryService.listProjectLessons(MAX_CANDIDATES);
-        for (const lesson of lessons) {
+        const lessons = await memoryService.listProjectLessonInjections(
+          resolveCanonicalMemoryActorId(input.actor_id),
+          MAX_CANDIDATES
+        );
+        for (const { value: lesson, injectionMode } of lessons) {
+          const injectedLesson = lessonForInjection(lesson, injectionMode);
           const candidate = scoreLessonEvidence(retrievalQuery, {
-            lessonId: String(lesson.lessonId ?? ''),
-            name: String(lesson.name ?? ''),
-            trigger: lesson.trigger ? String(lesson.trigger) : undefined,
-            steps: Array.isArray(lesson.steps) ? lesson.steps.map(String) : [],
-            failureModes: Array.isArray(lesson.failureModes) ? lesson.failureModes.map(String) : [],
-            confidence: Number(lesson.confidence ?? 0)
+            lessonId: String(injectedLesson.lessonId ?? ''),
+            name: String(injectedLesson.name ?? ''),
+            trigger: injectedLesson.trigger ? String(injectedLesson.trigger) : undefined,
+            steps: Array.isArray(injectedLesson.steps) ? injectedLesson.steps.map(String) : [],
+            failureModes: Array.isArray(injectedLesson.failureModes) ? injectedLesson.failureModes.map(String) : [],
+            confidence: Number(injectedLesson.confidence ?? 0)
           });
           if (candidate) mergedMemories.push(candidate);
         }
@@ -715,4 +720,21 @@ export async function main(): Promise<string> {
     }
     return formatClaudeContextHookOutput('UserPromptSubmit', '');
   }
+}
+
+export function lessonForInjection(
+  lesson: { lessonId: string; name: string; trigger: string; steps: string[]; failureModes: string[]; confidence: number },
+  injectionMode: 'direct' | 'summary' | 'reference'
+) {
+  if (injectionMode === 'direct') return lesson;
+  if (injectionMode === 'summary') {
+    return { ...lesson, steps: lesson.steps.slice(0, 2), failureModes: [] };
+  }
+  return {
+    ...lesson,
+    name: `[lesson:${lesson.lessonId}] ${lesson.name}`,
+    trigger: '',
+    steps: [],
+    failureModes: []
+  };
 }

--- a/src/apps/dashboard/assets/js/views.js
+++ b/src/apps/dashboard/assets/js/views.js
@@ -971,6 +971,7 @@ async function loadConfigurationView() {
 
     container.innerHTML = `
       ${renderSetupProviderHealthCard(setupHealth)}
+      ${renderSharedActorManagement()}
       <div class="cfg-grid">
         <div class="cfg-section">
           <div class="cfg-section-title"><i class="ri-database-2-line"></i>Storage</div>
@@ -1039,9 +1040,89 @@ async function loadConfigurationView() {
         </div>
       </div>
     `;
+    setupSharedActorManagement();
   } catch (error) {
     container.innerHTML = `<div style="text-align:center; padding:60px; color:var(--error);">Failed to load configuration: ${escapeHtml(error.message)}</div>`;
   }
+}
+
+function renderSharedActorManagement() {
+  if (!state.currentProject) {
+    return `
+      <div class="card" style="margin-bottom:24px;">
+        <div class="card-header"><div class="card-title"><i class="ri-share-forward-line"></i><span>Shared Actor Access</span></div></div>
+        <div class="disclosure-empty">Select a project to inspect or remove its explicit shared-actor mapping.</div>
+      </div>
+    `;
+  }
+  const savedActorId = window.localStorage?.getItem('cml.dashboard.sharedActorId') || '';
+  return `
+    <div class="card" style="margin-bottom:24px;">
+      <div class="card-header"><div class="card-title"><i class="ri-share-forward-line"></i><span>Shared Actor Access</span></div></div>
+      <div style="font-size:13px; color:var(--text-muted); margin-bottom:12px;">
+        Inspect or remove this project's explicit shared-principal mapping. Create mappings with the MCP tool so the principal value is not stored in the dashboard.
+      </div>
+      <div style="display:flex; flex-wrap:wrap; gap:8px; align-items:center;">
+        <input id="shared-actor-id-input" class="search-input" style="max-width:320px;" value="${escapeHtml(savedActorId)}" placeholder="Project actor ID">
+        <button id="shared-actor-status-btn" class="btn btn-secondary">Check status</button>
+        <button id="shared-actor-unlink-btn" class="btn btn-secondary" disabled>Unlink</button>
+      </div>
+      <div id="shared-actor-status" style="font-size:13px; color:var(--text-muted); margin-top:12px;">Enter an actor ID to check the selected project's mapping.</div>
+    </div>
+  `;
+}
+
+function setupSharedActorManagement() {
+  const input = document.getElementById('shared-actor-id-input');
+  const statusButton = document.getElementById('shared-actor-status-btn');
+  const unlinkButton = document.getElementById('shared-actor-unlink-btn');
+  const status = document.getElementById('shared-actor-status');
+  if (!input || !statusButton || !unlinkButton || !status || !state.currentProject) return;
+
+  const actorId = () => String(input.value || '').trim();
+  const setStatus = (message, linked = false) => {
+    status.textContent = message;
+    unlinkButton.disabled = !linked;
+  };
+  const refresh = async () => {
+    const value = actorId();
+    if (!value) return setStatus('Enter an actor ID to check the selected project.');
+    window.localStorage?.setItem('cml.dashboard.sharedActorId', value);
+    setStatus('Checking shared actor mapping…');
+    try {
+      const response = await fetch(apiUrl(`${API_BASE}/shared/actor`, {
+        project: state.currentProject,
+        actorId: value
+      }));
+      if (!response.ok) throw new Error('status unavailable');
+      const payload = await response.json();
+      if (!payload.linked) return setStatus('No shared-principal mapping is registered for this actor.');
+      setStatus(`Linked across ${payload.linkedProjectCount || 1} project${payload.linkedProjectCount === 1 ? '' : 's'}.`, true);
+    } catch {
+      setStatus('Shared actor status is unavailable.');
+    }
+  };
+  statusButton.addEventListener('click', refresh);
+  input.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') refresh();
+  });
+  unlinkButton.addEventListener('click', async () => {
+    const value = actorId();
+    if (!value) return;
+    unlinkButton.disabled = true;
+    setStatus('Removing shared actor mapping…');
+    try {
+      const response = await fetch(apiUrl(`${API_BASE}/shared/actor`, {
+        project: state.currentProject,
+        actorId: value
+      }), { method: 'DELETE' });
+      if (!response.ok) throw new Error('unlink unavailable');
+      const payload = await response.json();
+      setStatus(payload.unlinked ? 'Shared actor mapping removed.' : 'No shared actor mapping was registered.');
+    } catch {
+      setStatus('Shared actor unlink is unavailable.');
+    }
+  });
 }
 
 // --- Helpers ---

--- a/src/apps/server/api/index.ts
+++ b/src/apps/server/api/index.ts
@@ -14,6 +14,7 @@ import { projectsRouter } from './projects.js';
 import { chatRouter } from './chat.js';
 import { healthRouter } from './health.js';
 import { playgroundRouter } from './playground.js';
+import { sharedMemoryRouter } from './shared-memory.js';
 
 export const apiRouter = new Hono()
   .route('/sessions', sessionsRouter)
@@ -25,4 +26,5 @@ export const apiRouter = new Hono()
   .route('/projects', projectsRouter)
   .route('/chat', chatRouter)
   .route('/health', healthRouter)
-  .route('/playground', playgroundRouter);
+  .route('/playground', playgroundRouter)
+  .route('/shared', sharedMemoryRouter);

--- a/src/apps/server/api/shared-memory.ts
+++ b/src/apps/server/api/shared-memory.ts
@@ -1,0 +1,62 @@
+import { existsSync } from 'node:fs';
+import * as path from 'node:path';
+
+import { Hono } from 'hono';
+
+import { createSharedEventStore } from '../../../core/shared-event-store.js';
+import { createSharedStore } from '../../../core/shared-store.js';
+import { resolveSharedMemoryStoragePath } from '../../../services/memory-service-config.js';
+import { SharedMemoryActorAdapter } from '../../../extensions/shared-memory/shared-memory-actor-adapter.js';
+import { jsonError } from './utils.js';
+
+export const sharedMemoryRouter = new Hono();
+
+function requiredQuery(c: { req: { query(name: string): string | undefined } }, name: string): string {
+  const value = c.req.query(name)?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+async function withSharedMemoryActorAdapter<T>(
+  callback: (adapter: SharedMemoryActorAdapter) => Promise<T>
+): Promise<T | null> {
+  const dbPath = path.join(resolveSharedMemoryStoragePath(), 'shared.duckdb');
+  // Status/unlink must not create a global shared store merely because the
+  // dashboard was opened.
+  if (!existsSync(dbPath)) return null;
+  const eventStore = createSharedEventStore(dbPath);
+  await eventStore.initialize();
+  try {
+    return await callback(new SharedMemoryActorAdapter(createSharedStore(eventStore)));
+  } finally {
+    await eventStore.close();
+  }
+}
+
+// GET /api/shared/actor?project=<hash>&actorId=<id>
+sharedMemoryRouter.get('/actor', async (c) => {
+  try {
+    const projectHash = requiredQuery(c, 'project');
+    const actorId = requiredQuery(c, 'actorId');
+    const scope = await withSharedMemoryActorAdapter((adapter) => adapter.scope({ projectHash, actorId }));
+    return c.json({
+      projectHash,
+      linked: Boolean(scope?.identity),
+      linkedProjectCount: scope?.linkedProjectCount ?? 0
+    });
+  } catch (error) {
+    return jsonError(c, error, { status: 400, message: 'Shared actor status unavailable' });
+  }
+});
+
+// DELETE /api/shared/actor?project=<hash>&actorId=<id>
+sharedMemoryRouter.delete('/actor', async (c) => {
+  try {
+    const projectHash = requiredQuery(c, 'project');
+    const actorId = requiredQuery(c, 'actorId');
+    const unlinked = await withSharedMemoryActorAdapter((adapter) => adapter.unlink({ projectHash, actorId }));
+    return c.json({ projectHash, unlinked: unlinked === true });
+  } catch (error) {
+    return jsonError(c, error, { status: 400, message: 'Shared actor unlink unavailable' });
+  }
+});

--- a/src/core/db-wrapper.ts
+++ b/src/core/db-wrapper.ts
@@ -30,7 +30,7 @@ export interface DatabaseOptions {
  * mongo sync, or a second handle to the same file) holds a write lock.
  */
 export function createDatabase(dbPath: string, options?: DatabaseOptions): Database {
-  const db = new BetterSqlite3(dbPath, { readonly: options?.readOnly });
+  const db = new BetterSqlite3(dbPath, { readonly: options?.readOnly ?? false });
   db.pragma('busy_timeout = 5000');
   if (!options?.readOnly) {
     db.pragma('journal_mode = WAL');

--- a/src/core/engine/memory-query-service.ts
+++ b/src/core/engine/memory-query-service.ts
@@ -13,6 +13,10 @@ import type { DerivationLiveness, RecentEventsReadOptions } from '../sqlite-even
 import type { SQLiteDatabase } from '../sqlite-wrapper.js';
 import { LessonRepository } from '../operations/lesson-repository.js';
 import { CoreMemoryBlockRepository } from '../operations/core-memory-block-repository.js';
+import {
+  CanonicalMemoryInjectionService,
+  type CanonicalMemoryInjection
+} from '../operations/canonical-memory-injection-service.js';
 
 interface RankedKeywordResult {
   event: MemoryEvent;
@@ -110,8 +114,35 @@ export class MemoryQueryService {
     }
   }
 
+  async listProjectLessonInjections(
+    projectHash: string,
+    actorId: string | undefined,
+    limit = 25
+  ): Promise<CanonicalMemoryInjection<MemoryLesson>[]> {
+    await this.initialize();
+    const db = this.queryStore.getDatabase?.();
+    if (!db || !projectHash) return [];
+    try {
+      const lessons = await new LessonRepository(db).list({ projectHash, limit });
+      return new CanonicalMemoryInjectionService(db).select({
+        projectHash,
+        actorId,
+        lane: 'prompt',
+        candidates: lessons.map((lesson) => ({
+          canonicalType: 'lesson',
+          canonicalId: lesson.lessonId,
+          value: lesson
+        }))
+      }).items;
+    } catch {
+      // Injection is supplementary: a missing actor in an enforcement mode
+      // must fail closed without breaking the surrounding hook.
+      return [];
+    }
+  }
+
   /**
-   * Core memory blocks (project/user) for unconditional session-start
+   * Core memory blocks (project/user) for legacy unconditional session-start
    * injection. Stored outside the events table, same reasoning as lessons:
    * without this lookup, agent self-edits via mem-core-block-update would
    * never resurface anywhere.
@@ -124,6 +155,31 @@ export class MemoryQueryService {
       return await new CoreMemoryBlockRepository(db).listByProject(projectHash);
     } catch {
       // Core memory block injection is supplementary: never fail a prompt over it.
+      return [];
+    }
+  }
+
+  async getCoreMemoryBlockInjections(
+    projectHash: string,
+    actorId: string | undefined
+  ): Promise<CanonicalMemoryInjection<CoreMemoryBlock>[]> {
+    await this.initialize();
+    const db = this.queryStore.getDatabase?.();
+    if (!db || !projectHash) return [];
+    try {
+      const blocks = await new CoreMemoryBlockRepository(db).listByProject(projectHash);
+      return new CanonicalMemoryInjectionService(db).select({
+        projectHash,
+        actorId,
+        lane: 'session_start',
+        candidates: blocks.map((block) => ({
+          canonicalType: 'core_memory_block',
+          canonicalId: block.blockKey,
+          value: block
+        }))
+      }).items;
+    } catch {
+      // Same fail-closed hook behavior as curated lessons above.
       return [];
     }
   }

--- a/src/core/operations/canonical-memory-access-service.ts
+++ b/src/core/operations/canonical-memory-access-service.ts
@@ -1,0 +1,137 @@
+import { z } from 'zod';
+
+import type { SQLiteDatabase } from '../sqlite-wrapper.js';
+import {
+  canonicalMemoryAssetId,
+  isCanonicalMemoryAssetRegistration
+} from './memory-asset-catalog-service.js';
+import { MemoryAssetPermissionService } from './memory-asset-permission-service.js';
+import { MemoryAssetRepository } from './memory-asset-repository.js';
+import type { MemoryAssetPermissionSource } from './memory-asset-permissions.js';
+
+export const CANONICAL_MEMORY_PERMISSION_MODE_ENV = 'CLAUDE_MEMORY_ASSET_PERMISSION_MODE';
+
+export const CanonicalMemoryPermissionModeSchema = z.enum(['legacy', 'registered', 'strict']);
+export type CanonicalMemoryPermissionMode = z.infer<typeof CanonicalMemoryPermissionModeSchema>;
+
+const RequesterActorIdSchema = z.string().trim().min(1).max(240);
+
+const CanonicalMemoryAccessInputSchema = z.object({
+  projectHash: z.string().trim().min(1).max(240),
+  canonicalType: z.enum(['lesson', 'core_memory_block']),
+  canonicalId: z.string().trim().min(1).max(240),
+  requesterActorId: z.string().trim().min(1).max(240).optional(),
+  permission: z.enum(['read', 'write'])
+});
+
+export interface CanonicalMemoryAccessDecision {
+  allowed: boolean;
+  mode: CanonicalMemoryPermissionMode;
+  registered: boolean;
+  source: MemoryAssetPermissionSource | 'legacy' | 'unregistered';
+}
+
+export class CanonicalMemoryAccessDeniedError extends Error {
+  readonly code = 'CANONICAL_MEMORY_ACCESS_DENIED';
+
+  constructor() {
+    super('permission denied for canonical memory access');
+    this.name = 'CanonicalMemoryAccessDeniedError';
+  }
+}
+
+export function resolveCanonicalMemoryPermissionMode(
+  env: NodeJS.ProcessEnv = process.env
+): CanonicalMemoryPermissionMode {
+  const raw = env[CANONICAL_MEMORY_PERMISSION_MODE_ENV]?.trim().toLowerCase();
+  if (!raw) return 'legacy';
+  const parsed = CanonicalMemoryPermissionModeSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error(`${CANONICAL_MEMORY_PERMISSION_MODE_ENV} must be legacy, registered, or strict`);
+  }
+  return parsed.data;
+}
+
+export class CanonicalMemoryAccessService {
+  private readonly repository: MemoryAssetRepository;
+  private readonly permissionService: MemoryAssetPermissionService;
+  readonly mode: CanonicalMemoryPermissionMode;
+
+  constructor(
+    db: SQLiteDatabase,
+    options: { mode?: CanonicalMemoryPermissionMode; env?: NodeJS.ProcessEnv } = {}
+  ) {
+    this.repository = new MemoryAssetRepository(db);
+    this.permissionService = new MemoryAssetPermissionService(db);
+    this.mode = options.mode ?? resolveCanonicalMemoryPermissionMode(options.env);
+  }
+
+  requireRequester(requesterActorId: string | undefined): void {
+    if (this.mode === 'legacy') return;
+    if (!requesterActorId) {
+      throw new Error(`requesterActorId is required when ${CANONICAL_MEMORY_PERMISSION_MODE_ENV}=${this.mode}`);
+    }
+    RequesterActorIdSchema.parse(requesterActorId);
+  }
+
+  requireUnregisteredWrite(requesterActorId: string | undefined): CanonicalMemoryAccessDecision {
+    this.requireRequester(requesterActorId);
+    if (this.mode === 'strict') throw new CanonicalMemoryAccessDeniedError();
+    return {
+      allowed: true,
+      mode: this.mode,
+      registered: false,
+      source: this.mode === 'legacy' ? 'legacy' : 'unregistered'
+    };
+  }
+
+  check(input: unknown): CanonicalMemoryAccessDecision {
+    const parsed = CanonicalMemoryAccessInputSchema.parse(input);
+    const assetId = canonicalMemoryAssetId(parsed.canonicalType, parsed.canonicalId);
+    const asset = this.repository.get(assetId, parsed.projectHash);
+    const registered = Boolean(
+      asset && isCanonicalMemoryAssetRegistration(asset, parsed.canonicalType, parsed.canonicalId)
+    );
+
+    if (this.mode === 'legacy') {
+      return { allowed: true, mode: this.mode, registered, source: 'legacy' };
+    }
+    this.requireRequester(parsed.requesterActorId);
+
+    if (!asset) {
+      const allowed = this.mode === 'registered';
+      return {
+        allowed,
+        mode: this.mode,
+        registered: false,
+        source: allowed ? 'unregistered' : 'none'
+      };
+    }
+
+    // A deterministic id occupied by a non-canonical asset is a conflict, not
+    // an unregistered fallback. Otherwise a caller could bypass protection by
+    // creating an unrelated asset with the canonical id.
+    if (!registered) {
+      return { allowed: false, mode: this.mode, registered: false, source: 'none' };
+    }
+
+    const result = this.permissionService.check({
+      projectHash: parsed.projectHash,
+      assetId,
+      requesterActorId: parsed.requesterActorId!,
+      permission: parsed.permission
+    });
+    return {
+      allowed: result.decision.allowed,
+      mode: this.mode,
+      registered: true,
+      source: result.decision.source
+    };
+  }
+
+  require(input: unknown): CanonicalMemoryAccessDecision {
+    const decision = this.check(input);
+    if (!decision.allowed) throw new CanonicalMemoryAccessDeniedError();
+    return decision;
+  }
+}

--- a/src/core/operations/canonical-memory-injection-service.ts
+++ b/src/core/operations/canonical-memory-injection-service.ts
@@ -56,6 +56,7 @@ function injectionModeRank(mode: 'direct' | 'summary' | 'reference'): number {
 
 export class CanonicalMemoryInjectionService {
   private readonly repository: MemoryAssetRepository;
+  private readonly env: NodeJS.ProcessEnv;
   readonly mode: CanonicalMemoryPermissionMode;
 
   constructor(
@@ -63,7 +64,8 @@ export class CanonicalMemoryInjectionService {
     options: { mode?: CanonicalMemoryPermissionMode; env?: NodeJS.ProcessEnv } = {}
   ) {
     this.repository = new MemoryAssetRepository(db);
-    this.mode = options.mode ?? resolveCanonicalMemoryPermissionMode(options.env);
+    this.env = options.env ?? process.env;
+    this.mode = options.mode ?? resolveCanonicalMemoryPermissionMode(this.env);
   }
 
   select<T>(input: {
@@ -72,7 +74,7 @@ export class CanonicalMemoryInjectionService {
     lane: CanonicalMemoryInjectionLane;
     candidates: CanonicalMemoryInjectionCandidate<T>[];
   }): CanonicalMemoryInjectionSelection<T> {
-    const actorId = resolveCanonicalMemoryActorId(input.actorId);
+    const actorId = resolveCanonicalMemoryActorId(input.actorId, this.env);
     if (this.mode !== 'legacy' && !actorId) {
       throw new Error(`actor identity is required when ${CANONICAL_MEMORY_PERMISSION_MODE_ENV}=${this.mode}`);
     }

--- a/src/core/operations/canonical-memory-injection-service.ts
+++ b/src/core/operations/canonical-memory-injection-service.ts
@@ -1,0 +1,127 @@
+import { z } from 'zod';
+
+import type { SQLiteDatabase } from '../sqlite-wrapper.js';
+import {
+  canonicalMemoryAssetId,
+  isCanonicalMemoryAssetRegistration,
+  type CanonicalMemoryAssetType
+} from './memory-asset-catalog-service.js';
+import {
+  CANONICAL_MEMORY_PERMISSION_MODE_ENV,
+  resolveCanonicalMemoryPermissionMode,
+  type CanonicalMemoryPermissionMode
+} from './canonical-memory-access-service.js';
+import { MemoryAssetRepository } from './memory-asset-repository.js';
+import type { MemoryAssetInjectionMode } from './memory-asset-permissions.js';
+
+export const CANONICAL_MEMORY_ACTOR_ID_ENV = 'CLAUDE_MEMORY_ACTOR_ID';
+
+const ActorIdSchema = z.string().trim().min(1).max(240);
+
+export type CanonicalMemoryInjectionLane = 'session_start' | 'prompt' | 'context_pack';
+
+export interface CanonicalMemoryInjectionCandidate<T> {
+  canonicalType: CanonicalMemoryAssetType;
+  canonicalId: string;
+  value: T;
+}
+
+export interface CanonicalMemoryInjection<T> {
+  value: T;
+  injectionMode: Extract<MemoryAssetInjectionMode, 'direct' | 'summary' | 'reference'>;
+  priority: number;
+}
+
+export interface CanonicalMemoryInjectionSelection<T> {
+  mode: CanonicalMemoryPermissionMode;
+  items: CanonicalMemoryInjection<T>[];
+}
+
+export function resolveCanonicalMemoryActorId(
+  explicitActorId: unknown,
+  env: NodeJS.ProcessEnv = process.env
+): string | undefined {
+  const raw = typeof explicitActorId === 'string' && explicitActorId.trim().length > 0
+    ? explicitActorId
+    : env[CANONICAL_MEMORY_ACTOR_ID_ENV];
+  const parsed = ActorIdSchema.safeParse(raw);
+  return parsed.success ? parsed.data : undefined;
+}
+
+function injectionModeRank(mode: 'direct' | 'summary' | 'reference'): number {
+  if (mode === 'direct') return 3;
+  if (mode === 'summary') return 2;
+  return 1;
+}
+
+export class CanonicalMemoryInjectionService {
+  private readonly repository: MemoryAssetRepository;
+  readonly mode: CanonicalMemoryPermissionMode;
+
+  constructor(
+    db: SQLiteDatabase,
+    options: { mode?: CanonicalMemoryPermissionMode; env?: NodeJS.ProcessEnv } = {}
+  ) {
+    this.repository = new MemoryAssetRepository(db);
+    this.mode = options.mode ?? resolveCanonicalMemoryPermissionMode(options.env);
+  }
+
+  select<T>(input: {
+    projectHash: string;
+    actorId?: string;
+    lane: CanonicalMemoryInjectionLane;
+    candidates: CanonicalMemoryInjectionCandidate<T>[];
+  }): CanonicalMemoryInjectionSelection<T> {
+    const actorId = resolveCanonicalMemoryActorId(input.actorId);
+    if (this.mode !== 'legacy' && !actorId) {
+      throw new Error(`actor identity is required when ${CANONICAL_MEMORY_PERMISSION_MODE_ENV}=${this.mode}`);
+    }
+
+    if (this.mode === 'legacy') {
+      return {
+        mode: this.mode,
+        items: input.candidates.map((candidate) => ({
+          value: candidate.value,
+          injectionMode: 'direct',
+          priority: 0
+        }))
+      };
+    }
+
+    const selected: Array<CanonicalMemoryInjection<T> & { canonicalId: string }> = [];
+    for (const candidate of input.candidates) {
+      const assetId = canonicalMemoryAssetId(candidate.canonicalType, candidate.canonicalId);
+      const asset = this.repository.get(assetId, input.projectHash);
+      const registered = Boolean(
+        asset && isCanonicalMemoryAssetRegistration(asset, candidate.canonicalType, candidate.canonicalId)
+      );
+
+      if (!asset) {
+        if (this.mode === 'registered') {
+          selected.push({ value: candidate.value, injectionMode: 'direct', priority: 0, canonicalId: candidate.canonicalId });
+        }
+        continue;
+      }
+      if (!registered || asset.status !== 'active') continue;
+
+      const binding = this.repository.getBinding(assetId, actorId!, input.projectHash);
+      if (!binding?.enabled || binding.injectionMode === 'tool') continue;
+      selected.push({
+        value: candidate.value,
+        injectionMode: binding.injectionMode,
+        priority: binding.priority,
+        canonicalId: candidate.canonicalId
+      });
+    }
+
+    selected.sort((left, right) => (
+      right.priority - left.priority
+      || injectionModeRank(right.injectionMode) - injectionModeRank(left.injectionMode)
+      || left.canonicalId.localeCompare(right.canonicalId)
+    ));
+    return {
+      mode: this.mode,
+      items: selected.map(({ canonicalId: _canonicalId, ...item }) => item)
+    };
+  }
+}

--- a/src/core/operations/governance-audit.ts
+++ b/src/core/operations/governance-audit.ts
@@ -19,7 +19,11 @@ export const MEMORY_GOVERNANCE_AUDIT_OPERATIONS = [
   'perspective_observation_create',
   'perspective_observation_delete',
   'core_memory_block_update',
-  'entity_supersede'
+  'entity_supersede',
+  'memory_asset_create',
+  'memory_asset_update',
+  'memory_asset_bind',
+  'memory_asset_grant_set'
 ] as const;
 
 export type MemoryGovernanceAuditOperation = typeof MEMORY_GOVERNANCE_AUDIT_OPERATIONS[number];
@@ -123,10 +127,14 @@ function normalizeOperation(operation: MemoryGovernanceAuditOperation): MemoryGo
   return operation;
 }
 
-export async function writeGovernanceAuditEntry(
+/**
+ * Synchronous audit writer for callers that must include the audit row in an
+ * existing better-sqlite3 transaction.
+ */
+export function writeGovernanceAuditEntrySync(
   db: SQLiteDatabase,
   input: GovernanceAuditEntryInput
-): Promise<MemoryGovernanceAuditEntry> {
+): MemoryGovernanceAuditEntry {
   const entry: MemoryGovernanceAuditEntry = {
     auditId: randomUUID(),
     operation: normalizeOperation(input.operation),
@@ -161,4 +169,12 @@ export async function writeGovernanceAuditEntry(
   );
 
   return entry;
+}
+
+/** Preserve the existing async API used by repositories and external callers. */
+export async function writeGovernanceAuditEntry(
+  db: SQLiteDatabase,
+  input: GovernanceAuditEntryInput
+): Promise<MemoryGovernanceAuditEntry> {
+  return writeGovernanceAuditEntrySync(db, input);
 }

--- a/src/core/operations/index.ts
+++ b/src/core/operations/index.ts
@@ -29,3 +29,6 @@ export * from './perspective-consolidator.js';
 export * from './perspective-session-actor-backfill.js';
 export * from './tool-observation-vector-backfill.js';
 export * from './credential-redaction.js';
+export * from './memory-asset-permissions.js';
+export * from './memory-asset-repository.js';
+export * from './memory-asset-permission-service.js';

--- a/src/core/operations/index.ts
+++ b/src/core/operations/index.ts
@@ -34,3 +34,4 @@ export * from './memory-asset-repository.js';
 export * from './memory-asset-permission-service.js';
 export * from './memory-asset-catalog-service.js';
 export * from './canonical-memory-access-service.js';
+export * from './canonical-memory-injection-service.js';

--- a/src/core/operations/index.ts
+++ b/src/core/operations/index.ts
@@ -35,3 +35,4 @@ export * from './memory-asset-permission-service.js';
 export * from './memory-asset-catalog-service.js';
 export * from './canonical-memory-access-service.js';
 export * from './canonical-memory-injection-service.js';
+export * from './shared-canonical-memory-asset-read-service.js';

--- a/src/core/operations/index.ts
+++ b/src/core/operations/index.ts
@@ -33,3 +33,4 @@ export * from './memory-asset-permissions.js';
 export * from './memory-asset-repository.js';
 export * from './memory-asset-permission-service.js';
 export * from './memory-asset-catalog-service.js';
+export * from './canonical-memory-access-service.js';

--- a/src/core/operations/index.ts
+++ b/src/core/operations/index.ts
@@ -32,3 +32,4 @@ export * from './credential-redaction.js';
 export * from './memory-asset-permissions.js';
 export * from './memory-asset-repository.js';
 export * from './memory-asset-permission-service.js';
+export * from './memory-asset-catalog-service.js';

--- a/src/core/operations/lesson-repository.ts
+++ b/src/core/operations/lesson-repository.ts
@@ -121,7 +121,7 @@ export class LessonRepository {
   async upsert(input: unknown, auditOperation: LessonAuditOperation = 'lesson_promote'): Promise<MemoryLesson> {
     const parsed = sanitizeParsedLesson(UpsertMemoryLessonInputSchema.parse(input));
     const existingById = parsed.lessonId ? this.get(parsed.lessonId) : null;
-    const existingByName = this.findByProjectAndName(parsed.projectHash, parsed.name);
+    const existingByName = this.getByProjectAndName(parsed.projectHash, parsed.name);
     if (existingById && existingByName && existingById.lessonId !== existingByName.lessonId) {
       throw new Error('lesson name already exists for projectHash');
     }
@@ -201,17 +201,20 @@ export class LessonRepository {
       clauses.push('skill_candidate = ?');
       params.push(parsed.skillCandidate ? 1 : 0);
     }
-    params.push(parsed.limit);
+    params.push(parsed.limit, parsed.offset);
     const where = clauses.join(' AND ');
     const rows = sqliteAll<MemoryLessonRow>(
       this.db,
-      `SELECT * FROM memory_lessons WHERE ${where} ORDER BY confidence DESC, updated_at DESC LIMIT ?`,
+      `SELECT * FROM memory_lessons
+       WHERE ${where}
+       ORDER BY confidence DESC, updated_at DESC, lesson_id ASC
+       LIMIT ? OFFSET ?`,
       params
     );
     return rows.map(rowToLesson);
   }
 
-  private findByProjectAndName(projectHash: string | undefined, name: string): MemoryLesson | null {
+  getByProjectAndName(projectHash: string | undefined, name: string): MemoryLesson | null {
     const row = sqliteGet<MemoryLessonRow>(
       this.db,
       `SELECT * FROM memory_lessons WHERE project_hash = ? AND name = ?`,

--- a/src/core/operations/memory-asset-catalog-service.ts
+++ b/src/core/operations/memory-asset-catalog-service.ts
@@ -1,0 +1,219 @@
+import { z } from 'zod';
+
+import { sqliteAll, sqliteGet, type SQLiteDatabase } from '../sqlite-wrapper.js';
+import { MemoryAssetPermissionService } from './memory-asset-permission-service.js';
+import { MemoryAssetRepository } from './memory-asset-repository.js';
+import type { MemoryAsset, MemoryAssetStatus, MemoryAssetType } from './memory-asset-permissions.js';
+
+const CatalogSyncInputSchema = z.object({
+  projectHash: z.string().trim().min(1).max(240),
+  requesterActorId: z.string().trim().min(1).max(240),
+  apply: z.boolean().default(false),
+  limit: z.number().int().positive().max(500).default(100)
+});
+
+export type CanonicalMemoryAssetType = 'lesson' | 'core_memory_block';
+export type MemoryAssetCatalogAction = 'create' | 'created' | 'exists' | 'conflict';
+
+interface CanonicalAssetRow {
+  canonical_type: CanonicalMemoryAssetType;
+  canonical_id: string;
+  title: string;
+  canonical_status: MemoryAssetStatus;
+}
+
+interface CountRow {
+  count: number;
+}
+
+export interface CanonicalMemoryAssetCandidate {
+  canonicalType: CanonicalMemoryAssetType;
+  canonicalId: string;
+  assetId: string;
+  assetType: MemoryAssetType;
+  title: string;
+  status: MemoryAssetStatus;
+  sourceRefs: string[];
+  metadata: Record<string, unknown>;
+}
+
+export interface MemoryAssetCatalogItem {
+  candidate: CanonicalMemoryAssetCandidate;
+  action: MemoryAssetCatalogAction;
+  reason?: string;
+}
+
+export interface MemoryAssetCatalogSyncResult {
+  dryRun: boolean;
+  projectHash: string;
+  totalCandidates: number;
+  scanned: number;
+  truncated: boolean;
+  planned: number;
+  created: number;
+  existing: number;
+  conflicts: number;
+  items: MemoryAssetCatalogItem[];
+}
+
+export function canonicalMemoryAssetId(type: CanonicalMemoryAssetType, canonicalId: string): string {
+  return `${type}:${canonicalId.trim()}`;
+}
+
+function rowToCandidate(row: CanonicalAssetRow): CanonicalMemoryAssetCandidate {
+  const assetId = canonicalMemoryAssetId(row.canonical_type, row.canonical_id);
+  return {
+    canonicalType: row.canonical_type,
+    canonicalId: row.canonical_id,
+    assetId,
+    assetType: row.canonical_type === 'lesson' ? 'lesson' : 'memory',
+    title: row.title,
+    status: row.canonical_status,
+    // The canonical object retains its own evidence references. Keeping only
+    // this pointer avoids duplicating event ids (and potential legacy data)
+    // into the permission registry.
+    sourceRefs: [assetId],
+    metadata: {
+      canonicalType: row.canonical_type,
+      canonicalId: row.canonical_id
+    }
+  };
+}
+
+function matchesCanonicalAsset(asset: MemoryAsset, candidate: CanonicalMemoryAssetCandidate): boolean {
+  return asset.assetType === candidate.assetType && asset.sourceRefs.includes(candidate.assetId);
+}
+
+function classifyCandidate(
+  repository: MemoryAssetRepository,
+  projectHash: string,
+  candidate: CanonicalMemoryAssetCandidate
+): MemoryAssetCatalogItem {
+  const asset = repository.get(candidate.assetId, projectHash);
+  if (!asset) return { candidate, action: 'create' };
+  if (matchesCanonicalAsset(asset, candidate)) return { candidate, action: 'exists' };
+  return {
+    candidate,
+    action: 'conflict',
+    reason: 'deterministic asset id is already registered for another canonical source',
+  };
+}
+
+export class MemoryAssetCatalogService {
+  private readonly repository: MemoryAssetRepository;
+  private readonly permissionService: MemoryAssetPermissionService;
+
+  constructor(private readonly db: SQLiteDatabase) {
+    this.repository = new MemoryAssetRepository(db);
+    this.permissionService = new MemoryAssetPermissionService(db);
+  }
+
+  async sync(input: unknown): Promise<MemoryAssetCatalogSyncResult> {
+    const parsed = CatalogSyncInputSchema.parse(input);
+    const candidates = this.listCanonicalCandidates(parsed.projectHash, parsed.limit);
+    const totalCandidates = this.countCanonicalCandidates(parsed.projectHash);
+    const items = candidates.map((candidate) => classifyCandidate(this.repository, parsed.projectHash, candidate));
+    const planned = items.filter((item) => item.action === 'create').length;
+
+    if (parsed.apply) {
+      for (let index = 0; index < items.length; index++) {
+        const item = items[index];
+        if (item.action !== 'create') continue;
+
+        // Recheck immediately before the write so a concurrent/idempotent
+        // registration becomes an exists/conflict result instead of an overwrite.
+        const current = classifyCandidate(this.repository, parsed.projectHash, item.candidate);
+        if (current.action !== 'create') {
+          items[index] = current;
+          continue;
+        }
+
+        try {
+          await this.permissionService.create({
+            projectHash: parsed.projectHash,
+            requesterActorId: parsed.requesterActorId,
+            assetId: item.candidate.assetId,
+            assetType: item.candidate.assetType,
+            title: item.candidate.title,
+            status: item.candidate.status,
+            visibility: 'private',
+            sourceRefs: item.candidate.sourceRefs,
+            metadata: item.candidate.metadata
+          });
+          items[index] = { ...item, action: 'created' };
+        } catch (error) {
+          // Another connection may have won after the preflight check. Treat
+          // the now-visible row idempotently; propagate unrelated failures.
+          const raced = classifyCandidate(this.repository, parsed.projectHash, item.candidate);
+          if (raced.action === 'create') throw error;
+          items[index] = raced;
+        }
+      }
+    }
+
+    return this.buildResult(parsed.apply, parsed.projectHash, totalCandidates, planned, items);
+  }
+
+  private countCanonicalCandidates(projectHash: string): number {
+    const lessonCount = sqliteGet<CountRow>(
+      this.db,
+      `SELECT COUNT(*) AS count FROM memory_lessons WHERE project_hash = ?`,
+      [projectHash]
+    )?.count ?? 0;
+    const blockCount = sqliteGet<CountRow>(
+      this.db,
+      `SELECT COUNT(*) AS count FROM core_memory_blocks WHERE project_hash = ?`,
+      [projectHash]
+    )?.count ?? 0;
+    return Number(lessonCount) + Number(blockCount);
+  }
+
+  private listCanonicalCandidates(projectHash: string, limit: number): CanonicalMemoryAssetCandidate[] {
+    const rows = sqliteAll<CanonicalAssetRow>(
+      this.db,
+      `SELECT canonical_type, canonical_id, title, canonical_status
+       FROM (
+         SELECT
+           'lesson' AS canonical_type,
+           lesson_id AS canonical_id,
+           name AS title,
+           'active' AS canonical_status
+         FROM memory_lessons
+         WHERE project_hash = ?
+         UNION ALL
+         SELECT
+           'core_memory_block' AS canonical_type,
+           block_key AS canonical_id,
+           'Core memory: ' || block_key AS title,
+           CASE WHEN LENGTH(TRIM(content)) = 0 THEN 'archived' ELSE 'active' END AS canonical_status
+         FROM core_memory_blocks
+         WHERE project_hash = ?
+       )
+       ORDER BY canonical_type ASC, canonical_id ASC
+       LIMIT ?`,
+      [projectHash, projectHash, limit]
+    );
+    return rows.map(rowToCandidate);
+  }
+
+  private buildResult(
+    apply: boolean,
+    projectHash: string,
+    totalCandidates: number,
+    planned: number,
+    items: MemoryAssetCatalogItem[]
+  ): MemoryAssetCatalogSyncResult {
+    return {
+      dryRun: !apply,
+      projectHash,
+      totalCandidates,
+      scanned: items.length,
+      truncated: totalCandidates > items.length,
+      planned,
+      created: items.filter((item) => item.action === 'created').length,
+      existing: items.filter((item) => item.action === 'exists').length,
+      conflicts: items.filter((item) => item.action === 'conflict').length,
+      items
+    };
+  }
+}

--- a/src/core/operations/memory-asset-catalog-service.ts
+++ b/src/core/operations/memory-asset-catalog-service.ts
@@ -60,6 +60,18 @@ export function canonicalMemoryAssetId(type: CanonicalMemoryAssetType, canonical
   return `${type}:${canonicalId.trim()}`;
 }
 
+export function isCanonicalMemoryAssetRegistration(
+  asset: MemoryAsset,
+  canonicalType: CanonicalMemoryAssetType,
+  canonicalId: string
+): boolean {
+  const assetId = canonicalMemoryAssetId(canonicalType, canonicalId);
+  const expectedAssetType: MemoryAssetType = canonicalType === 'lesson' ? 'lesson' : 'memory';
+  return asset.assetId === assetId
+    && asset.assetType === expectedAssetType
+    && asset.sourceRefs.includes(assetId);
+}
+
 function rowToCandidate(row: CanonicalAssetRow): CanonicalMemoryAssetCandidate {
   const assetId = canonicalMemoryAssetId(row.canonical_type, row.canonical_id);
   return {
@@ -81,7 +93,7 @@ function rowToCandidate(row: CanonicalAssetRow): CanonicalMemoryAssetCandidate {
 }
 
 function matchesCanonicalAsset(asset: MemoryAsset, candidate: CanonicalMemoryAssetCandidate): boolean {
-  return asset.assetType === candidate.assetType && asset.sourceRefs.includes(candidate.assetId);
+  return isCanonicalMemoryAssetRegistration(asset, candidate.canonicalType, candidate.canonicalId);
 }
 
 function classifyCandidate(

--- a/src/core/operations/memory-asset-permission-service.ts
+++ b/src/core/operations/memory-asset-permission-service.ts
@@ -1,0 +1,248 @@
+import { z } from 'zod';
+
+import { sqliteTransaction, type SQLiteDatabase } from '../sqlite-wrapper.js';
+import { writeGovernanceAuditEntrySync } from './governance-audit.js';
+import { MemoryAssetRepository, type ListMemoryAssetsInput } from './memory-asset-repository.js';
+import {
+  CreateMemoryAssetInputSchema,
+  MemoryAssetPermissionDeniedError,
+  MemoryAssetPermissionSchema,
+  SetMemoryAssetBindingInputSchema,
+  SetMemoryAssetGrantInputSchema,
+  UpdateMemoryAssetInputSchema,
+  checkMemoryAssetPermission,
+  type MemoryAsset,
+  type MemoryAssetBinding,
+  type MemoryAssetGrant,
+  type MemoryAssetPermission,
+  type MemoryAssetPermissionDecision
+} from './memory-asset-permissions.js';
+
+const ActorIdSchema = z.string().trim().min(1).max(240);
+
+export interface MemoryAssetAccessInput {
+  projectHash?: string;
+  assetId: string;
+  requesterActorId: string;
+  permission: MemoryAssetPermission;
+}
+
+export interface MemoryAssetAccessResult {
+  asset?: MemoryAsset;
+  decision: MemoryAssetPermissionDecision;
+}
+
+export interface CreateAuthorizedMemoryAssetInput {
+  projectHash?: string;
+  requesterActorId: string;
+  assetId?: string;
+  assetType: MemoryAsset['assetType'];
+  title: string;
+  status?: MemoryAsset['status'];
+  visibility?: MemoryAsset['visibility'];
+  sourceRefs?: string[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface UpdateAuthorizedMemoryAssetInput {
+  projectHash?: string;
+  requesterActorId: string;
+  assetId: string;
+  expectedVersion?: number;
+  title?: string;
+  status?: MemoryAsset['status'];
+  visibility?: MemoryAsset['visibility'];
+  sourceRefs?: string[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface BindAuthorizedMemoryAssetInput {
+  projectHash?: string;
+  requesterActorId: string;
+  assetId: string;
+  actorId: string;
+  injectionMode?: MemoryAssetBinding['injectionMode'];
+  priority?: number;
+  enabled?: boolean;
+}
+
+export interface GrantAuthorizedMemoryAssetInput {
+  projectHash?: string;
+  requesterActorId: string;
+  assetId: string;
+  actorId: string;
+  permissions: MemoryAssetPermission[];
+}
+
+function snapshot(value: MemoryAsset | MemoryAssetBinding | MemoryAssetGrant | null): Record<string, unknown> | undefined {
+  if (!value) return undefined;
+  return { ...value };
+}
+
+export class MemoryAssetPermissionService {
+  private readonly repository: MemoryAssetRepository;
+
+  constructor(private readonly db: SQLiteDatabase) {
+    this.repository = new MemoryAssetRepository(db);
+  }
+
+  async create(input: CreateAuthorizedMemoryAssetInput): Promise<MemoryAsset> {
+    const requesterActorId = ActorIdSchema.parse(input.requesterActorId);
+    const parsed = CreateMemoryAssetInputSchema.parse({
+      ...input,
+      ownerActorId: requesterActorId,
+      sourceRefs: input.sourceRefs ?? []
+    });
+    return sqliteTransaction(this.db, () => {
+      const asset = this.repository.create(parsed);
+      writeGovernanceAuditEntrySync(this.db, {
+        operation: 'memory_asset_create',
+        actor: requesterActorId,
+        projectHash: asset.projectHash,
+        targetType: 'memory_asset',
+        targetId: asset.assetId,
+        afterJson: snapshot(asset)
+      });
+      return asset;
+    });
+  }
+
+  async list(input: ListMemoryAssetsInput & { requesterActorId: string }): Promise<MemoryAsset[]> {
+    const requesterActorId = ActorIdSchema.parse(input.requesterActorId);
+    const requestedLimit = Math.min(500, Math.max(1, input.limit ?? 100));
+    const pageSize = Math.max(100, requestedLimit);
+    const readable: MemoryAsset[] = [];
+    let offset = 0;
+
+    // Filtering after a limited query can omit readable assets when newer
+    // private assets occupy the first page. Scan deterministic pages until the
+    // requested number of authorized results is found or the project is exhausted.
+    while (readable.length < requestedLimit) {
+      const assets = this.repository.list({
+        projectHash: input.projectHash,
+        assetType: input.assetType,
+        status: input.status,
+        limit: pageSize,
+        offset
+      });
+      for (const asset of assets) {
+        if (this.evaluate(asset, requesterActorId, 'read').allowed) {
+          readable.push(asset);
+          if (readable.length === requestedLimit) return readable;
+        }
+      }
+      if (assets.length < pageSize) break;
+      offset += assets.length;
+    }
+    return readable;
+  }
+
+  async get(input: Omit<MemoryAssetAccessInput, 'permission'>): Promise<MemoryAsset | null> {
+    const result = this.check({ ...input, permission: 'read' });
+    return result.decision.allowed ? result.asset ?? null : null;
+  }
+
+  check(input: MemoryAssetAccessInput): MemoryAssetAccessResult {
+    const requesterActorId = ActorIdSchema.parse(input.requesterActorId);
+    const permission = MemoryAssetPermissionSchema.parse(input.permission);
+    const asset = this.repository.get(input.assetId, input.projectHash);
+    if (!asset) {
+      return {
+        decision: {
+          allowed: false,
+          permission,
+          source: 'none',
+          reason: 'permission denied'
+        }
+      };
+    }
+    const decision = this.evaluate(asset, requesterActorId, permission);
+    return decision.allowed ? { asset, decision } : { decision };
+  }
+
+  async update(input: UpdateAuthorizedMemoryAssetInput): Promise<MemoryAsset> {
+    const requesterActorId = ActorIdSchema.parse(input.requesterActorId);
+    const parsed = UpdateMemoryAssetInputSchema.parse(input);
+    return sqliteTransaction(this.db, () => {
+      const before = this.requireAllowed(input.projectHash, input.assetId, requesterActorId, 'write');
+      const after = this.repository.update(parsed);
+      writeGovernanceAuditEntrySync(this.db, {
+        operation: 'memory_asset_update',
+        actor: requesterActorId,
+        projectHash: after.projectHash,
+        targetType: 'memory_asset',
+        targetId: after.assetId,
+        beforeJson: snapshot(before),
+        afterJson: snapshot(after)
+      });
+      return after;
+    });
+  }
+
+  async bind(input: BindAuthorizedMemoryAssetInput): Promise<MemoryAssetBinding> {
+    const requesterActorId = ActorIdSchema.parse(input.requesterActorId);
+    const parsed = SetMemoryAssetBindingInputSchema.parse(input);
+    return sqliteTransaction(this.db, () => {
+      const asset = this.requireAllowed(input.projectHash, input.assetId, requesterActorId, 'bind');
+      const before = this.repository.getBinding(asset.assetId, parsed.actorId, asset.projectHash);
+      const after = this.repository.setBinding(parsed);
+      writeGovernanceAuditEntrySync(this.db, {
+        operation: 'memory_asset_bind',
+        actor: requesterActorId,
+        projectHash: asset.projectHash,
+        targetType: 'memory_asset_binding',
+        targetId: `${asset.assetId}:${parsed.actorId}`,
+        beforeJson: snapshot(before),
+        afterJson: snapshot(after)
+      });
+      return after;
+    });
+  }
+
+  async setGrant(input: GrantAuthorizedMemoryAssetInput): Promise<MemoryAssetGrant> {
+    const requesterActorId = ActorIdSchema.parse(input.requesterActorId);
+    const parsed = SetMemoryAssetGrantInputSchema.parse({ ...input, createdBy: requesterActorId });
+    return sqliteTransaction(this.db, () => {
+      const asset = this.requireAllowed(input.projectHash, input.assetId, requesterActorId, 'grant');
+      const before = this.repository.getGrant(asset.assetId, parsed.actorId, asset.projectHash);
+      const after = this.repository.setGrant(parsed);
+      writeGovernanceAuditEntrySync(this.db, {
+        operation: 'memory_asset_grant_set',
+        actor: requesterActorId,
+        projectHash: asset.projectHash,
+        targetType: 'memory_asset_grant',
+        targetId: `${asset.assetId}:${parsed.actorId}`,
+        beforeJson: snapshot(before),
+        afterJson: snapshot(after)
+      });
+      return after;
+    });
+  }
+
+  private evaluate(
+    asset: MemoryAsset,
+    actorId: string,
+    permission: MemoryAssetPermission
+  ): MemoryAssetPermissionDecision {
+    return checkMemoryAssetPermission({
+      asset,
+      actorId,
+      permission,
+      binding: this.repository.getBinding(asset.assetId, actorId, asset.projectHash),
+      grant: this.repository.getGrant(asset.assetId, actorId, asset.projectHash)
+    });
+  }
+
+  private requireAllowed(
+    projectHash: string | undefined,
+    assetId: string,
+    actorId: string,
+    permission: MemoryAssetPermission
+  ): MemoryAsset {
+    const result = this.check({ projectHash, assetId, requesterActorId: actorId, permission });
+    if (!result.asset || !result.decision.allowed) {
+      throw new MemoryAssetPermissionDeniedError(assetId, actorId, permission);
+    }
+    return result.asset;
+  }
+}

--- a/src/core/operations/memory-asset-permissions.ts
+++ b/src/core/operations/memory-asset-permissions.ts
@@ -1,0 +1,181 @@
+import { z } from 'zod';
+
+const NonEmptyStringSchema = z.string().trim().min(1).max(240);
+const OptionalProjectHashSchema = z.string().trim().min(1).max(240).optional();
+const StringArraySchema = z.array(z.string().trim().min(1).max(240)).max(100).default([]);
+
+export const MemoryAssetTypeSchema = z.enum(['memory', 'lesson', 'skill', 'wiki', 'code_graph']);
+export type MemoryAssetType = z.infer<typeof MemoryAssetTypeSchema>;
+
+export const MemoryAssetStatusSchema = z.enum(['candidate', 'active', 'deprecated', 'archived']);
+export type MemoryAssetStatus = z.infer<typeof MemoryAssetStatusSchema>;
+
+export const MemoryAssetVisibilitySchema = z.enum(['private', 'project', 'shared']);
+export type MemoryAssetVisibility = z.infer<typeof MemoryAssetVisibilitySchema>;
+
+export const MemoryAssetPermissionSchema = z.enum(['read', 'write', 'bind', 'grant']);
+export type MemoryAssetPermission = z.infer<typeof MemoryAssetPermissionSchema>;
+
+export const MemoryAssetInjectionModeSchema = z.enum(['direct', 'summary', 'tool', 'reference']);
+export type MemoryAssetInjectionMode = z.infer<typeof MemoryAssetInjectionModeSchema>;
+
+export const MemoryAssetSchema = z.object({
+  assetId: NonEmptyStringSchema,
+  projectHash: OptionalProjectHashSchema,
+  assetType: MemoryAssetTypeSchema,
+  title: NonEmptyStringSchema,
+  ownerActorId: NonEmptyStringSchema,
+  version: z.number().int().positive(),
+  status: MemoryAssetStatusSchema,
+  visibility: MemoryAssetVisibilitySchema,
+  sourceRefs: StringArraySchema,
+  metadata: z.record(z.unknown()).optional(),
+  createdAt: z.date(),
+  updatedAt: z.date()
+});
+export type MemoryAsset = z.infer<typeof MemoryAssetSchema>;
+
+export const CreateMemoryAssetInputSchema = z.object({
+  assetId: NonEmptyStringSchema.optional(),
+  projectHash: OptionalProjectHashSchema,
+  assetType: MemoryAssetTypeSchema,
+  title: NonEmptyStringSchema,
+  ownerActorId: NonEmptyStringSchema,
+  status: MemoryAssetStatusSchema.default('active'),
+  visibility: MemoryAssetVisibilitySchema.default('private'),
+  sourceRefs: StringArraySchema,
+  metadata: z.record(z.unknown()).optional()
+});
+export type CreateMemoryAssetInput = z.input<typeof CreateMemoryAssetInputSchema>;
+
+export const UpdateMemoryAssetInputSchema = z.object({
+  assetId: NonEmptyStringSchema,
+  projectHash: OptionalProjectHashSchema,
+  expectedVersion: z.number().int().positive().optional(),
+  title: NonEmptyStringSchema.optional(),
+  status: MemoryAssetStatusSchema.optional(),
+  visibility: MemoryAssetVisibilitySchema.optional(),
+  sourceRefs: StringArraySchema.optional(),
+  metadata: z.record(z.unknown()).optional()
+}).refine(
+  (input) => input.title !== undefined
+    || input.status !== undefined
+    || input.visibility !== undefined
+    || input.sourceRefs !== undefined
+    || input.metadata !== undefined,
+  'at least one asset field must be supplied'
+);
+export type UpdateMemoryAssetInput = z.input<typeof UpdateMemoryAssetInputSchema>;
+
+export const MemoryAssetBindingSchema = z.object({
+  projectHash: OptionalProjectHashSchema,
+  assetId: NonEmptyStringSchema,
+  actorId: NonEmptyStringSchema,
+  injectionMode: MemoryAssetInjectionModeSchema,
+  priority: z.number().int().min(-1000).max(1000),
+  enabled: z.boolean(),
+  createdAt: z.date(),
+  updatedAt: z.date()
+});
+export type MemoryAssetBinding = z.infer<typeof MemoryAssetBindingSchema>;
+
+export const SetMemoryAssetBindingInputSchema = z.object({
+  projectHash: OptionalProjectHashSchema,
+  assetId: NonEmptyStringSchema,
+  actorId: NonEmptyStringSchema,
+  injectionMode: MemoryAssetInjectionModeSchema.default('reference'),
+  priority: z.number().int().min(-1000).max(1000).default(0),
+  enabled: z.boolean().default(true)
+});
+export type SetMemoryAssetBindingInput = z.input<typeof SetMemoryAssetBindingInputSchema>;
+
+export const MemoryAssetGrantSchema = z.object({
+  projectHash: OptionalProjectHashSchema,
+  assetId: NonEmptyStringSchema,
+  actorId: NonEmptyStringSchema,
+  permissions: z.array(MemoryAssetPermissionSchema).max(4),
+  createdBy: NonEmptyStringSchema,
+  createdAt: z.date(),
+  updatedAt: z.date()
+});
+export type MemoryAssetGrant = z.infer<typeof MemoryAssetGrantSchema>;
+
+export const SetMemoryAssetGrantInputSchema = z.object({
+  projectHash: OptionalProjectHashSchema,
+  assetId: NonEmptyStringSchema,
+  actorId: NonEmptyStringSchema,
+  permissions: z.array(MemoryAssetPermissionSchema).max(4),
+  createdBy: NonEmptyStringSchema
+});
+export type SetMemoryAssetGrantInput = z.input<typeof SetMemoryAssetGrantInputSchema>;
+
+export type MemoryAssetPermissionSource = 'owner' | 'visibility' | 'binding' | 'grant' | 'none';
+
+export interface MemoryAssetPermissionDecision {
+  allowed: boolean;
+  permission: MemoryAssetPermission;
+  source: MemoryAssetPermissionSource;
+  reason: string;
+}
+
+export interface CheckMemoryAssetPermissionInput {
+  asset: MemoryAsset;
+  actorId: string;
+  permission: MemoryAssetPermission;
+  binding?: MemoryAssetBinding | null;
+  grant?: MemoryAssetGrant | null;
+}
+
+/**
+ * Small, deterministic permission core. Precedence deliberately follows
+ * owner -> read visibility -> active binding -> explicit grant -> deny.
+ * Bindings make an asset readable/injectable; they never confer mutation or
+ * delegation rights.
+ */
+export function checkMemoryAssetPermission(input: CheckMemoryAssetPermissionInput): MemoryAssetPermissionDecision {
+  const actorId = NonEmptyStringSchema.parse(input.actorId);
+  const permission = MemoryAssetPermissionSchema.parse(input.permission);
+
+  if (input.asset.ownerActorId === actorId) {
+    return { allowed: true, permission, source: 'owner', reason: 'asset owner' };
+  }
+
+  if (permission === 'read' && (input.asset.visibility === 'project' || input.asset.visibility === 'shared')) {
+    return { allowed: true, permission, source: 'visibility', reason: `${input.asset.visibility} visibility` };
+  }
+
+  if (
+    permission === 'read'
+    && input.binding?.actorId === actorId
+    && input.binding.assetId === input.asset.assetId
+    && input.binding.enabled
+  ) {
+    return { allowed: true, permission, source: 'binding', reason: 'active actor binding' };
+  }
+
+  if (
+    input.grant?.actorId === actorId
+    && input.grant.assetId === input.asset.assetId
+    && input.grant.permissions.includes(permission)
+  ) {
+    return { allowed: true, permission, source: 'grant', reason: 'explicit actor grant' };
+  }
+
+  // Keep missing and inaccessible assets indistinguishable at the public
+  // permission-check boundary. Allowed decisions still explain the winning
+  // rule, while a denial never confirms that a private asset exists.
+  return { allowed: false, permission, source: 'none', reason: 'permission denied' };
+}
+
+export class MemoryAssetPermissionDeniedError extends Error {
+  readonly code = 'MEMORY_ASSET_PERMISSION_DENIED';
+
+  constructor(
+    readonly assetId: string,
+    readonly actorId: string,
+    readonly permission: MemoryAssetPermission
+  ) {
+    super(`Permission denied: actor ${actorId} cannot ${permission} memory asset ${assetId}`);
+    this.name = 'MemoryAssetPermissionDeniedError';
+  }
+}

--- a/src/core/operations/memory-asset-repository.ts
+++ b/src/core/operations/memory-asset-repository.ts
@@ -1,0 +1,320 @@
+import { randomUUID } from 'node:crypto';
+
+import {
+  sqliteAll,
+  sqliteGet,
+  sqliteRun,
+  toDateFromSQLite,
+  type SQLiteDatabase
+} from '../sqlite-wrapper.js';
+import {
+  CreateMemoryAssetInputSchema,
+  MemoryAssetBindingSchema,
+  MemoryAssetGrantSchema,
+  MemoryAssetPermissionSchema,
+  MemoryAssetSchema,
+  SetMemoryAssetBindingInputSchema,
+  SetMemoryAssetGrantInputSchema,
+  UpdateMemoryAssetInputSchema,
+  type MemoryAsset,
+  type MemoryAssetBinding,
+  type MemoryAssetGrant,
+  type MemoryAssetPermission,
+  type MemoryAssetStatus,
+  type MemoryAssetType,
+  type MemoryAssetVisibility
+} from './memory-asset-permissions.js';
+
+interface MemoryAssetRow {
+  asset_id: string;
+  project_hash: string;
+  asset_type: MemoryAssetType;
+  title: string;
+  owner_actor_id: string;
+  version: number;
+  status: MemoryAssetStatus;
+  visibility: MemoryAssetVisibility;
+  source_refs_json: string;
+  metadata_json: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface MemoryAssetBindingRow {
+  project_hash: string;
+  asset_id: string;
+  actor_id: string;
+  injection_mode: MemoryAssetBinding['injectionMode'];
+  priority: number;
+  enabled: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface MemoryAssetGrantRow {
+  project_hash: string;
+  asset_id: string;
+  actor_id: string;
+  permissions_json: string;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
+function projectHashToStorage(projectHash: string | undefined): string {
+  return projectHash ?? '';
+}
+
+function projectHashFromStorage(projectHash: string): string | undefined {
+  return projectHash.length > 0 ? projectHash : undefined;
+}
+
+function parseStringArray(value: string): string[] {
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function parseRecord(value: string | null): Record<string, unknown> | undefined {
+  if (!value) return undefined;
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function rowToAsset(row: MemoryAssetRow): MemoryAsset {
+  return MemoryAssetSchema.parse({
+    assetId: row.asset_id,
+    projectHash: projectHashFromStorage(row.project_hash),
+    assetType: row.asset_type,
+    title: row.title,
+    ownerActorId: row.owner_actor_id,
+    version: Number(row.version),
+    status: row.status,
+    visibility: row.visibility,
+    sourceRefs: parseStringArray(row.source_refs_json),
+    metadata: parseRecord(row.metadata_json),
+    createdAt: toDateFromSQLite(row.created_at),
+    updatedAt: toDateFromSQLite(row.updated_at)
+  });
+}
+
+function rowToBinding(row: MemoryAssetBindingRow): MemoryAssetBinding {
+  return MemoryAssetBindingSchema.parse({
+    projectHash: projectHashFromStorage(row.project_hash),
+    assetId: row.asset_id,
+    actorId: row.actor_id,
+    injectionMode: row.injection_mode,
+    priority: Number(row.priority),
+    enabled: Boolean(row.enabled),
+    createdAt: toDateFromSQLite(row.created_at),
+    updatedAt: toDateFromSQLite(row.updated_at)
+  });
+}
+
+function rowToGrant(row: MemoryAssetGrantRow): MemoryAssetGrant {
+  const permissions = parseStringArray(row.permissions_json)
+    .map((permission) => MemoryAssetPermissionSchema.safeParse(permission))
+    .filter((result) => result.success)
+    .map((result) => result.data);
+  return MemoryAssetGrantSchema.parse({
+    projectHash: projectHashFromStorage(row.project_hash),
+    assetId: row.asset_id,
+    actorId: row.actor_id,
+    permissions,
+    createdBy: row.created_by,
+    createdAt: toDateFromSQLite(row.created_at),
+    updatedAt: toDateFromSQLite(row.updated_at)
+  });
+}
+
+export interface ListMemoryAssetsInput {
+  projectHash?: string;
+  assetType?: MemoryAssetType;
+  status?: MemoryAssetStatus;
+  limit?: number;
+  offset?: number;
+}
+
+export class MemoryAssetRepository {
+  constructor(private readonly db: SQLiteDatabase) {}
+
+  create(input: unknown): MemoryAsset {
+    const parsed = CreateMemoryAssetInputSchema.parse(input);
+    const assetId = parsed.assetId ?? randomUUID();
+    const now = new Date().toISOString();
+    sqliteRun(
+      this.db,
+      `INSERT INTO memory_assets (
+        asset_id, project_hash, asset_type, title, owner_actor_id, version,
+        status, visibility, source_refs_json, metadata_json, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?)`,
+      [
+        assetId,
+        projectHashToStorage(parsed.projectHash),
+        parsed.assetType,
+        parsed.title,
+        parsed.ownerActorId,
+        parsed.status,
+        parsed.visibility,
+        JSON.stringify(parsed.sourceRefs),
+        parsed.metadata ? JSON.stringify(parsed.metadata) : null,
+        now,
+        now
+      ]
+    );
+    return this.require(assetId, parsed.projectHash);
+  }
+
+  get(assetId: string, projectHash?: string): MemoryAsset | null {
+    const row = sqliteGet<MemoryAssetRow>(
+      this.db,
+      `SELECT * FROM memory_assets WHERE asset_id = ? AND project_hash = ?`,
+      [assetId.trim(), projectHashToStorage(projectHash)]
+    );
+    return row ? rowToAsset(row) : null;
+  }
+
+  require(assetId: string, projectHash?: string): MemoryAsset {
+    const asset = this.get(assetId, projectHash);
+    if (!asset) throw new Error(`Memory asset not found: ${assetId}`);
+    return asset;
+  }
+
+  list(input: ListMemoryAssetsInput): MemoryAsset[] {
+    const clauses = ['project_hash = ?'];
+    const params: unknown[] = [projectHashToStorage(input.projectHash)];
+    if (input.assetType) {
+      clauses.push('asset_type = ?');
+      params.push(input.assetType);
+    }
+    if (input.status) {
+      clauses.push('status = ?');
+      params.push(input.status);
+    }
+    params.push(
+      Math.min(500, Math.max(1, input.limit ?? 100)),
+      Math.max(0, Math.floor(input.offset ?? 0))
+    );
+    return sqliteAll<MemoryAssetRow>(
+      this.db,
+      `SELECT * FROM memory_assets
+       WHERE ${clauses.join(' AND ')}
+       ORDER BY updated_at DESC, asset_id ASC
+       LIMIT ? OFFSET ?`,
+      params
+    ).map(rowToAsset);
+  }
+
+  update(input: unknown): MemoryAsset {
+    const parsed = UpdateMemoryAssetInputSchema.parse(input);
+    const before = this.require(parsed.assetId, parsed.projectHash);
+    const assignments: string[] = [];
+    const params: unknown[] = [];
+    const set = (column: string, value: unknown) => {
+      assignments.push(`${column} = ?`);
+      params.push(value);
+    };
+    if (parsed.title !== undefined) set('title', parsed.title);
+    if (parsed.status !== undefined) set('status', parsed.status);
+    if (parsed.visibility !== undefined) set('visibility', parsed.visibility);
+    if (parsed.sourceRefs !== undefined) set('source_refs_json', JSON.stringify(parsed.sourceRefs));
+    if (parsed.metadata !== undefined) set('metadata_json', JSON.stringify(parsed.metadata));
+    assignments.push('version = version + 1', 'updated_at = ?');
+    params.push(new Date().toISOString(), parsed.assetId, projectHashToStorage(parsed.projectHash));
+
+    let where = 'asset_id = ? AND project_hash = ?';
+    if (parsed.expectedVersion !== undefined) {
+      where += ' AND version = ?';
+      params.push(parsed.expectedVersion);
+    }
+    const result = sqliteRun(this.db, `UPDATE memory_assets SET ${assignments.join(', ')} WHERE ${where}`, params);
+    if (result.changes !== 1) {
+      throw new Error(`Memory asset version conflict: expected ${parsed.expectedVersion}, current ${before.version}`);
+    }
+    return this.require(parsed.assetId, parsed.projectHash);
+  }
+
+  getBinding(assetId: string, actorId: string, projectHash?: string): MemoryAssetBinding | null {
+    const row = sqliteGet<MemoryAssetBindingRow>(
+      this.db,
+      `SELECT * FROM memory_asset_bindings WHERE asset_id = ? AND actor_id = ? AND project_hash = ?`,
+      [assetId.trim(), actorId.trim(), projectHashToStorage(projectHash)]
+    );
+    return row ? rowToBinding(row) : null;
+  }
+
+  setBinding(input: unknown): MemoryAssetBinding {
+    const parsed = SetMemoryAssetBindingInputSchema.parse(input);
+    const now = new Date().toISOString();
+    sqliteRun(
+      this.db,
+      `INSERT INTO memory_asset_bindings (
+        project_hash, asset_id, actor_id, injection_mode, priority, enabled, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(project_hash, asset_id, actor_id) DO UPDATE SET
+        injection_mode = excluded.injection_mode,
+        priority = excluded.priority,
+        enabled = excluded.enabled,
+        updated_at = excluded.updated_at`,
+      [
+        projectHashToStorage(parsed.projectHash),
+        parsed.assetId,
+        parsed.actorId,
+        parsed.injectionMode,
+        parsed.priority,
+        parsed.enabled ? 1 : 0,
+        now,
+        now
+      ]
+    );
+    const binding = this.getBinding(parsed.assetId, parsed.actorId, parsed.projectHash);
+    if (!binding) throw new Error('Memory asset binding write failed');
+    return binding;
+  }
+
+  getGrant(assetId: string, actorId: string, projectHash?: string): MemoryAssetGrant | null {
+    const row = sqliteGet<MemoryAssetGrantRow>(
+      this.db,
+      `SELECT * FROM memory_asset_grants WHERE asset_id = ? AND actor_id = ? AND project_hash = ?`,
+      [assetId.trim(), actorId.trim(), projectHashToStorage(projectHash)]
+    );
+    return row ? rowToGrant(row) : null;
+  }
+
+  setGrant(input: unknown): MemoryAssetGrant {
+    const parsed = SetMemoryAssetGrantInputSchema.parse(input);
+    const permissions = Array.from(new Set<MemoryAssetPermission>(parsed.permissions)).sort();
+    const now = new Date().toISOString();
+    sqliteRun(
+      this.db,
+      `INSERT INTO memory_asset_grants (
+        project_hash, asset_id, actor_id, permissions_json, created_by, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(project_hash, asset_id, actor_id) DO UPDATE SET
+        permissions_json = excluded.permissions_json,
+        created_by = excluded.created_by,
+        updated_at = excluded.updated_at`,
+      [
+        projectHashToStorage(parsed.projectHash),
+        parsed.assetId,
+        parsed.actorId,
+        JSON.stringify(permissions),
+        parsed.createdBy,
+        now,
+        now
+      ]
+    );
+    const grant = this.getGrant(parsed.assetId, parsed.actorId, parsed.projectHash);
+    if (!grant) throw new Error('Memory asset grant write failed');
+    return grant;
+  }
+}

--- a/src/core/operations/shared-canonical-memory-asset-read-service.ts
+++ b/src/core/operations/shared-canonical-memory-asset-read-service.ts
@@ -1,0 +1,82 @@
+import { z } from 'zod';
+
+import type { SQLiteDatabase } from '../sqlite-wrapper.js';
+import type { CoreMemoryBlock, MemoryLesson } from '../types.js';
+import {
+  canonicalMemoryAssetId,
+  isCanonicalMemoryAssetRegistration,
+  type CanonicalMemoryAssetType
+} from './memory-asset-catalog-service.js';
+import { CoreMemoryBlockRepository } from './core-memory-block-repository.js';
+import { LessonRepository } from './lesson-repository.js';
+import { MemoryAssetPermissionService } from './memory-asset-permission-service.js';
+import { MemoryAssetRepository } from './memory-asset-repository.js';
+import type { MemoryAsset } from './memory-asset-permissions.js';
+
+const InputSchema = z.object({
+  projectHash: z.string().trim().min(1).max(240),
+  actorId: z.string().trim().min(1).max(240),
+  canonicalType: z.enum(['lesson', 'core_memory_block']),
+  canonicalId: z.string().trim().min(1).max(240)
+});
+
+export interface SharedCanonicalMemoryAsset {
+  asset: MemoryAsset;
+  canonicalType: CanonicalMemoryAssetType;
+  canonicalId: string;
+  value: MemoryLesson | CoreMemoryBlock;
+}
+
+/**
+ * Validates a source project's shared canonical asset without applying the
+ * migration-oriented legacy/registered fallback. Cross-project reads are
+ * always strict: the registry must be valid, active, and explicitly shared.
+ */
+export class SharedCanonicalMemoryAssetReadService {
+  private readonly assets: MemoryAssetRepository;
+  private readonly permissions: MemoryAssetPermissionService;
+  private readonly lessons: LessonRepository;
+  private readonly blocks: CoreMemoryBlockRepository;
+
+  constructor(db: SQLiteDatabase) {
+    this.assets = new MemoryAssetRepository(db);
+    this.permissions = new MemoryAssetPermissionService(db);
+    this.lessons = new LessonRepository(db);
+    this.blocks = new CoreMemoryBlockRepository(db);
+  }
+
+  async get(input: unknown): Promise<SharedCanonicalMemoryAsset | null> {
+    const parsed = InputSchema.parse(input);
+    const assetId = canonicalMemoryAssetId(parsed.canonicalType, parsed.canonicalId);
+    const asset = this.assets.get(assetId, parsed.projectHash);
+    if (!asset
+      || asset.status !== 'active'
+      || asset.visibility !== 'shared'
+      || !isCanonicalMemoryAssetRegistration(asset, parsed.canonicalType, parsed.canonicalId)) {
+      return null;
+    }
+
+    const decision = this.permissions.check({
+      projectHash: parsed.projectHash,
+      assetId,
+      requesterActorId: parsed.actorId,
+      permission: 'read'
+    });
+    if (!decision.decision.allowed) return null;
+
+    const value = await this.loadCanonicalValue(parsed.projectHash, parsed.canonicalType, parsed.canonicalId);
+    return value ? { asset, canonicalType: parsed.canonicalType, canonicalId: parsed.canonicalId, value } : null;
+  }
+
+  private async loadCanonicalValue(
+    projectHash: string,
+    canonicalType: CanonicalMemoryAssetType,
+    canonicalId: string
+  ): Promise<MemoryLesson | CoreMemoryBlock | null> {
+    if (canonicalType === 'lesson') {
+      const lesson = this.lessons.get(canonicalId);
+      return lesson?.projectHash === projectHash ? lesson : null;
+    }
+    return this.blocks.get({ projectHash, blockKey: canonicalId as 'project' | 'user' });
+  }
+}

--- a/src/core/shared-event-store.ts
+++ b/src/core/shared-event-store.ts
@@ -93,6 +93,21 @@ export class SharedEventStore {
       )
     `);
 
+    // Identity links change the set of projects visible to a shared principal.
+    // Keep their history beside the mapping so link/relink/unlink can be
+    // committed atomically even though each project has a separate database.
+    await dbRun(this.db, `
+      CREATE TABLE IF NOT EXISTS shared_actor_identity_audit (
+        audit_id VARCHAR PRIMARY KEY,
+        operation VARCHAR NOT NULL,
+        project_hash VARCHAR NOT NULL,
+        actor_id VARCHAR NOT NULL,
+        before_shared_principal_id VARCHAR,
+        after_shared_principal_id VARCHAR,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+
     // Indexes for troubleshooting
     await dbRun(this.db, `
       CREATE INDEX IF NOT EXISTS idx_shared_ts_confidence
@@ -109,6 +124,10 @@ export class SharedEventStore {
     await dbRun(this.db, `
       CREATE INDEX IF NOT EXISTS idx_shared_actor_identities_principal
       ON shared_actor_identities(shared_principal_id, project_hash)
+    `);
+    await dbRun(this.db, `
+      CREATE INDEX IF NOT EXISTS idx_shared_actor_identity_audit_actor
+      ON shared_actor_identity_audit(project_hash, actor_id, created_at DESC)
     `);
 
     this.initialized = true;

--- a/src/core/shared-event-store.ts
+++ b/src/core/shared-event-store.ts
@@ -78,6 +78,21 @@ export class SharedEventStore {
       )
     `);
 
+    // A shared principal is intentionally an explicit link between an actor in
+    // one project and the same actor in another project.  It is not an
+    // authentication provider: callers still have to supply the local actor
+    // id, and the adapter uses this table only to narrow shared reads.
+    await dbRun(this.db, `
+      CREATE TABLE IF NOT EXISTS shared_actor_identities (
+        project_hash VARCHAR NOT NULL,
+        actor_id VARCHAR NOT NULL,
+        shared_principal_id VARCHAR NOT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY(project_hash, actor_id)
+      )
+    `);
+
     // Indexes for troubleshooting
     await dbRun(this.db, `
       CREATE INDEX IF NOT EXISTS idx_shared_ts_confidence
@@ -90,6 +105,10 @@ export class SharedEventStore {
     await dbRun(this.db, `
       CREATE INDEX IF NOT EXISTS idx_shared_ts_source
       ON shared_troubleshooting(source_project_hash)
+    `);
+    await dbRun(this.db, `
+      CREATE INDEX IF NOT EXISTS idx_shared_actor_identities_principal
+      ON shared_actor_identities(shared_principal_id, project_hash)
     `);
 
     this.initialized = true;

--- a/src/core/shared-store.ts
+++ b/src/core/shared-store.ts
@@ -11,6 +11,14 @@ import type {
 } from './types.js';
 import { SharedEventStore } from './shared-event-store.js';
 
+export interface SharedActorIdentity {
+  projectHash: string;
+  actorId: string;
+  sharedPrincipalId: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
 export class SharedStore {
   constructor(private sharedEventStore: SharedEventStore) {}
 
@@ -85,6 +93,90 @@ export class SharedStore {
     );
 
     return rows.map(this.rowToEntry);
+  }
+
+  /**
+   * Link a project-local actor to an explicit shared principal.  A local actor
+   * can have one principal at a time; relinking atomically revokes the old
+   * principal's access to that project's shared entries.
+   */
+  async linkActorIdentity(input: {
+    projectHash: string;
+    actorId: string;
+    sharedPrincipalId: string;
+  }): Promise<SharedActorIdentity> {
+    await dbRun(
+      this.db,
+      `INSERT INTO shared_actor_identities (
+        project_hash, actor_id, shared_principal_id, created_at, updated_at
+      ) VALUES (?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+      ON CONFLICT(project_hash, actor_id)
+      DO UPDATE SET
+        shared_principal_id = excluded.shared_principal_id,
+        updated_at = CURRENT_TIMESTAMP`,
+      [input.projectHash, input.actorId, input.sharedPrincipalId]
+    );
+    return this.requireActorIdentity(input.projectHash, input.actorId);
+  }
+
+  async getActorIdentity(projectHash: string, actorId: string): Promise<SharedActorIdentity | null> {
+    const rows = await dbAll<Record<string, unknown>>(
+      this.db,
+      `SELECT * FROM shared_actor_identities WHERE project_hash = ? AND actor_id = ?`,
+      [projectHash, actorId]
+    );
+    return rows[0] ? this.rowToActorIdentity(rows[0]) : null;
+  }
+
+  async unlinkActorIdentity(projectHash: string, actorId: string): Promise<boolean> {
+    const existing = await this.getActorIdentity(projectHash, actorId);
+    if (!existing) return false;
+    await dbRun(
+      this.db,
+      `DELETE FROM shared_actor_identities WHERE project_hash = ? AND actor_id = ?`,
+      [projectHash, actorId]
+    );
+    return true;
+  }
+
+  async listProjectHashesForPrincipal(sharedPrincipalId: string): Promise<string[]> {
+    const rows = await dbAll<{ project_hash: string }>(
+      this.db,
+      `SELECT DISTINCT project_hash FROM shared_actor_identities
+       WHERE shared_principal_id = ? ORDER BY project_hash ASC`,
+      [sharedPrincipalId]
+    );
+    return rows.map((row) => row.project_hash);
+  }
+
+  /**
+   * Actor-scoped shared search.  Unlike the legacy search() API, this does
+   * not reveal entries from projects that the caller's explicit principal has
+   * not linked.
+   */
+  async searchForPrincipal(
+    sharedPrincipalId: string,
+    query: string,
+    options?: { topK?: number; minConfidence?: number }
+  ): Promise<{ sourceProjectHashes: string[]; entries: SharedTroubleshootingEntry[] }> {
+    const sourceProjectHashes = await this.listProjectHashesForPrincipal(sharedPrincipalId);
+    if (sourceProjectHashes.length === 0) return { sourceProjectHashes, entries: [] };
+
+    const topK = options?.topK || 5;
+    const minConfidence = options?.minConfidence || 0.5;
+    const searchPattern = `%${query}%`;
+    const placeholders = sourceProjectHashes.map(() => '?').join(', ');
+    const rows = await dbAll<Record<string, unknown>>(
+      this.db,
+      `SELECT * FROM shared_troubleshooting
+       WHERE source_project_hash IN (${placeholders})
+       AND (title LIKE ? OR root_cause LIKE ? OR solution LIKE ?)
+       AND confidence >= ?
+       ORDER BY confidence DESC, usage_count DESC
+       LIMIT ?`,
+      [...sourceProjectHashes, searchPattern, searchPattern, searchPattern, minConfidence, topK]
+    );
+    return { sourceProjectHashes, entries: rows.map(this.rowToEntry) };
   }
 
   /**
@@ -278,6 +370,22 @@ export class SharedStore {
       lastUsedAt: row.last_used_at ? toDate(row.last_used_at) : undefined,
       promotedAt: toDate(row.promoted_at),
       createdAt: toDate(row.created_at)
+    };
+  }
+
+  private async requireActorIdentity(projectHash: string, actorId: string): Promise<SharedActorIdentity> {
+    const identity = await this.getActorIdentity(projectHash, actorId);
+    if (!identity) throw new Error('Shared actor identity was not persisted');
+    return identity;
+  }
+
+  private rowToActorIdentity(row: Record<string, unknown>): SharedActorIdentity {
+    return {
+      projectHash: String(row.project_hash),
+      actorId: String(row.actor_id),
+      sharedPrincipalId: String(row.shared_principal_id),
+      createdAt: toDate(row.created_at),
+      updatedAt: toDate(row.updated_at)
     };
   }
 }

--- a/src/core/shared-store.ts
+++ b/src/core/shared-store.ts
@@ -105,18 +105,39 @@ export class SharedStore {
     actorId: string;
     sharedPrincipalId: string;
   }): Promise<SharedActorIdentity> {
-    await dbRun(
-      this.db,
-      `INSERT INTO shared_actor_identities (
-        project_hash, actor_id, shared_principal_id, created_at, updated_at
-      ) VALUES (?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
-      ON CONFLICT(project_hash, actor_id)
-      DO UPDATE SET
-        shared_principal_id = excluded.shared_principal_id,
-        updated_at = CURRENT_TIMESTAMP`,
-      [input.projectHash, input.actorId, input.sharedPrincipalId]
-    );
-    return this.requireActorIdentity(input.projectHash, input.actorId);
+    const transaction = this.db.transaction(() => {
+      const existing = this.db.prepare(
+        `SELECT * FROM shared_actor_identities WHERE project_hash = ? AND actor_id = ?`
+      ).get(input.projectHash, input.actorId) as Record<string, unknown> | undefined;
+      this.db.prepare(
+        `INSERT INTO shared_actor_identities (
+          project_hash, actor_id, shared_principal_id, created_at, updated_at
+        ) VALUES (?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+        ON CONFLICT(project_hash, actor_id)
+        DO UPDATE SET
+          shared_principal_id = excluded.shared_principal_id,
+          updated_at = CURRENT_TIMESTAMP`
+      ).run(input.projectHash, input.actorId, input.sharedPrincipalId);
+      this.db.prepare(
+        `INSERT INTO shared_actor_identity_audit (
+          audit_id, operation, project_hash, actor_id,
+          before_shared_principal_id, after_shared_principal_id, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`
+      ).run(
+        randomUUID(),
+        existing && String(existing.shared_principal_id) !== input.sharedPrincipalId ? 'relink' : 'link',
+        input.projectHash,
+        input.actorId,
+        existing ? String(existing.shared_principal_id) : null,
+        input.sharedPrincipalId
+      );
+      const saved = this.db.prepare(
+        `SELECT * FROM shared_actor_identities WHERE project_hash = ? AND actor_id = ?`
+      ).get(input.projectHash, input.actorId) as Record<string, unknown> | undefined;
+      if (!saved) throw new Error('Shared actor identity was not saved');
+      return this.rowToActorIdentity(saved);
+    });
+    return transaction();
   }
 
   async getActorIdentity(projectHash: string, actorId: string): Promise<SharedActorIdentity | null> {
@@ -129,14 +150,23 @@ export class SharedStore {
   }
 
   async unlinkActorIdentity(projectHash: string, actorId: string): Promise<boolean> {
-    const existing = await this.getActorIdentity(projectHash, actorId);
-    if (!existing) return false;
-    await dbRun(
-      this.db,
-      `DELETE FROM shared_actor_identities WHERE project_hash = ? AND actor_id = ?`,
-      [projectHash, actorId]
-    );
-    return true;
+    const transaction = this.db.transaction(() => {
+      const existing = this.db.prepare(
+        `SELECT * FROM shared_actor_identities WHERE project_hash = ? AND actor_id = ?`
+      ).get(projectHash, actorId) as Record<string, unknown> | undefined;
+      if (!existing) return false;
+      this.db.prepare(
+        `DELETE FROM shared_actor_identities WHERE project_hash = ? AND actor_id = ?`
+      ).run(projectHash, actorId);
+      this.db.prepare(
+        `INSERT INTO shared_actor_identity_audit (
+          audit_id, operation, project_hash, actor_id,
+          before_shared_principal_id, after_shared_principal_id, created_at
+        ) VALUES (?, 'unlink', ?, ?, ?, NULL, CURRENT_TIMESTAMP)`
+      ).run(randomUUID(), projectHash, actorId, String(existing.shared_principal_id));
+      return true;
+    });
+    return transaction();
   }
 
   async listProjectHashesForPrincipal(sharedPrincipalId: string): Promise<string[]> {
@@ -162,8 +192,8 @@ export class SharedStore {
     const sourceProjectHashes = await this.listProjectHashesForPrincipal(sharedPrincipalId);
     if (sourceProjectHashes.length === 0) return { sourceProjectHashes, entries: [] };
 
-    const topK = options?.topK || 5;
-    const minConfidence = options?.minConfidence || 0.5;
+    const topK = options?.topK ?? 5;
+    const minConfidence = options?.minConfidence ?? 0.5;
     const searchPattern = `%${query}%`;
     const placeholders = sourceProjectHashes.map(() => '?').join(', ');
     const rows = await dbAll<Record<string, unknown>>(
@@ -371,12 +401,6 @@ export class SharedStore {
       promotedAt: toDate(row.promoted_at),
       createdAt: toDate(row.created_at)
     };
-  }
-
-  private async requireActorIdentity(projectHash: string, actorId: string): Promise<SharedActorIdentity> {
-    const identity = await this.getActorIdentity(projectHash, actorId);
-    if (!identity) throw new Error('Shared actor identity was not persisted');
-    return identity;
   }
 
   private rowToActorIdentity(row: Record<string, unknown>): SharedActorIdentity {

--- a/src/core/sqlite-event-store.ts
+++ b/src/core/sqlite-event-store.ts
@@ -802,6 +802,54 @@ export class SQLiteEventStore {
         UNIQUE(project_hash, observer_actor_id, observed_actor_id, level, content_hash, source_hash)
       );
 
+      -- Memory Assets: project-scoped registry and minimal actor permissions.
+      -- Asset content remains in its canonical subsystem; this table owns only
+      -- lifecycle, provenance, and access-control metadata.
+      CREATE TABLE IF NOT EXISTS memory_assets (
+        asset_id TEXT NOT NULL,
+        project_hash TEXT NOT NULL DEFAULT '',
+        asset_type TEXT NOT NULL,
+        title TEXT NOT NULL,
+        owner_actor_id TEXT NOT NULL,
+        version INTEGER NOT NULL DEFAULT 1,
+        status TEXT NOT NULL DEFAULT 'active',
+        visibility TEXT NOT NULL DEFAULT 'private',
+        source_refs_json TEXT NOT NULL DEFAULT '[]',
+        metadata_json TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY(project_hash, asset_id)
+      );
+
+      -- An enabled binding makes a private asset readable/injectable for one
+      -- actor. It does not grant write, bind, or delegation authority.
+      CREATE TABLE IF NOT EXISTS memory_asset_bindings (
+        project_hash TEXT NOT NULL DEFAULT '',
+        asset_id TEXT NOT NULL,
+        actor_id TEXT NOT NULL,
+        injection_mode TEXT NOT NULL DEFAULT 'reference',
+        priority INTEGER NOT NULL DEFAULT 0,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY(project_hash, asset_id, actor_id),
+        FOREIGN KEY(project_hash, asset_id) REFERENCES memory_assets(project_hash, asset_id) ON DELETE CASCADE
+      );
+
+      -- Explicit grants are full replacements per asset/actor. An empty JSON
+      -- permission list is therefore an auditable revocation tombstone.
+      CREATE TABLE IF NOT EXISTS memory_asset_grants (
+        project_hash TEXT NOT NULL DEFAULT '',
+        asset_id TEXT NOT NULL,
+        actor_id TEXT NOT NULL,
+        permissions_json TEXT NOT NULL DEFAULT '[]',
+        created_by TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY(project_hash, asset_id, actor_id),
+        FOREIGN KEY(project_hash, asset_id) REFERENCES memory_assets(project_hash, asset_id) ON DELETE CASCADE
+      );
+
       -- Perspective Memory: FTS5 index for observation content queries.
       -- Use an external-content FTS table so the searchable projection stores the index,
       -- not a second raw copy of private observation text.
@@ -907,6 +955,10 @@ export class SQLiteEventStore {
       CREATE INDEX IF NOT EXISTS idx_perspective_observations_session ON perspective_observations(project_hash, session_id, level, updated_at DESC);
       CREATE INDEX IF NOT EXISTS idx_perspective_observations_source_hash ON perspective_observations(project_hash, source_hash);
       CREATE INDEX IF NOT EXISTS idx_perspective_observations_deleted ON perspective_observations(deleted_at);
+      CREATE INDEX IF NOT EXISTS idx_memory_assets_project_status ON memory_assets(project_hash, status, updated_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_memory_assets_owner ON memory_assets(project_hash, owner_actor_id, updated_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_memory_asset_bindings_actor ON memory_asset_bindings(project_hash, actor_id, enabled, priority DESC);
+      CREATE INDEX IF NOT EXISTS idx_memory_asset_grants_actor ON memory_asset_grants(project_hash, actor_id, updated_at DESC);
       CREATE INDEX IF NOT EXISTS idx_memory_governance_audit_project_operation ON memory_governance_audit(project_hash, operation, created_at DESC);
       CREATE INDEX IF NOT EXISTS idx_memory_governance_audit_target ON memory_governance_audit(target_type, target_id, created_at DESC);
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -261,7 +261,8 @@ export type UpsertMemoryLessonInput = z.input<typeof UpsertMemoryLessonInputSche
 export const ListMemoryLessonsInputSchema = z.object({
   projectHash: MemoryLessonNonEmptyStringSchema.optional(),
   skillCandidate: z.boolean().optional(),
-  limit: z.number().int().positive().max(500).default(50)
+  limit: z.number().int().positive().max(500).default(50),
+  offset: z.number().int().nonnegative().default(0)
 });
 export type ListMemoryLessonsInput = z.input<typeof ListMemoryLessonsInputSchema>;
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -659,6 +659,7 @@ export type AppendResult =
 export interface SessionStartInput {
   session_id: string;
   cwd: string;
+  actor_id?: string;
 }
 
 export interface SessionStartOutput {
@@ -671,6 +672,7 @@ export interface SessionStartOutput {
 export interface UserPromptSubmitInput {
   session_id: string;
   prompt: string;
+  actor_id?: string;
 }
 
 export interface UserPromptSubmitOutput {

--- a/src/extensions/mcp/handlers.ts
+++ b/src/extensions/mcp/handlers.ts
@@ -45,6 +45,7 @@ import {
   MemoryAssetCatalogService,
   MemoryAssetPermissionSchema,
   MemoryAssetPermissionService,
+  SharedCanonicalMemoryAssetReadService,
   MemoryAssetStatusSchema,
   MemoryAssetTypeSchema,
   MemoryAssetVisibilitySchema,
@@ -318,7 +319,8 @@ const SHARED_MEMORY_ACTOR_TOOL_NAMES = new Set([
   'mem-shared-actor-link',
   'mem-shared-actor-status',
   'mem-shared-actor-unlink',
-  'mem-shared-search'
+  'mem-shared-search',
+  'mem-shared-asset-get'
 ]);
 
 interface MemoryOperationContext {
@@ -369,6 +371,42 @@ async function handleSharedMemoryActorTool(name: string, args: Record<string, un
           count: result.entries.length,
           entries: result.entries.map(formatSharedTroubleshootingEntry)
         });
+      }
+      case 'mem-shared-asset-get': {
+        const sourceProjectPath = requiredOperationString(args.sourceProjectPath, 'sourceProjectPath');
+        if (!isAbsoluteProjectPath(sourceProjectPath)) {
+          throw new Error('sourceProjectPath must be an absolute project path');
+        }
+        const sourceActorId = requiredOperationString(args.sourceActorId, 'sourceActorId');
+        const sourceProjectHash = hashProjectPath(sourceProjectPath);
+        if (!await adapter.sharesPrincipalWith({
+          projectHash,
+          actorId: requesterActorId,
+          sourceProjectHash,
+          sourceActorId
+        })) {
+          return jsonResult({ operation: name, projectHash, found: false });
+        }
+
+        const sourceDbPath = path.join(getProjectStoragePath(sourceProjectPath), 'events.sqlite');
+        if (!existsSync(sourceDbPath)) return jsonResult({ operation: name, projectHash, found: false });
+        const sourceDb = createSQLiteDatabase(sourceDbPath, { readonly: true, walMode: false });
+        try {
+          const asset = await new SharedCanonicalMemoryAssetReadService(sourceDb).get({
+            projectHash: sourceProjectHash,
+            actorId: sourceActorId,
+            canonicalType: requiredOperationString(args.canonicalType, 'canonicalType'),
+            canonicalId: requiredOperationString(args.canonicalId, 'canonicalId')
+          });
+          return jsonResult({
+            operation: name,
+            projectHash,
+            found: Boolean(asset),
+            asset: asset ? formatSharedCanonicalMemoryAsset(asset) : undefined
+          });
+        } finally {
+          sqliteClose(sourceDb);
+        }
       }
       default:
         throw new Error(`Unknown shared memory actor tool: ${name}`);
@@ -422,6 +460,23 @@ function formatSharedTroubleshootingEntry(entry: {
     topics: compactStringArray(entry.topics, 20, 120),
     technologies: compactStringArray(entry.technologies, 20, 120),
     confidence: entry.confidence
+  };
+}
+
+function formatSharedCanonicalMemoryAsset(asset: {
+  asset: MemoryAsset;
+  canonicalType: 'lesson' | 'core_memory_block';
+  canonicalId: string;
+  value: MemoryLesson | CoreMemoryBlock;
+}): Record<string, unknown> {
+  const canonical = asset.canonicalType === 'lesson'
+    ? formatLesson(asset.value as MemoryLesson)
+    : formatCoreMemoryBlock(asset.value as CoreMemoryBlock);
+  return {
+    asset: formatMemoryAsset(asset.asset),
+    canonicalType: asset.canonicalType,
+    canonicalId: sanitizeOperationString(asset.canonicalId, 240),
+    canonical
   };
 }
 

--- a/src/extensions/mcp/handlers.ts
+++ b/src/extensions/mcp/handlers.ts
@@ -29,6 +29,7 @@ import {
   ActionRepository,
   ActorCardRepository,
   ActorRepository,
+  CanonicalMemoryAccessService,
   CheckpointRepository,
   CoreMemoryBlockRepository,
   FacetRepository,
@@ -601,18 +602,47 @@ function handleGraphQuery(context: MemoryOperationContext, args: Record<string, 
 
 async function handleLessonList(context: MemoryOperationContext, args: Record<string, unknown>): Promise<Record<string, unknown>> {
   const repository = new LessonRepository(context.db);
-  const lessons = await repository.list(omitUndefined({
+  const access = new CanonicalMemoryAccessService(context.db);
+  const requesterActorId = optionalRequesterActorIdArg(args);
+  access.requireRequester(requesterActorId);
+  const limit = numberArg(args.limit, 50, 1, 100);
+  const listInput = {
     projectHash: context.projectHash,
-    skillCandidate: typeof args.skillCandidate === 'boolean' ? args.skillCandidate : undefined,
-    limit: numberArg(args.limit, 50, 1, 100)
-  }));
+    skillCandidate: typeof args.skillCandidate === 'boolean' ? args.skillCandidate : undefined
+  };
   const minConfidence = typeof args.minConfidence === 'number' ? Math.min(1, Math.max(0, args.minConfidence)) : undefined;
-  const filtered = minConfidence === undefined
-    ? lessons
-    : lessons.filter((lesson) => Number(lesson.confidence ?? 0) >= minConfidence);
+  let filtered: MemoryLesson[];
+  if (access.mode === 'legacy') {
+    const lessons = await repository.list(omitUndefined({ ...listInput, limit }));
+    filtered = minConfidence === undefined
+      ? lessons
+      : lessons.filter((lesson) => Number(lesson.confidence ?? 0) >= minConfidence);
+  } else {
+    filtered = [];
+    const pageSize = Math.max(100, limit);
+    let offset = 0;
+    while (filtered.length < limit) {
+      const page = await repository.list(omitUndefined({ ...listInput, limit: pageSize, offset }));
+      for (const lesson of page) {
+        if (minConfidence !== undefined && Number(lesson.confidence ?? 0) < minConfidence) continue;
+        const decision = access.check({
+          projectHash: context.projectHash,
+          canonicalType: 'lesson',
+          canonicalId: lesson.lessonId,
+          requesterActorId,
+          permission: 'read'
+        });
+        if (decision.allowed) filtered.push(lesson);
+        if (filtered.length === limit) break;
+      }
+      if (page.length < pageSize) break;
+      offset += page.length;
+    }
+  }
   return {
     operation: 'mem-lesson-list',
     projectHash: context.projectHash,
+    permissionMode: access.mode,
     count: filtered.length,
     lessons: filtered.map((lesson) => ({
       lessonId: sanitizeOperationString(String(lesson.lessonId ?? ''), 120),
@@ -657,10 +687,32 @@ async function handleLessonCandidates(context: MemoryOperationContext, args: Rec
 }
 
 async function handleLessonSave(context: MemoryOperationContext, args: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const access = new CanonicalMemoryAccessService(context.db);
+  const requesterActorId = optionalRequesterActorIdArg(args);
+  access.requireRequester(requesterActorId);
+  const name = requiredOperationString(args.name, 'name');
+  const actor = requiredOperationString(args.actor, 'actor');
+  if (access.mode !== 'legacy') {
+    if (actor !== requesterActorId) {
+      throw new Error('actor must match requesterActorId when canonical memory permissions are enforced');
+    }
+    const existing = new LessonRepository(context.db).getByProjectAndName(context.projectHash, name);
+    if (existing) {
+      access.require({
+        projectHash: context.projectHash,
+        canonicalType: 'lesson',
+        canonicalId: existing.lessonId,
+        requesterActorId,
+        permission: 'write'
+      });
+    } else {
+      access.requireUnregisteredWrite(requesterActorId);
+    }
+  }
   const lesson = await new LessonService(context.db).saveCurated({
     projectHash: context.projectHash,
-    actor: requiredOperationString(args.actor, 'actor'),
-    name: requiredOperationString(args.name, 'name'),
+    actor,
+    name,
     trigger: requiredOperationString(args.trigger, 'trigger'),
     steps: requiredOperationStringArray(args.steps, 'steps', 100),
     confidence: typeof args.confidence === 'number' ? args.confidence : undefined,
@@ -672,6 +724,7 @@ async function handleLessonSave(context: MemoryOperationContext, args: Record<st
   return {
     operation: 'mem-lesson-save',
     projectHash: context.projectHash,
+    permissionMode: access.mode,
     lesson: formatLesson(lesson)
   };
 }
@@ -711,6 +764,10 @@ function requesterActorIdArg(args: Record<string, unknown>): string {
   // payloads are sanitized separately; mutating the id here can authorize a
   // different principal from the one supplied by the caller.
   return requiredOperationString(args.requesterActorId, 'requesterActorId');
+}
+
+function optionalRequesterActorIdArg(args: Record<string, unknown>): string | undefined {
+  return args.requesterActorId === undefined ? undefined : requesterActorIdArg(args);
 }
 
 function memoryAssetMetadataArg(value: unknown): Record<string, unknown> | undefined {
@@ -1033,6 +1090,9 @@ function coreMemoryBlockKeyArg(value: unknown): CoreMemoryBlockKey | undefined {
 
 async function handleCoreMemoryBlockGet(context: MemoryOperationContext, args: Record<string, unknown>): Promise<Record<string, unknown>> {
   const repository = new CoreMemoryBlockRepository(context.db);
+  const access = new CanonicalMemoryAccessService(context.db);
+  const requesterActorId = optionalRequesterActorIdArg(args);
+  access.requireRequester(requesterActorId);
   const blockKey = coreMemoryBlockKeyArg(args.blockKey);
   let blocks: CoreMemoryBlock[];
   if (blockKey) {
@@ -1041,27 +1101,55 @@ async function handleCoreMemoryBlockGet(context: MemoryOperationContext, args: R
   } else {
     blocks = await repository.listByProject(context.projectHash);
   }
+  const readable = access.mode === 'legacy'
+    ? blocks
+    : blocks.filter((block) => access.check({
+      projectHash: context.projectHash,
+      canonicalType: 'core_memory_block',
+      canonicalId: block.blockKey,
+      requesterActorId,
+      permission: 'read'
+    }).allowed);
   return {
     operation: 'mem-core-block-get',
     projectHash: context.projectHash,
-    blocks: blocks.map(formatCoreMemoryBlock)
+    permissionMode: access.mode,
+    blocks: readable.map(formatCoreMemoryBlock)
   };
 }
 
 async function handleCoreMemoryBlockUpdate(context: MemoryOperationContext, args: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const access = new CanonicalMemoryAccessService(context.db);
+  const requesterActorId = optionalRequesterActorIdArg(args);
+  access.requireRequester(requesterActorId);
+  const blockKey = coreMemoryBlockKeyArg(requiredOperationString(args.blockKey, 'blockKey'))!;
+  const actor = requiredOperationString(args.actor, 'actor');
+  if (access.mode !== 'legacy') {
+    if (actor !== requesterActorId) {
+      throw new Error('actor must match requesterActorId when canonical memory permissions are enforced');
+    }
+    access.require({
+      projectHash: context.projectHash,
+      canonicalType: 'core_memory_block',
+      canonicalId: blockKey,
+      requesterActorId,
+      permission: 'write'
+    });
+  }
   const repository = new CoreMemoryBlockRepository(context.db);
   const block = await repository.upsert({
     projectHash: context.projectHash,
-    blockKey: requiredOperationString(args.blockKey, 'blockKey'),
+    blockKey,
     // Empty content is the documented way to retire a stale block: the
     // session-start hook skips empty blocks, so this clears the injection.
     content: requiredPossiblyEmptyOperationString(args.content, 'content'),
     sourceEventIds: stringArrayOperationArg(args.sourceEventIds, 20),
-    updatedBy: sanitizeOperationString(requiredOperationString(args.actor, 'actor'), 120)
+    updatedBy: sanitizeOperationString(actor, 120)
   });
   return {
     operation: 'mem-core-block-update',
     projectHash: context.projectHash,
+    permissionMode: access.mode,
     block: formatCoreMemoryBlock(block)
   };
 }

--- a/src/extensions/mcp/handlers.ts
+++ b/src/extensions/mcp/handlers.ts
@@ -30,6 +30,8 @@ import {
   ActorCardRepository,
   ActorRepository,
   CanonicalMemoryAccessService,
+  CanonicalMemoryInjectionService,
+  resolveCanonicalMemoryPermissionMode,
   CheckpointRepository,
   CoreMemoryBlockRepository,
   FacetRepository,
@@ -57,6 +59,7 @@ import {
   type MemoryAssetGrant,
   type MemoryAssetCatalogSyncResult,
   type MemoryCheckpoint,
+  type CanonicalMemoryInjection,
   type MemoryFacetAssignment,
   type QueryEntityCandidate,
   type TemporalGraphExpandResult
@@ -1952,6 +1955,15 @@ async function handleMemContextPack(memoryService: MemoryService, args: Record<s
   const sessionLimit = numberArg(args.sessionLimit, 5, 1, 20);
   const sessionId = optionalString(args.sessionId);
   const projectPath = optionalString(args.projectPath);
+  const requesterActorId = optionalRequesterActorIdArg(args);
+  if (
+    projectPath
+    && path.isAbsolute(projectPath)
+    && resolveCanonicalMemoryPermissionMode() !== 'legacy'
+    && !requesterActorId
+  ) {
+    throw new Error('requesterActorId is required for canonical memory injection when permissions are enforced');
+  }
   const maxContextChars = contextPackMaxCharsArg(args);
   const compression = contextCompressionModeArg(args.compression, maxContextChars !== undefined);
   const retrievalMode = contextPackRetrievalModeArg(args.retrievalMode);
@@ -1985,7 +1997,7 @@ async function handleMemContextPack(memoryService: MemoryService, args: Record<s
 
   const search = await retrieveMcpMemories(memoryService, query, { topK: retrievalTopK, sessionId, retrievalMode });
   const recentEvents = await memoryService.getRecentEvents(recentLimit);
-  const curatedLessons = await loadCuratedLessons(projectPath);
+  const curatedLessons = await loadCuratedLessons(projectPath, requesterActorId);
 
   const timelineEvents = selectContextPackTimelineEvents(
     recentEvents,
@@ -2370,7 +2382,10 @@ interface ContextPackMemory {
   score: number;
 }
 
-async function loadCuratedLessons(projectPath: string | undefined): Promise<MemoryLesson[]> {
+async function loadCuratedLessons(
+  projectPath: string | undefined,
+  requesterActorId: string | undefined
+): Promise<CanonicalMemoryInjection<MemoryLesson>[]> {
   if (!projectPath || !path.isAbsolute(projectPath)) return [];
   const dbPath = path.join(getProjectStoragePath(projectPath), 'events.sqlite');
   if (!existsSync(dbPath)) return [];
@@ -2383,8 +2398,16 @@ async function loadCuratedLessons(projectPath: string | undefined): Promise<Memo
       ['memory_lessons']
     );
     if (!table) return [];
-    const lessons = await new LessonRepository(db).list({ projectHash: hashProjectPath(projectPath), limit: 20 });
-    return lessons.filter((lesson) => lesson.sourceClass === 'curated').slice(0, 3);
+    const projectHash = hashProjectPath(projectPath);
+    const lessons = await new LessonRepository(db).list({ projectHash, limit: 20 });
+    return new CanonicalMemoryInjectionService(db).select({
+      projectHash,
+      actorId: requesterActorId,
+      lane: 'context_pack',
+      candidates: lessons
+        .filter((lesson) => lesson.sourceClass === 'curated')
+        .map((lesson) => ({ canonicalType: 'lesson', canonicalId: lesson.lessonId, value: lesson }))
+    }).items.slice(0, 3);
   } catch {
     return [];
   } finally {
@@ -2625,13 +2648,18 @@ function appendRelevantMemories(
   }
 }
 
-function appendCuratedLessons(lines: string[], lessons: MemoryLesson[]): void {
+function appendCuratedLessons(lines: string[], lessons: CanonicalMemoryInjection<MemoryLesson>[]): void {
   if (lessons.length === 0) return;
   lines.push('### Curated Lessons', '');
-  for (const lesson of lessons.slice(0, 3)) {
+  for (const { value: lesson, injectionMode } of lessons.slice(0, 3)) {
     lines.push(`- [lesson:${sanitizeOperationString(lesson.lessonId, 120)}] ${sanitizeOperationString(lesson.name, 180)}`);
+    if (injectionMode === 'reference') {
+      lines.push('  - Reference only: use mem-lesson-list with the same projectPath for details.');
+      continue;
+    }
     lines.push(`  - Apply when: ${sanitizeOperationString(lesson.trigger, 240)}`);
-    for (const step of lesson.steps.slice(0, 5)) {
+    const stepLimit = injectionMode === 'summary' ? 2 : 5;
+    for (const step of lesson.steps.slice(0, stepLimit)) {
       lines.push(`  - ${sanitizeOperationString(step, 300)}`);
     }
   }

--- a/src/extensions/mcp/handlers.ts
+++ b/src/extensions/mcp/handlers.ts
@@ -332,17 +332,22 @@ interface MemoryOperationContext {
 async function handleSharedMemoryActorTool(name: string, args: Record<string, unknown>): Promise<ToolResult> {
   const projectHash = hashProjectPath(requiredProjectPath(args));
   const requesterActorId = requesterActorIdArg(args);
-  return withSharedMemoryActorAdapter(async (adapter) => {
-    switch (name) {
-      case 'mem-shared-actor-link': {
+  switch (name) {
+    case 'mem-shared-actor-link': {
+      const sharedPrincipalId = requiredOperationString(args.sharedPrincipalId, 'sharedPrincipalId');
+      const result = await withSharedMemoryActorAdapter(async (adapter) => {
         const identity = await adapter.link({
           projectHash,
           actorId: requesterActorId,
-          sharedPrincipalId: requiredOperationString(args.sharedPrincipalId, 'sharedPrincipalId')
+          sharedPrincipalId
         });
         return jsonResult({ operation: name, projectHash, identity: formatSharedActorIdentity(identity) });
-      }
-      case 'mem-shared-actor-status': {
+      }, { createIfMissing: true });
+      if (!result) throw new Error('Shared memory store could not be created');
+      return result;
+    }
+    case 'mem-shared-actor-status': {
+      const result = await withSharedMemoryActorAdapter(async (adapter) => {
         const identity = await adapter.status({ projectHash, actorId: requesterActorId });
         return jsonResult({
           operation: name,
@@ -350,18 +355,27 @@ async function handleSharedMemoryActorTool(name: string, args: Record<string, un
           linked: Boolean(identity),
           identity: identity ? formatSharedActorIdentity(identity) : undefined
         });
-      }
-      case 'mem-shared-actor-unlink': {
+      });
+      return result ?? jsonResult({ operation: name, projectHash, linked: false });
+    }
+    case 'mem-shared-actor-unlink': {
+      const result = await withSharedMemoryActorAdapter(async (adapter) => {
         const unlinked = await adapter.unlink({ projectHash, actorId: requesterActorId });
         return jsonResult({ operation: name, projectHash, unlinked });
-      }
-      case 'mem-shared-search': {
+      });
+      return result ?? jsonResult({ operation: name, projectHash, unlinked: false });
+    }
+    case 'mem-shared-search': {
+      const query = requiredOperationString(args.query, 'query');
+      const topK = numberArg(args.topK, 5, 1, 20);
+      const minConfidence = boundedNumberArg(args.minConfidence, 0.5, 0, 1);
+      const result = await withSharedMemoryActorAdapter(async (adapter) => {
         const result = await adapter.search({
           projectHash,
           actorId: requesterActorId,
-          query: requiredOperationString(args.query, 'query'),
-          topK: numberArg(args.topK, 5, 1, 20),
-          minConfidence: boundedNumberArg(args.minConfidence, 0.5, 0, 1)
+          query,
+          topK,
+          minConfidence
         });
         return jsonResult({
           operation: name,
@@ -371,14 +385,29 @@ async function handleSharedMemoryActorTool(name: string, args: Record<string, un
           count: result.entries.length,
           entries: result.entries.map(formatSharedTroubleshootingEntry)
         });
+      });
+      return result ?? jsonResult({
+        operation: name,
+        projectHash,
+        linked: false,
+        sourceProjectHashes: [],
+        count: 0,
+        entries: []
+      });
+    }
+    case 'mem-shared-asset-get': {
+      const sourceProjectPath = requiredOperationString(args.sourceProjectPath, 'sourceProjectPath');
+      if (!isAbsoluteProjectPath(sourceProjectPath)) {
+        throw new Error('sourceProjectPath must be an absolute project path');
       }
-      case 'mem-shared-asset-get': {
-        const sourceProjectPath = requiredOperationString(args.sourceProjectPath, 'sourceProjectPath');
-        if (!isAbsoluteProjectPath(sourceProjectPath)) {
-          throw new Error('sourceProjectPath must be an absolute project path');
-        }
-        const sourceActorId = requiredOperationString(args.sourceActorId, 'sourceActorId');
-        const sourceProjectHash = hashProjectPath(sourceProjectPath);
+      const sourceActorId = requiredOperationString(args.sourceActorId, 'sourceActorId');
+      const sourceProjectHash = hashProjectPath(sourceProjectPath);
+      const canonicalType = requiredOperationString(args.canonicalType, 'canonicalType');
+      const canonicalId = requiredOperationString(args.canonicalId, 'canonicalId');
+      if (canonicalType !== 'lesson' && canonicalType !== 'core_memory_block') {
+        throw new Error('canonicalType must be lesson or core_memory_block');
+      }
+      const result = await withSharedMemoryActorAdapter(async (adapter) => {
         if (!await adapter.sharesPrincipalWith({
           projectHash,
           actorId: requesterActorId,
@@ -392,11 +421,20 @@ async function handleSharedMemoryActorTool(name: string, args: Record<string, un
         if (!existsSync(sourceDbPath)) return jsonResult({ operation: name, projectHash, found: false });
         const sourceDb = createSQLiteDatabase(sourceDbPath, { readonly: true, walMode: false });
         try {
+          const requiredTables = [
+            'memory_assets',
+            'memory_asset_bindings',
+            'memory_asset_grants',
+            canonicalType === 'lesson' ? 'memory_lessons' : 'core_memory_blocks'
+          ];
+          if (!requiredTables.every((tableName) => sqliteTableExists(sourceDb, tableName))) {
+            return jsonResult({ operation: name, projectHash, found: false });
+          }
           const asset = await new SharedCanonicalMemoryAssetReadService(sourceDb).get({
             projectHash: sourceProjectHash,
             actorId: sourceActorId,
-            canonicalType: requiredOperationString(args.canonicalType, 'canonicalType'),
-            canonicalId: requiredOperationString(args.canonicalId, 'canonicalId')
+            canonicalType,
+            canonicalId
           });
           return jsonResult({
             operation: name,
@@ -407,25 +445,39 @@ async function handleSharedMemoryActorTool(name: string, args: Record<string, un
         } finally {
           sqliteClose(sourceDb);
         }
-      }
-      default:
-        throw new Error(`Unknown shared memory actor tool: ${name}`);
+      });
+      return result ?? jsonResult({ operation: name, projectHash, found: false });
     }
-  });
+    default:
+      throw new Error(`Unknown shared memory actor tool: ${name}`);
+  }
 }
 
 async function withSharedMemoryActorAdapter<T>(
-  callback: (adapter: SharedMemoryActorAdapter) => Promise<T>
-): Promise<T> {
+  callback: (adapter: SharedMemoryActorAdapter) => Promise<T>,
+  options: { createIfMissing?: boolean } = {}
+): Promise<T | null> {
   const sharedStoragePath = resolveSharedMemoryStoragePath();
-  mkdirSync(sharedStoragePath, { recursive: true });
-  const eventStore = createSharedEventStore(path.join(sharedStoragePath, 'shared.duckdb'));
+  const dbPath = path.join(sharedStoragePath, 'shared.duckdb');
+  if (!existsSync(dbPath)) {
+    if (!options.createIfMissing) return null;
+    mkdirSync(sharedStoragePath, { recursive: true });
+  }
+  const eventStore = createSharedEventStore(dbPath);
   await eventStore.initialize();
   try {
     return await callback(new SharedMemoryActorAdapter(createSharedStore(eventStore)));
   } finally {
     await eventStore.close();
   }
+}
+
+function sqliteTableExists(db: SQLiteDatabase, tableName: string): boolean {
+  return Boolean(sqliteGet<{ name: string }>(
+    db,
+    `SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`,
+    [tableName]
+  ));
 }
 
 function formatSharedActorIdentity(identity: SharedActorIdentity): Record<string, unknown> {

--- a/src/extensions/mcp/handlers.ts
+++ b/src/extensions/mcp/handlers.ts
@@ -37,6 +37,7 @@ import {
   LessonCandidateService,
   LessonRepository,
   LessonService,
+  MemoryAssetCatalogService,
   MemoryAssetPermissionSchema,
   MemoryAssetPermissionService,
   MemoryAssetStatusSchema,
@@ -53,6 +54,7 @@ import {
   type MemoryAsset,
   type MemoryAssetBinding,
   type MemoryAssetGrant,
+  type MemoryAssetCatalogSyncResult,
   type MemoryCheckpoint,
   type MemoryFacetAssignment,
   type QueryEntityCandidate,
@@ -283,6 +285,7 @@ const MEMORY_OPERATION_TOOL_NAMES = new Set([
   'mem-asset-create',
   'mem-asset-get',
   'mem-asset-list',
+  'mem-asset-catalog-sync',
   'mem-asset-update',
   'mem-asset-bind',
   'mem-asset-grant-set',
@@ -342,6 +345,8 @@ async function handleMemoryOperationTool(name: string, args: Record<string, unkn
         return jsonResult(await handleMemoryAssetGet(context, args));
       case 'mem-asset-list':
         return jsonResult(await handleMemoryAssetList(context, args));
+      case 'mem-asset-catalog-sync':
+        return jsonResult(await handleMemoryAssetCatalogSync(context, args));
       case 'mem-asset-update':
         return jsonResult(await handleMemoryAssetUpdate(context, args));
       case 'mem-asset-bind':
@@ -773,6 +778,19 @@ async function handleMemoryAssetList(
   };
 }
 
+async function handleMemoryAssetCatalogSync(
+  context: MemoryOperationContext,
+  args: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  const result = await new MemoryAssetCatalogService(context.db).sync({
+    projectHash: context.projectHash,
+    requesterActorId: requesterActorIdArg(args),
+    apply: booleanArg(args.apply, false),
+    limit: numberArg(args.limit, 100, 1, 500)
+  });
+  return formatMemoryAssetCatalogResult(result);
+}
+
 async function handleMemoryAssetUpdate(
   context: MemoryOperationContext,
   args: Record<string, unknown>
@@ -895,6 +913,34 @@ function formatMemoryAssetGrant(grant: MemoryAssetGrant): Record<string, unknown
     createdBy: sanitizeOperationString(grant.createdBy, 240),
     createdAt: isoDate(grant.createdAt),
     updatedAt: isoDate(grant.updatedAt)
+  };
+}
+
+function formatMemoryAssetCatalogResult(result: MemoryAssetCatalogSyncResult): Record<string, unknown> {
+  const items = result.items.slice(0, 25).map((item) => ({
+    canonicalType: item.candidate.canonicalType,
+    canonicalId: sanitizeOperationString(item.candidate.canonicalId, 240),
+    assetId: sanitizeOperationString(item.candidate.assetId, 240),
+    assetType: item.candidate.assetType,
+    title: sanitizeOperationString(item.candidate.title, 240),
+    status: item.candidate.status,
+    sourceRefs: compactStringArray(item.candidate.sourceRefs, 10, 240),
+    action: item.action,
+    reason: item.reason ? sanitizeOperationString(item.reason, 300) : undefined
+  }));
+  return {
+    operation: 'mem-asset-catalog-sync',
+    projectHash: result.projectHash,
+    dryRun: result.dryRun,
+    totalCandidates: result.totalCandidates,
+    scanned: result.scanned,
+    truncated: result.truncated,
+    planned: result.planned,
+    created: result.created,
+    existing: result.existing,
+    conflicts: result.conflicts,
+    returnedItems: items.length,
+    items
   };
 }
 

--- a/src/extensions/mcp/handlers.ts
+++ b/src/extensions/mcp/handlers.ts
@@ -37,6 +37,11 @@ import {
   LessonCandidateService,
   LessonRepository,
   LessonService,
+  MemoryAssetPermissionSchema,
+  MemoryAssetPermissionService,
+  MemoryAssetStatusSchema,
+  MemoryAssetTypeSchema,
+  MemoryAssetVisibilitySchema,
   PerspectiveObservationRepository,
   QueryEntityExtractor,
   RETENTION_POLICY_VERSION,
@@ -45,6 +50,9 @@ import {
   type FrontierItem,
   type GraphPathExpandResult,
   type MemoryAction,
+  type MemoryAsset,
+  type MemoryAssetBinding,
+  type MemoryAssetGrant,
   type MemoryCheckpoint,
   type MemoryFacetAssignment,
   type QueryEntityCandidate,
@@ -272,6 +280,13 @@ const MEMORY_OPERATION_TOOL_NAMES = new Set([
   'mem-lesson-candidates',
   'mem-lesson-list',
   'mem-lesson-save',
+  'mem-asset-create',
+  'mem-asset-get',
+  'mem-asset-list',
+  'mem-asset-update',
+  'mem-asset-bind',
+  'mem-asset-grant-set',
+  'mem-asset-check',
   'mem-actor-list',
   'mem-actor-card-get',
   'mem-actor-card-upsert',
@@ -321,6 +336,20 @@ async function handleMemoryOperationTool(name: string, args: Record<string, unkn
         return jsonResult(await handleLessonList(context, args));
       case 'mem-lesson-save':
         return jsonResult(await handleLessonSave(context, args));
+      case 'mem-asset-create':
+        return jsonResult(await handleMemoryAssetCreate(context, args));
+      case 'mem-asset-get':
+        return jsonResult(await handleMemoryAssetGet(context, args));
+      case 'mem-asset-list':
+        return jsonResult(await handleMemoryAssetList(context, args));
+      case 'mem-asset-update':
+        return jsonResult(await handleMemoryAssetUpdate(context, args));
+      case 'mem-asset-bind':
+        return jsonResult(await handleMemoryAssetBind(context, args));
+      case 'mem-asset-grant-set':
+        return jsonResult(await handleMemoryAssetGrantSet(context, args));
+      case 'mem-asset-check':
+        return jsonResult(handleMemoryAssetCheck(context, args));
       case 'mem-actor-list':
         return jsonResult(await handleActorList(context, args));
       case 'mem-actor-card-get':
@@ -669,6 +698,203 @@ function formatLesson(lesson: {
     sourceSessionIds: lesson.sourceSessionIds.slice(0, 10).map((id) => sanitizeOperationString(id, 120)),
     createdAt: isoDate(lesson.createdAt),
     updatedAt: isoDate(lesson.updatedAt)
+  };
+}
+
+function requesterActorIdArg(args: Record<string, unknown>): string {
+  // Principal identifiers must remain byte-for-byte stable. Output and audit
+  // payloads are sanitized separately; mutating the id here can authorize a
+  // different principal from the one supplied by the caller.
+  return requiredOperationString(args.requesterActorId, 'requesterActorId');
+}
+
+function memoryAssetMetadataArg(value: unknown): Record<string, unknown> | undefined {
+  if (value === undefined) return undefined;
+  if (!isPlainRecord(value)) throw new Error('metadata must be an object');
+  return sanitizeOperationRecord(value);
+}
+
+async function handleMemoryAssetCreate(
+  context: MemoryOperationContext,
+  args: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  const service = new MemoryAssetPermissionService(context.db);
+  const asset = await service.create({
+    projectHash: context.projectHash,
+    requesterActorId: requesterActorIdArg(args),
+    assetId: optionalString(args.assetId),
+    assetType: MemoryAssetTypeSchema.parse(args.assetType),
+    title: requiredOperationString(args.title, 'title'),
+    status: args.status === undefined ? undefined : MemoryAssetStatusSchema.parse(args.status),
+    visibility: args.visibility === undefined ? undefined : MemoryAssetVisibilitySchema.parse(args.visibility),
+    sourceRefs: optionalOperationStringArray(args.sourceRefs, 'sourceRefs', 100),
+    metadata: memoryAssetMetadataArg(args.metadata)
+  });
+  return {
+    operation: 'mem-asset-create',
+    projectHash: context.projectHash,
+    asset: formatMemoryAsset(asset)
+  };
+}
+
+async function handleMemoryAssetGet(
+  context: MemoryOperationContext,
+  args: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  const asset = await new MemoryAssetPermissionService(context.db).get({
+    projectHash: context.projectHash,
+    requesterActorId: requesterActorIdArg(args),
+    assetId: requiredOperationString(args.assetId, 'assetId')
+  });
+  return {
+    operation: 'mem-asset-get',
+    projectHash: context.projectHash,
+    found: Boolean(asset),
+    asset: asset ? formatMemoryAsset(asset) : undefined
+  };
+}
+
+async function handleMemoryAssetList(
+  context: MemoryOperationContext,
+  args: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  const assets = await new MemoryAssetPermissionService(context.db).list({
+    projectHash: context.projectHash,
+    requesterActorId: requesterActorIdArg(args),
+    assetType: args.assetType === undefined ? undefined : MemoryAssetTypeSchema.parse(args.assetType),
+    status: args.status === undefined ? undefined : MemoryAssetStatusSchema.parse(args.status),
+    limit: numberArg(args.limit, 50, 1, 100)
+  });
+  return {
+    operation: 'mem-asset-list',
+    projectHash: context.projectHash,
+    count: assets.length,
+    assets: assets.map(formatMemoryAsset)
+  };
+}
+
+async function handleMemoryAssetUpdate(
+  context: MemoryOperationContext,
+  args: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  const asset = await new MemoryAssetPermissionService(context.db).update({
+    projectHash: context.projectHash,
+    requesterActorId: requesterActorIdArg(args),
+    assetId: requiredOperationString(args.assetId, 'assetId'),
+    expectedVersion: args.expectedVersion as number | undefined,
+    title: optionalString(args.title),
+    status: args.status === undefined ? undefined : MemoryAssetStatusSchema.parse(args.status),
+    visibility: args.visibility === undefined ? undefined : MemoryAssetVisibilitySchema.parse(args.visibility),
+    sourceRefs: hasSuppliedArg(args, 'sourceRefs')
+      ? optionalOperationStringArray(args.sourceRefs, 'sourceRefs', 100)
+      : undefined,
+    metadata: memoryAssetMetadataArg(args.metadata)
+  });
+  return {
+    operation: 'mem-asset-update',
+    projectHash: context.projectHash,
+    asset: formatMemoryAsset(asset)
+  };
+}
+
+async function handleMemoryAssetBind(
+  context: MemoryOperationContext,
+  args: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  const binding = await new MemoryAssetPermissionService(context.db).bind({
+    projectHash: context.projectHash,
+    requesterActorId: requesterActorIdArg(args),
+    assetId: requiredOperationString(args.assetId, 'assetId'),
+    actorId: requiredOperationString(args.targetActorId, 'targetActorId'),
+    injectionMode: args.injectionMode as MemoryAssetBinding['injectionMode'] | undefined,
+    priority: args.priority as number | undefined,
+    enabled: typeof args.enabled === 'boolean' ? args.enabled : undefined
+  });
+  return {
+    operation: 'mem-asset-bind',
+    projectHash: context.projectHash,
+    binding: formatMemoryAssetBinding(binding)
+  };
+}
+
+async function handleMemoryAssetGrantSet(
+  context: MemoryOperationContext,
+  args: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  const permissions = zArrayMemoryAssetPermissions(args.permissions);
+  const grant = await new MemoryAssetPermissionService(context.db).setGrant({
+    projectHash: context.projectHash,
+    requesterActorId: requesterActorIdArg(args),
+    assetId: requiredOperationString(args.assetId, 'assetId'),
+    actorId: requiredOperationString(args.targetActorId, 'targetActorId'),
+    permissions
+  });
+  return {
+    operation: 'mem-asset-grant-set',
+    projectHash: context.projectHash,
+    grant: formatMemoryAssetGrant(grant)
+  };
+}
+
+function handleMemoryAssetCheck(
+  context: MemoryOperationContext,
+  args: Record<string, unknown>
+): Record<string, unknown> {
+  const result = new MemoryAssetPermissionService(context.db).check({
+    projectHash: context.projectHash,
+    requesterActorId: requesterActorIdArg(args),
+    assetId: requiredOperationString(args.assetId, 'assetId'),
+    permission: MemoryAssetPermissionSchema.parse(args.permission)
+  });
+  return {
+    operation: 'mem-asset-check',
+    projectHash: context.projectHash,
+    assetId: requiredOperationString(args.assetId, 'assetId'),
+    decision: result.decision
+  };
+}
+
+function zArrayMemoryAssetPermissions(value: unknown): Array<'read' | 'write' | 'bind' | 'grant'> {
+  if (!Array.isArray(value)) throw new Error('permissions must be an array');
+  return value.map((permission) => MemoryAssetPermissionSchema.parse(permission));
+}
+
+function formatMemoryAsset(asset: MemoryAsset): Record<string, unknown> {
+  return {
+    assetId: sanitizeOperationString(asset.assetId, 240),
+    assetType: asset.assetType,
+    title: sanitizeOperationString(asset.title, 240),
+    ownerActorId: sanitizeOperationString(asset.ownerActorId, 240),
+    version: asset.version,
+    status: asset.status,
+    visibility: asset.visibility,
+    sourceRefs: compactStringArray(asset.sourceRefs, 20, 240),
+    metadata: asset.metadata ? compactRecord(sanitizeOperationRecord(asset.metadata), 20) : undefined,
+    createdAt: isoDate(asset.createdAt),
+    updatedAt: isoDate(asset.updatedAt)
+  };
+}
+
+function formatMemoryAssetBinding(binding: MemoryAssetBinding): Record<string, unknown> {
+  return {
+    assetId: sanitizeOperationString(binding.assetId, 240),
+    actorId: sanitizeOperationString(binding.actorId, 240),
+    injectionMode: binding.injectionMode,
+    priority: binding.priority,
+    enabled: binding.enabled,
+    createdAt: isoDate(binding.createdAt),
+    updatedAt: isoDate(binding.updatedAt)
+  };
+}
+
+function formatMemoryAssetGrant(grant: MemoryAssetGrant): Record<string, unknown> {
+  return {
+    assetId: sanitizeOperationString(grant.assetId, 240),
+    actorId: sanitizeOperationString(grant.actorId, 240),
+    permissions: grant.permissions,
+    createdBy: sanitizeOperationString(grant.createdBy, 240),
+    createdAt: isoDate(grant.createdAt),
+    updatedAt: isoDate(grant.updatedAt)
   };
 }
 

--- a/src/extensions/mcp/handlers.ts
+++ b/src/extensions/mcp/handlers.ts
@@ -68,7 +68,7 @@ import {
   type TemporalGraphExpandResult
 } from '../../core/operations/index.js';
 import { SharedMemoryActorAdapter } from '../shared-memory/shared-memory-actor-adapter.js';
-import { DEFAULT_SHARED_STORAGE_PATH } from '../../services/memory-service-config.js';
+import { resolveSharedMemoryStoragePath } from '../../services/memory-service-config.js';
 import { DEFAULT_EMBEDDING_MODEL } from '../../extensions/vector/embedder.js';
 import {
   isGenericContinuationQuery,
@@ -417,8 +417,9 @@ async function handleSharedMemoryActorTool(name: string, args: Record<string, un
 async function withSharedMemoryActorAdapter<T>(
   callback: (adapter: SharedMemoryActorAdapter) => Promise<T>
 ): Promise<T> {
-  mkdirSync(DEFAULT_SHARED_STORAGE_PATH, { recursive: true });
-  const eventStore = createSharedEventStore(path.join(DEFAULT_SHARED_STORAGE_PATH, 'shared.duckdb'));
+  const sharedStoragePath = resolveSharedMemoryStoragePath();
+  mkdirSync(sharedStoragePath, { recursive: true });
+  const eventStore = createSharedEventStore(path.join(sharedStoragePath, 'shared.duckdb'));
   await eventStore.initialize();
   try {
     return await callback(new SharedMemoryActorAdapter(createSharedStore(eventStore)));

--- a/src/extensions/mcp/handlers.ts
+++ b/src/extensions/mcp/handlers.ts
@@ -3,7 +3,7 @@
  * Implementation of tool calls
  */
 
-import { existsSync } from 'node:fs';
+import { existsSync, mkdirSync } from 'node:fs';
 import * as path from 'node:path';
 
 import {
@@ -12,6 +12,8 @@ import {
   type MemoryService
 } from '../../services/memory-service.js';
 import { SQLiteEventStore } from '../../core/sqlite-event-store.js';
+import { createSharedEventStore } from '../../core/shared-event-store.js';
+import { createSharedStore, type SharedActorIdentity } from '../../core/shared-store.js';
 import { EntityRepo } from '../../core/entity-repo.js';
 import { createSQLiteDatabase, sqliteClose, sqliteGet, type SQLiteDatabase } from '../../core/sqlite-wrapper.js';
 import { createSessionHistoryImporter, type ImportResult } from '../../services/session-history-importer.js';
@@ -64,6 +66,8 @@ import {
   type QueryEntityCandidate,
   type TemporalGraphExpandResult
 } from '../../core/operations/index.js';
+import { SharedMemoryActorAdapter } from '../shared-memory/shared-memory-actor-adapter.js';
+import { DEFAULT_SHARED_STORAGE_PATH } from '../../services/memory-service-config.js';
 import { DEFAULT_EMBEDDING_MODEL } from '../../extensions/vector/embedder.js';
 import {
   isGenericContinuationQuery,
@@ -220,6 +224,10 @@ export async function handleToolCall(
       return await handleMemoryOperationTool(name, args);
     }
 
+    if (SHARED_MEMORY_ACTOR_TOOL_NAMES.has(name)) {
+      return await handleSharedMemoryActorTool(name, args);
+    }
+
     if (name === 'mem-import-latest' || (name === 'mem-context-pack' && args.refreshLatest === true)) {
       const projectPath = optionalString(args.projectPath);
       if (!projectPath || !path.isAbsolute(projectPath)) {
@@ -306,10 +314,115 @@ const MEMORY_OPERATION_TOOL_NAMES = new Set([
   'mem-perspective-observation-delete'
 ]);
 
+const SHARED_MEMORY_ACTOR_TOOL_NAMES = new Set([
+  'mem-shared-actor-link',
+  'mem-shared-actor-status',
+  'mem-shared-actor-unlink',
+  'mem-shared-search'
+]);
+
 interface MemoryOperationContext {
   projectPath: string;
   projectHash: string;
   db: SQLiteDatabase;
+}
+
+async function handleSharedMemoryActorTool(name: string, args: Record<string, unknown>): Promise<ToolResult> {
+  const projectHash = hashProjectPath(requiredProjectPath(args));
+  const requesterActorId = requesterActorIdArg(args);
+  return withSharedMemoryActorAdapter(async (adapter) => {
+    switch (name) {
+      case 'mem-shared-actor-link': {
+        const identity = await adapter.link({
+          projectHash,
+          actorId: requesterActorId,
+          sharedPrincipalId: requiredOperationString(args.sharedPrincipalId, 'sharedPrincipalId')
+        });
+        return jsonResult({ operation: name, projectHash, identity: formatSharedActorIdentity(identity) });
+      }
+      case 'mem-shared-actor-status': {
+        const identity = await adapter.status({ projectHash, actorId: requesterActorId });
+        return jsonResult({
+          operation: name,
+          projectHash,
+          linked: Boolean(identity),
+          identity: identity ? formatSharedActorIdentity(identity) : undefined
+        });
+      }
+      case 'mem-shared-actor-unlink': {
+        const unlinked = await adapter.unlink({ projectHash, actorId: requesterActorId });
+        return jsonResult({ operation: name, projectHash, unlinked });
+      }
+      case 'mem-shared-search': {
+        const result = await adapter.search({
+          projectHash,
+          actorId: requesterActorId,
+          query: requiredOperationString(args.query, 'query'),
+          topK: numberArg(args.topK, 5, 1, 20),
+          minConfidence: boundedNumberArg(args.minConfidence, 0.5, 0, 1)
+        });
+        return jsonResult({
+          operation: name,
+          projectHash,
+          linked: Boolean(result.identity),
+          sourceProjectHashes: result.sourceProjectHashes,
+          count: result.entries.length,
+          entries: result.entries.map(formatSharedTroubleshootingEntry)
+        });
+      }
+      default:
+        throw new Error(`Unknown shared memory actor tool: ${name}`);
+    }
+  });
+}
+
+async function withSharedMemoryActorAdapter<T>(
+  callback: (adapter: SharedMemoryActorAdapter) => Promise<T>
+): Promise<T> {
+  mkdirSync(DEFAULT_SHARED_STORAGE_PATH, { recursive: true });
+  const eventStore = createSharedEventStore(path.join(DEFAULT_SHARED_STORAGE_PATH, 'shared.duckdb'));
+  await eventStore.initialize();
+  try {
+    return await callback(new SharedMemoryActorAdapter(createSharedStore(eventStore)));
+  } finally {
+    await eventStore.close();
+  }
+}
+
+function formatSharedActorIdentity(identity: SharedActorIdentity): Record<string, unknown> {
+  return {
+    projectHash: sanitizeOperationString(identity.projectHash, 240),
+    actorId: sanitizeOperationString(identity.actorId, 240),
+    sharedPrincipalId: sanitizeOperationString(identity.sharedPrincipalId, 240),
+    createdAt: isoDate(identity.createdAt),
+    updatedAt: isoDate(identity.updatedAt)
+  };
+}
+
+function formatSharedTroubleshootingEntry(entry: {
+  entryId: string;
+  sourceProjectHash: string;
+  sourceEntryId: string;
+  title: string;
+  symptoms: string[];
+  rootCause: string;
+  solution: string;
+  topics: string[];
+  technologies?: string[];
+  confidence: number;
+}): Record<string, unknown> {
+  return {
+    entryId: sanitizeOperationString(entry.entryId, 240),
+    sourceProjectHash: sanitizeOperationString(entry.sourceProjectHash, 240),
+    sourceEntryId: sanitizeOperationString(entry.sourceEntryId, 240),
+    title: sanitizeOperationString(entry.title, 240),
+    symptoms: compactStringArray(entry.symptoms, 20, 240),
+    rootCause: sanitizeOperationString(entry.rootCause, 500),
+    solution: sanitizeOperationString(entry.solution, 500),
+    topics: compactStringArray(entry.topics, 20, 120),
+    technologies: compactStringArray(entry.technologies, 20, 120),
+    confidence: entry.confidence
+  };
 }
 
 async function handleMemoryOperationTool(name: string, args: Record<string, unknown>): Promise<ToolResult> {

--- a/src/extensions/mcp/tools.ts
+++ b/src/extensions/mcp/tools.ts
@@ -762,6 +762,28 @@ export const tools: Tool[] = [
     }
   },
   {
+    name: 'mem-asset-catalog-sync',
+    description: 'Preview or apply idempotent registration of canonical project lessons and core-memory blocks as private memory assets. Preview is the default and never changes canonical content.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: requiredProjectPathProperty,
+        requesterActorId: requesterActorIdProperty,
+        apply: {
+          type: 'boolean',
+          description: 'When true, create missing private assets owned by requesterActorId. Default false returns a read-only preview.'
+        },
+        limit: {
+          type: 'number',
+          minimum: 1,
+          maximum: 500,
+          description: 'Maximum canonical records to inspect in deterministic order (default: 100, max: 500).'
+        }
+      },
+      required: ['projectPath', 'requesterActorId']
+    }
+  },
+  {
     name: 'mem-asset-update',
     description: 'Update memory asset metadata after an owner or explicit write-grant check. Supports optimistic version checks.',
     inputSchema: {

--- a/src/extensions/mcp/tools.ts
+++ b/src/extensions/mcp/tools.ts
@@ -860,6 +860,61 @@ export const tools: Tool[] = [
     }
   },
   {
+    name: 'mem-shared-actor-link',
+    description: 'Explicitly link this project-local actor to a shared principal before using actor-scoped cross-project troubleshooting search. This is a global shared-store mutation; it does not grant canonical memory-asset permissions.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: requiredProjectPathProperty,
+        requesterActorId: requesterActorIdProperty,
+        sharedPrincipalId: {
+          type: 'string',
+          description: 'Stable opaque identifier representing the same actor across projects. Reusing it in another project explicitly joins that project to the same shared-search scope.'
+        }
+      },
+      required: ['projectPath', 'requesterActorId', 'sharedPrincipalId']
+    }
+  },
+  {
+    name: 'mem-shared-actor-status',
+    description: 'Inspect whether this project-local actor has an explicit shared principal link. No shared troubleshooting content is returned.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: requiredProjectPathProperty,
+        requesterActorId: requesterActorIdProperty
+      },
+      required: ['projectPath', 'requesterActorId']
+    }
+  },
+  {
+    name: 'mem-shared-actor-unlink',
+    description: 'Remove this project-local actor\'s explicit shared principal link. Subsequent actor-scoped shared searches fail closed until linked again.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: requiredProjectPathProperty,
+        requesterActorId: requesterActorIdProperty
+      },
+      required: ['projectPath', 'requesterActorId']
+    }
+  },
+  {
+    name: 'mem-shared-search',
+    description: 'Search verified shared troubleshooting entries only from projects explicitly linked to requesterActorId through the same shared principal. An unlinked actor receives an empty result.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: requiredProjectPathProperty,
+        requesterActorId: requesterActorIdProperty,
+        query: { type: 'string', description: 'Troubleshooting query' },
+        topK: { type: 'number', minimum: 1, maximum: 20, description: 'Maximum entries to return (default: 5)' },
+        minConfidence: { type: 'number', minimum: 0, maximum: 1, description: 'Minimum verified-entry confidence (default: 0.5)' }
+      },
+      required: ['projectPath', 'requesterActorId', 'query']
+    }
+  },
+  {
     name: 'mem-actor-list',
     description: 'List project-scoped or global memory actors with compact privacy-safe identity metadata.',
     inputSchema: {

--- a/src/extensions/mcp/tools.ts
+++ b/src/extensions/mcp/tools.ts
@@ -915,6 +915,31 @@ export const tools: Tool[] = [
     }
   },
   {
+    name: 'mem-shared-asset-get',
+    description: 'Read one active canonical lesson or core-memory block from another project only after both named actors are explicitly linked to the same shared principal. The source asset must be registered, active, visibility=shared, and readable under the source project policy. This never auto-injects content.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: requiredProjectPathProperty,
+        requesterActorId: requesterActorIdProperty,
+        sourceProjectPath: {
+          type: 'string',
+          description: 'Required absolute path of the source project. Its hash must be linked to the requester through the shared principal.'
+        },
+        sourceActorId: {
+          type: 'string',
+          description: 'Explicit source-project actor id linked to the same shared principal; it is used for the source read-permission check.'
+        },
+        canonicalType: { type: 'string', enum: ['lesson', 'core_memory_block'] },
+        canonicalId: {
+          type: 'string',
+          description: 'Lesson id, or project/user for a core-memory block.'
+        }
+      },
+      required: ['projectPath', 'requesterActorId', 'sourceProjectPath', 'sourceActorId', 'canonicalType', 'canonicalId']
+    }
+  },
+  {
     name: 'mem-actor-list',
     description: 'List project-scoped or global memory actors with compact privacy-safe identity metadata.',
     inputSchema: {

--- a/src/extensions/mcp/tools.ts
+++ b/src/extensions/mcp/tools.ts
@@ -25,6 +25,11 @@ const requesterActorIdProperty = {
   description: 'Memory actor id of the caller. Permission checks and governance audit records use this identity.'
 } as const;
 
+const canonicalRequesterActorIdProperty = {
+  type: 'string',
+  description: 'Memory actor id of the caller. Optional only in the default legacy migration mode; required for registered or strict server-side permission checks.'
+} as const;
+
 const memoryAssetIdProperty = {
   type: 'string',
   description: 'Project-scoped memory asset id.'
@@ -611,11 +616,12 @@ export const tools: Tool[] = [
   },
   {
     name: 'mem-lesson-list',
-    description: 'List project-scoped procedural lessons as compact skill/runbook candidates without raw transcript or local path disclosure.',
+    description: 'List project-scoped procedural lessons as compact skill/runbook candidates. Registered assets are permission-filtered when server enforcement is enabled.',
     inputSchema: {
       type: 'object',
       properties: {
         projectPath: requiredProjectPathProperty,
+        requesterActorId: canonicalRequesterActorIdProperty,
         skillCandidate: {
           type: 'boolean',
           description: 'Optional filter for lessons marked as manual skill candidates.'
@@ -659,11 +665,12 @@ export const tools: Tool[] = [
   },
   {
     name: 'mem-lesson-save',
-    description: 'Save a reviewed project-scoped lesson or rule as a curated memory. Rejects private or credential-like content and preserves compact provenance.',
+    description: 'Save a reviewed project-scoped lesson or rule as a curated memory. Updates to registered lessons require write access when server enforcement is enabled.',
     inputSchema: {
       type: 'object',
       properties: {
         projectPath: requiredProjectPathProperty,
+        requesterActorId: canonicalRequesterActorIdProperty,
         name: {
           type: 'string',
           description: 'Short stable name for the curated lesson.'
@@ -956,11 +963,12 @@ export const tools: Tool[] = [
   },
   {
     name: 'mem-core-block-get',
-    description: 'Read this project\'s core memory blocks — small, always-injected resident context shown at the start of every session (Letta-style core memory), separate from query-scored retrieval.',
+    description: 'Read this project\'s core memory blocks. Registered blocks are permission-filtered when server enforcement is enabled.',
     inputSchema: {
       type: 'object',
       properties: {
         projectPath: requiredProjectPathProperty,
+        requesterActorId: canonicalRequesterActorIdProperty,
         blockKey: {
           type: 'string',
           enum: ['project', 'user'],
@@ -972,11 +980,12 @@ export const tools: Tool[] = [
   },
   {
     name: 'mem-core-block-update',
-    description: 'Replace one core memory block for this project through an audited, self-editable write. Core memory blocks are injected unconditionally on every SessionStart, so keep content compact and durable (conventions, active constraints) rather than transient session detail.',
+    description: 'Replace one core memory block through an audited write. Registered blocks require write access when server enforcement is enabled.',
     inputSchema: {
       type: 'object',
       properties: {
         projectPath: requiredProjectPathProperty,
+        requesterActorId: canonicalRequesterActorIdProperty,
         blockKey: {
           type: 'string',
           enum: ['project', 'user'],

--- a/src/extensions/mcp/tools.ts
+++ b/src/extensions/mcp/tools.ts
@@ -188,6 +188,10 @@ export const tools: Tool[] = [
           description: 'Optional: filter relevant memories by specific session ID'
         },
         projectPath: projectPathProperty,
+        requesterActorId: {
+          type: 'string',
+          description: 'Actor identity for canonical lesson injection. Required when server-side asset permission mode is registered or strict.'
+        },
         compression: {
           type: 'string',
           enum: ['off', 'safe', 'aggressive'],

--- a/src/extensions/mcp/tools.ts
+++ b/src/extensions/mcp/tools.ts
@@ -20,6 +20,28 @@ const actorProperty = {
   description: 'Actor identifier recorded in governance audit metadata for state-changing operations.'
 } as const;
 
+const requesterActorIdProperty = {
+  type: 'string',
+  description: 'Memory actor id of the caller. Permission checks and governance audit records use this identity.'
+} as const;
+
+const memoryAssetIdProperty = {
+  type: 'string',
+  description: 'Project-scoped memory asset id.'
+} as const;
+
+const memoryAssetTypeProperty = {
+  type: 'string',
+  enum: ['memory', 'lesson', 'skill', 'wiki', 'code_graph'],
+  description: 'Canonical kind of the registered memory asset.'
+} as const;
+
+const memoryAssetPermissionProperty = {
+  type: 'string',
+  enum: ['read', 'write', 'bind', 'grant'],
+  description: 'Permission evaluated by the memory asset policy.'
+} as const;
+
 const targetActorAliasAnyOf = [
   { required: ['targetActorId'] },
   { required: ['observedActorId'] }
@@ -690,6 +712,118 @@ export const tools: Tool[] = [
         }
       },
       required: ['projectPath', 'name', 'trigger', 'steps', 'actor']
+    }
+  },
+  {
+    name: 'mem-asset-create',
+    description: 'Register a project-scoped memory asset. The requester becomes its owner; content stays in the referenced canonical subsystem.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: requiredProjectPathProperty,
+        requesterActorId: requesterActorIdProperty,
+        assetId: memoryAssetIdProperty,
+        assetType: memoryAssetTypeProperty,
+        title: { type: 'string', maxLength: 240, description: 'Compact human-readable asset title.' },
+        status: { type: 'string', enum: ['candidate', 'active', 'deprecated', 'archived'], description: 'Initial lifecycle status (default: active).' },
+        visibility: { type: 'string', enum: ['private', 'project', 'shared'], description: 'Read visibility (default: private). Visibility never grants mutation rights.' },
+        sourceRefs: { type: 'array', items: { type: 'string' }, maxItems: 100, description: 'Bounded canonical source ids or references.' },
+        metadata: { type: 'object', description: 'Optional compact asset metadata; secrets and local paths are sanitized from public output and audit snapshots.' }
+      },
+      required: ['projectPath', 'requesterActorId', 'assetType', 'title']
+    }
+  },
+  {
+    name: 'mem-asset-get',
+    description: 'Get one memory asset only when the requester has read access; unauthorized and missing assets return the same not-found shape.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: requiredProjectPathProperty,
+        requesterActorId: requesterActorIdProperty,
+        assetId: memoryAssetIdProperty
+      },
+      required: ['projectPath', 'requesterActorId', 'assetId']
+    }
+  },
+  {
+    name: 'mem-asset-list',
+    description: 'List only memory assets readable by the requester; inaccessible private assets are omitted.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: requiredProjectPathProperty,
+        requesterActorId: requesterActorIdProperty,
+        assetType: memoryAssetTypeProperty,
+        status: { type: 'string', enum: ['candidate', 'active', 'deprecated', 'archived'], description: 'Optional lifecycle filter.' },
+        limit: operationLimitProperty
+      },
+      required: ['projectPath', 'requesterActorId']
+    }
+  },
+  {
+    name: 'mem-asset-update',
+    description: 'Update memory asset metadata after an owner or explicit write-grant check. Supports optimistic version checks.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: requiredProjectPathProperty,
+        requesterActorId: requesterActorIdProperty,
+        assetId: memoryAssetIdProperty,
+        expectedVersion: { type: 'number', minimum: 1, description: 'Optional current version; stale writes fail instead of overwriting.' },
+        title: { type: 'string', maxLength: 240 },
+        status: { type: 'string', enum: ['candidate', 'active', 'deprecated', 'archived'] },
+        visibility: { type: 'string', enum: ['private', 'project', 'shared'] },
+        sourceRefs: { type: 'array', items: { type: 'string' }, maxItems: 100 },
+        metadata: { type: 'object' }
+      },
+      required: ['projectPath', 'requesterActorId', 'assetId']
+    }
+  },
+  {
+    name: 'mem-asset-bind',
+    description: 'Create, update, or disable an actor-to-asset injection binding after a bind permission check.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: requiredProjectPathProperty,
+        requesterActorId: requesterActorIdProperty,
+        assetId: memoryAssetIdProperty,
+        targetActorId: { type: 'string', description: 'Actor receiving the asset binding.' },
+        injectionMode: { type: 'string', enum: ['direct', 'summary', 'tool', 'reference'], description: 'How a future injector should deliver the asset (default: reference).' },
+        priority: { type: 'number', minimum: -1000, maximum: 1000, description: 'Binding priority (default: 0).' },
+        enabled: { type: 'boolean', description: 'Set false to disable and revoke binding-based read access (default: true).' }
+      },
+      required: ['projectPath', 'requesterActorId', 'assetId', 'targetActorId']
+    }
+  },
+  {
+    name: 'mem-asset-grant-set',
+    description: 'Replace one actor\'s explicit asset permissions after a grant permission check. Pass an empty list to revoke all explicit permissions.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: requiredProjectPathProperty,
+        requesterActorId: requesterActorIdProperty,
+        assetId: memoryAssetIdProperty,
+        targetActorId: { type: 'string', description: 'Actor whose explicit permission set is replaced.' },
+        permissions: { type: 'array', items: memoryAssetPermissionProperty, maxItems: 4, description: 'Full replacement permission set; empty means explicit grant revocation.' }
+      },
+      required: ['projectPath', 'requesterActorId', 'assetId', 'targetActorId', 'permissions']
+    }
+  },
+  {
+    name: 'mem-asset-check',
+    description: 'Explain whether the requester has a specific memory asset permission and which policy rule decided it.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: requiredProjectPathProperty,
+        requesterActorId: requesterActorIdProperty,
+        assetId: memoryAssetIdProperty,
+        permission: memoryAssetPermissionProperty
+      },
+      required: ['projectPath', 'requesterActorId', 'assetId', 'permission']
     }
   },
   {

--- a/src/extensions/shared-memory/index.ts
+++ b/src/extensions/shared-memory/index.ts
@@ -1,1 +1,2 @@
 export * from './shared-memory-services.js';
+export * from './shared-memory-actor-adapter.js';

--- a/src/extensions/shared-memory/shared-memory-actor-adapter.ts
+++ b/src/extensions/shared-memory/shared-memory-actor-adapter.ts
@@ -38,6 +38,16 @@ export class SharedMemoryActorAdapter {
     );
   }
 
+  async scope(input: { projectHash: string; actorId: string }): Promise<{
+    identity: SharedActorIdentity | null;
+    linkedProjectCount: number;
+  }> {
+    const identity = await this.status(input);
+    if (!identity) return { identity: null, linkedProjectCount: 0 };
+    const projectHashes = await this.store.listProjectHashesForPrincipal(identity.sharedPrincipalId);
+    return { identity, linkedProjectCount: projectHashes.length };
+  }
+
   async unlink(input: { projectHash: string; actorId: string }): Promise<boolean> {
     return this.store.unlinkActorIdentity(
       NonEmptyIdSchema.parse(input.projectHash),

--- a/src/extensions/shared-memory/shared-memory-actor-adapter.ts
+++ b/src/extensions/shared-memory/shared-memory-actor-adapter.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+
+import {
+  type SharedActorIdentity,
+  type SharedStore
+} from '../../core/shared-store.js';
+import type { SharedTroubleshootingEntry } from '../../core/types.js';
+
+const NonEmptyIdSchema = z.string().trim().min(1).max(240);
+
+export interface SharedMemoryActorSearchResult {
+  identity: SharedActorIdentity | null;
+  sourceProjectHashes: string[];
+  entries: SharedTroubleshootingEntry[];
+}
+
+/**
+ * Deliberately narrow adapter for cross-project reads.  It makes an actor's
+ * project memberships explicit before delegating to the shared store and is
+ * kept separate from legacy retrieval so existing includeShared behavior does
+ * not silently gain a new identity policy.
+ */
+export class SharedMemoryActorAdapter {
+  constructor(private readonly store: SharedStore) {}
+
+  async link(input: { projectHash: string; actorId: string; sharedPrincipalId: string }): Promise<SharedActorIdentity> {
+    return this.store.linkActorIdentity({
+      projectHash: NonEmptyIdSchema.parse(input.projectHash),
+      actorId: NonEmptyIdSchema.parse(input.actorId),
+      sharedPrincipalId: NonEmptyIdSchema.parse(input.sharedPrincipalId)
+    });
+  }
+
+  async status(input: { projectHash: string; actorId: string }): Promise<SharedActorIdentity | null> {
+    return this.store.getActorIdentity(
+      NonEmptyIdSchema.parse(input.projectHash),
+      NonEmptyIdSchema.parse(input.actorId)
+    );
+  }
+
+  async unlink(input: { projectHash: string; actorId: string }): Promise<boolean> {
+    return this.store.unlinkActorIdentity(
+      NonEmptyIdSchema.parse(input.projectHash),
+      NonEmptyIdSchema.parse(input.actorId)
+    );
+  }
+
+  async search(input: {
+    projectHash: string;
+    actorId: string;
+    query: string;
+    topK?: number;
+    minConfidence?: number;
+  }): Promise<SharedMemoryActorSearchResult> {
+    const identity = await this.status({ projectHash: input.projectHash, actorId: input.actorId });
+    if (!identity) return { identity: null, sourceProjectHashes: [], entries: [] };
+    const result = await this.store.searchForPrincipal(identity.sharedPrincipalId, NonEmptyIdSchema.parse(input.query), {
+      topK: input.topK,
+      minConfidence: input.minConfidence
+    });
+    return { identity, ...result };
+  }
+}

--- a/src/extensions/shared-memory/shared-memory-actor-adapter.ts
+++ b/src/extensions/shared-memory/shared-memory-actor-adapter.ts
@@ -45,6 +45,26 @@ export class SharedMemoryActorAdapter {
     );
   }
 
+  /**
+   * The caller supplies the source actor deliberately. Matching a principal
+   * by project alone would allow a different actor in the source project to
+   * become an accidental deputy for a private grant.
+   */
+  async sharesPrincipalWith(input: {
+    projectHash: string;
+    actorId: string;
+    sourceProjectHash: string;
+    sourceActorId: string;
+  }): Promise<boolean> {
+    const identity = await this.status({ projectHash: input.projectHash, actorId: input.actorId });
+    if (!identity) return false;
+    const sourceIdentity = await this.status({
+      projectHash: input.sourceProjectHash,
+      actorId: input.sourceActorId
+    });
+    return sourceIdentity?.sharedPrincipalId === identity.sharedPrincipalId;
+  }
+
   async search(input: {
     projectHash: string;
     actorId: string;

--- a/src/services/memory-service-config.ts
+++ b/src/services/memory-service-config.ts
@@ -42,6 +42,21 @@ export const DEFAULT_ENABLED_SHARED_STORE_CONFIG: SharedStoreConfig = {
 };
 
 export const DEFAULT_SHARED_STORAGE_PATH = SHARED_STORAGE_PATH;
+export const SHARED_MEMORY_STORAGE_PATH_ENV = 'CLAUDE_MEMORY_SHARED_STORAGE_PATH';
+
+/**
+ * MCP shared-actor tools open the global shared store outside a project
+ * MemoryService instance. Keep that path configurable without allowing a
+ * relative path to silently create a second store under the server cwd.
+ */
+export function resolveSharedMemoryStoragePath(env: NodeJS.ProcessEnv = process.env): string {
+  const configured = env[SHARED_MEMORY_STORAGE_PATH_ENV]?.trim();
+  if (!configured) return DEFAULT_SHARED_STORAGE_PATH;
+  if (!path.isAbsolute(configured)) {
+    throw new Error(`${SHARED_MEMORY_STORAGE_PATH_ENV} must be an absolute path`);
+  }
+  return configured;
+}
 
 export const DISABLED_MEMORY_OPERATIONS_CONFIG: MemoryOperationsConfig = {
   enabled: false,

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -41,6 +41,7 @@ import type { DerivationLiveness, RecentEventsReadOptions } from '../core/sqlite
 import type { IngestInterceptor } from '../core/ingest-interceptor.js';
 import type { MemoryIngestService } from '../core/engine/memory-ingest-service.js';
 import type { MemoryQueryService } from '../core/engine/memory-query-service.js';
+import type { CanonicalMemoryInjection } from '../core/operations/canonical-memory-injection-service.js';
 import { createMemoryServiceComposition } from '../core/engine/memory-service-composition.js';
 import {
   getProjectStoragePath as defaultGetProjectStoragePath,
@@ -243,9 +244,24 @@ export class MemoryService {
     return this.queryService.listProjectLessons(this.projectHash ?? '', limit);
   }
 
+  /** Curated lessons selected for automatic prompt injection by actor binding. */
+  async listProjectLessonInjections(
+    actorId: string | undefined,
+    limit = 25
+  ): Promise<CanonicalMemoryInjection<MemoryLesson>[]> {
+    return this.queryService.listProjectLessonInjections(this.projectHash ?? '', actorId, limit);
+  }
+
   /** Core memory blocks (project/user), for unconditional session-start injection. */
   async getCoreMemoryBlocks(): Promise<CoreMemoryBlock[]> {
     return this.queryService.getCoreMemoryBlocks(this.projectHash ?? '');
+  }
+
+  /** Core blocks selected for SessionStart injection by actor binding. */
+  async getCoreMemoryBlockInjections(
+    actorId: string | undefined
+  ): Promise<CanonicalMemoryInjection<CoreMemoryBlock>[]> {
+    return this.queryService.getCoreMemoryBlockInjections(this.projectHash ?? '', actorId);
   }
 
   /**

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -89,6 +89,8 @@ export {
   DEFAULT_ENABLED_SHARED_STORE_CONFIG,
   DEFAULT_SHARED_STORAGE_PATH,
   DISABLED_SHARED_STORE_CONFIG,
+  resolveSharedMemoryStoragePath,
+  SHARED_MEMORY_STORAGE_PATH_ENV,
   type MemoryServiceConfig
 } from './memory-service-config.js';
 

--- a/tests/adapters/claude-hook-adherence.test.ts
+++ b/tests/adapters/claude-hook-adherence.test.ts
@@ -7,7 +7,8 @@ import {
   type AdherenceState,
   selectEvidencePreview,
   formatMemoryContext,
-  redactForStorage
+  redactForStorage,
+  lessonForInjection
 } from '../../src/adapters/claude/hooks/user-prompt-submit.js';
 
 function adherenceState(overrides: Partial<AdherenceState> = {}): AdherenceState {
@@ -23,6 +24,17 @@ function adherenceState(overrides: Partial<AdherenceState> = {}): AdherenceState
 }
 
 describe('Claude user prompt adherence trigger heuristics', () => {
+  it('keeps reference-mode lesson injection to a non-body hint', () => {
+    const lesson = lessonForInjection({
+      lessonId: 'lesson-1', name: 'Safe deployment', trigger: 'When production is unstable',
+      steps: ['Inspect private rollout notes'], failureModes: ['Do not disclose credentials'], confidence: 1
+    }, 'reference');
+    expect(lesson.name).toBe('[lesson:lesson-1] Safe deployment');
+    expect(lesson.trigger).toBe('');
+    expect(lesson.steps).toEqual([]);
+    expect(lesson.failureModes).toEqual([]);
+  });
+
   it('renders a long evidence excerpt around the strongest query identifier', () => {
     const content = `${'unrelated prelude '.repeat(30)}PR 167 review found a null handling risk and required a regression test.`;
     const preview = selectEvidencePreview(content, 'PR 167 코드 리뷰 결론', 160);

--- a/tests/adapters/claude-hook-session-start.test.ts
+++ b/tests/adapters/claude-hook-session-start.test.ts
@@ -47,6 +47,19 @@ describe('formatCoreMemoryBlockContext', () => {
     expect(context).toContain('**Project**: Kept content.');
     expect(context).not.toContain('**User**:');
   });
+
+  it('honors summary and reference binding delivery modes without exposing direct content', () => {
+    const content = 'A'.repeat(400);
+    const context = formatCoreMemoryBlockContext([
+      { value: block({ blockKey: 'project', content }), injectionMode: 'summary', priority: 1 },
+      { value: block({ blockKey: 'user', content: 'Private user preference' }), injectionMode: 'reference', priority: 0 }
+    ]);
+
+    expect(context).toContain(`${'A'.repeat(317)}...`);
+    expect(context).not.toContain(content);
+    expect(context).toContain('[reference: use mem-core-block-get for user block]');
+    expect(context).not.toContain('Private user preference');
+  });
 });
 
 let eventSeq = 0;

--- a/tests/apps/dashboard-setup-health-ui.test.ts
+++ b/tests/apps/dashboard-setup-health-ui.test.ts
@@ -84,6 +84,8 @@ describe('dashboard setup/provider health UI', () => {
     const setupRequest = requested.map(url => new URL(url)).find(url => url.pathname === '/api/health/setup');
     expect(setupRequest?.searchParams.get('project')).toBe('project-safe-hash');
     expect(cfg.innerHTML).toContain('Setup & Provider Health');
+    expect(cfg.innerHTML).toContain('Shared Actor Access');
+    expect(cfg.innerHTML).toContain('shared-actor-id-input');
     expect(cfg.innerHTML).toContain('needs-setup');
     expect(cfg.innerHTML).toContain('Claude CLI');
     expect(cfg.innerHTML).toContain('missing');

--- a/tests/apps/dashboard-shared-memory-api.test.ts
+++ b/tests/apps/dashboard-shared-memory-api.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Hono } from 'hono';
+
+import { createSharedEventStore } from '../../src/core/shared-event-store.js';
+import { createSharedStore } from '../../src/core/shared-store.js';
+import { SharedMemoryActorAdapter } from '../../src/extensions/shared-memory/shared-memory-actor-adapter.js';
+import { sharedMemoryRouter } from '../../src/apps/server/api/shared-memory.js';
+import { SHARED_MEMORY_STORAGE_PATH_ENV } from '../../src/services/memory-service-config.js';
+
+const tempDirs: string[] = [];
+const originalSharedPath = process.env[SHARED_MEMORY_STORAGE_PATH_ENV];
+
+afterEach(() => {
+  if (originalSharedPath === undefined) delete process.env[SHARED_MEMORY_STORAGE_PATH_ENV];
+  else process.env[SHARED_MEMORY_STORAGE_PATH_ENV] = originalSharedPath;
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function createApp() {
+  const app = new Hono();
+  app.route('/api/shared', sharedMemoryRouter);
+  return app;
+}
+
+describe('dashboard shared actor API', () => {
+  it('returns aggregate mapping scope and unlinks without exposing the principal', async () => {
+    const sharedPath = mkdtempSync(join(tmpdir(), 'cml-dashboard-shared-'));
+    tempDirs.push(sharedPath);
+    process.env[SHARED_MEMORY_STORAGE_PATH_ENV] = sharedPath;
+    const eventStore = createSharedEventStore(join(sharedPath, 'shared.duckdb'));
+    await eventStore.initialize();
+    try {
+      const adapter = new SharedMemoryActorAdapter(createSharedStore(eventStore));
+      await adapter.link({ projectHash: 'abc12345', actorId: 'actor-a', sharedPrincipalId: 'principal-private' });
+      await adapter.link({ projectHash: 'def67890', actorId: 'actor-b', sharedPrincipalId: 'principal-private' });
+    } finally {
+      await eventStore.close();
+    }
+
+    const app = createApp();
+    const status = await app.request('/api/shared/actor?project=abc12345&actorId=actor-a');
+    expect(status.status).toBe(200);
+    const statusBody = await status.json();
+    expect(statusBody).toEqual({ projectHash: 'abc12345', linked: true, linkedProjectCount: 2 });
+    expect(JSON.stringify(statusBody)).not.toContain('principal-private');
+
+    const unlinked = await app.request('/api/shared/actor?project=abc12345&actorId=actor-a', { method: 'DELETE' });
+    expect(unlinked.status).toBe(200);
+    expect(await unlinked.json()).toEqual({ projectHash: 'abc12345', unlinked: true });
+
+    const after = await app.request('/api/shared/actor?project=abc12345&actorId=actor-a');
+    expect(await after.json()).toEqual({ projectHash: 'abc12345', linked: false, linkedProjectCount: 0 });
+  });
+
+  it('does not create a shared store merely to report an unlinked actor', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'cml-dashboard-shared-empty-'));
+    tempDirs.push(root);
+    const sharedPath = join(root, 'shared');
+    process.env[SHARED_MEMORY_STORAGE_PATH_ENV] = sharedPath;
+
+    const response = await createApp().request('/api/shared/actor?project=abc12345&actorId=actor-a');
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ projectHash: 'abc12345', linked: false, linkedProjectCount: 0 });
+  });
+});

--- a/tests/core/canonical-memory-access-service.test.ts
+++ b/tests/core/canonical-memory-access-service.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  CANONICAL_MEMORY_PERMISSION_MODE_ENV,
+  CanonicalMemoryAccessDeniedError,
+  CanonicalMemoryAccessService,
+  resolveCanonicalMemoryPermissionMode
+} from '../../src/core/operations/canonical-memory-access-service.js';
+import { MemoryAssetPermissionService } from '../../src/core/operations/memory-asset-permission-service.js';
+import { SQLiteEventStore } from '../../src/core/sqlite-event-store.js';
+
+const tempDirs: string[] = [];
+
+async function createFixture(): Promise<{
+  store: SQLiteEventStore;
+  permissions: MemoryAssetPermissionService;
+}> {
+  const dir = mkdtempSync(join(tmpdir(), 'cml-canonical-access-'));
+  tempDirs.push(dir);
+  const store = new SQLiteEventStore(join(dir, 'events.sqlite'));
+  await store.initialize();
+  return {
+    store,
+    permissions: new MemoryAssetPermissionService(store.getDatabase())
+  };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('canonical memory permission mode', () => {
+  it('defaults to legacy and rejects invalid configuration instead of silently downgrading', () => {
+    expect(resolveCanonicalMemoryPermissionMode({})).toBe('legacy');
+    expect(resolveCanonicalMemoryPermissionMode({
+      [CANONICAL_MEMORY_PERMISSION_MODE_ENV]: ' REGISTERED '
+    })).toBe('registered');
+    expect(() => resolveCanonicalMemoryPermissionMode({
+      [CANONICAL_MEMORY_PERMISSION_MODE_ENV]: 'registred'
+    })).toThrow(`${CANONICAL_MEMORY_PERMISSION_MODE_ENV} must be legacy, registered, or strict`);
+  });
+});
+
+describe('CanonicalMemoryAccessService', () => {
+  it('preserves legacy access while registered and strict modes require a principal', async () => {
+    const { store } = await createFixture();
+    try {
+      const legacy = new CanonicalMemoryAccessService(store.getDatabase(), { mode: 'legacy' });
+      expect(legacy.check({
+        projectHash: 'project-1', canonicalType: 'lesson', canonicalId: 'lesson-1', permission: 'read'
+      })).toMatchObject({ allowed: true, mode: 'legacy', registered: false, source: 'legacy' });
+
+      for (const mode of ['registered', 'strict'] as const) {
+        const service = new CanonicalMemoryAccessService(store.getDatabase(), { mode });
+        expect(() => service.check({
+          projectHash: 'project-1', canonicalType: 'lesson', canonicalId: 'lesson-1', permission: 'read'
+        })).toThrow(`requesterActorId is required when ${CANONICAL_MEMORY_PERMISSION_MODE_ENV}=${mode}`);
+      }
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('uses unregistered fallback only in registered migration mode', async () => {
+    const { store } = await createFixture();
+    try {
+      const registered = new CanonicalMemoryAccessService(store.getDatabase(), { mode: 'registered' });
+      expect(registered.check({
+        projectHash: 'project-1', canonicalType: 'core_memory_block', canonicalId: 'project',
+        requesterActorId: 'caller', permission: 'write'
+      })).toMatchObject({ allowed: true, registered: false, source: 'unregistered' });
+      expect(registered.requireUnregisteredWrite('caller')).toMatchObject({ allowed: true, source: 'unregistered' });
+
+      const strict = new CanonicalMemoryAccessService(store.getDatabase(), { mode: 'strict' });
+      expect(strict.check({
+        projectHash: 'project-1', canonicalType: 'core_memory_block', canonicalId: 'project',
+        requesterActorId: 'caller', permission: 'write'
+      })).toMatchObject({ allowed: false, registered: false, source: 'none' });
+      expect(() => strict.requireUnregisteredWrite('caller')).toThrow(CanonicalMemoryAccessDeniedError);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('enforces owner and explicit grants for valid canonical registrations', async () => {
+    const { store, permissions } = await createFixture();
+    try {
+      await permissions.create({
+        projectHash: 'project-1',
+        requesterActorId: 'owner',
+        assetId: 'lesson:lesson-1',
+        assetType: 'lesson',
+        title: 'Registered lesson',
+        sourceRefs: ['lesson:lesson-1']
+      });
+      const service = new CanonicalMemoryAccessService(store.getDatabase(), { mode: 'registered' });
+      expect(service.check({
+        projectHash: 'project-1', canonicalType: 'lesson', canonicalId: 'lesson-1',
+        requesterActorId: 'owner', permission: 'write'
+      })).toMatchObject({ allowed: true, registered: true, source: 'owner' });
+      expect(service.check({
+        projectHash: 'project-1', canonicalType: 'lesson', canonicalId: 'lesson-1',
+        requesterActorId: 'reader', permission: 'read'
+      })).toMatchObject({ allowed: false, registered: true, source: 'none' });
+
+      await permissions.setGrant({
+        projectHash: 'project-1', requesterActorId: 'owner', assetId: 'lesson:lesson-1',
+        actorId: 'reader', permissions: ['read']
+      });
+      expect(service.check({
+        projectHash: 'project-1', canonicalType: 'lesson', canonicalId: 'lesson-1',
+        requesterActorId: 'reader', permission: 'read'
+      })).toMatchObject({ allowed: true, registered: true, source: 'grant' });
+      expect(() => service.require({
+        projectHash: 'project-1', canonicalType: 'lesson', canonicalId: 'lesson-1',
+        requesterActorId: 'reader', permission: 'write'
+      })).toThrow(CanonicalMemoryAccessDeniedError);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('denies deterministic-id conflicts instead of treating them as unregistered fallback', async () => {
+    const { store, permissions } = await createFixture();
+    try {
+      await permissions.create({
+        projectHash: 'project-1',
+        requesterActorId: 'caller',
+        assetId: 'core_memory_block:project',
+        assetType: 'wiki',
+        title: 'Unrelated conflicting asset',
+        sourceRefs: ['wiki:other']
+      });
+      const service = new CanonicalMemoryAccessService(store.getDatabase(), { mode: 'registered' });
+      expect(service.check({
+        projectHash: 'project-1', canonicalType: 'core_memory_block', canonicalId: 'project',
+        requesterActorId: 'caller', permission: 'read'
+      })).toMatchObject({ allowed: false, registered: false, source: 'none' });
+    } finally {
+      await store.close();
+    }
+  });
+});

--- a/tests/core/canonical-memory-injection-service.test.ts
+++ b/tests/core/canonical-memory-injection-service.test.ts
@@ -123,6 +123,27 @@ describe('CanonicalMemoryInjectionService', () => {
     }
   });
 
+  it('uses the constructor environment for the fallback actor', async () => {
+    const { store, permissions } = await createFixture();
+    try {
+      await registerLesson(permissions, 'bound', 'summary', 2);
+      const service = new CanonicalMemoryInjectionService(store.getDatabase(), {
+        mode: 'strict',
+        env: { [CANONICAL_MEMORY_ACTOR_ID_ENV]: 'agent-a' }
+      });
+
+      const selection = service.select({
+        projectHash: 'project-1',
+        lane: 'context_pack',
+        candidates: [{ canonicalType: 'lesson', canonicalId: 'bound', value: 'bound' }]
+      });
+
+      expect(selection.items).toEqual([{ value: 'bound', injectionMode: 'summary', priority: 2 }]);
+    } finally {
+      await store.close();
+    }
+  });
+
   it('uses a hook input actor before the server fallback actor', () => {
     expect(resolveCanonicalMemoryActorId('input-actor', {
       [CANONICAL_MEMORY_ACTOR_ID_ENV]: 'env-actor'

--- a/tests/core/canonical-memory-injection-service.test.ts
+++ b/tests/core/canonical-memory-injection-service.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  CANONICAL_MEMORY_ACTOR_ID_ENV,
+  CanonicalMemoryInjectionService,
+  resolveCanonicalMemoryActorId
+} from '../../src/core/operations/canonical-memory-injection-service.js';
+import { MemoryAssetPermissionService } from '../../src/core/operations/memory-asset-permission-service.js';
+import { SQLiteEventStore } from '../../src/core/sqlite-event-store.js';
+
+const tempDirs: string[] = [];
+
+async function createFixture(): Promise<{
+  store: SQLiteEventStore;
+  permissions: MemoryAssetPermissionService;
+}> {
+  const dir = mkdtempSync(join(tmpdir(), 'cml-canonical-injection-'));
+  tempDirs.push(dir);
+  const store = new SQLiteEventStore(join(dir, 'events.sqlite'));
+  await store.initialize();
+  return { store, permissions: new MemoryAssetPermissionService(store.getDatabase()) };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+async function registerLesson(
+  permissions: MemoryAssetPermissionService,
+  lessonId: string,
+  injectionMode: 'direct' | 'summary' | 'reference' | 'tool',
+  priority = 0,
+  enabled = true
+): Promise<void> {
+  const assetId = `lesson:${lessonId}`;
+  await permissions.create({
+    projectHash: 'project-1', requesterActorId: 'owner', assetId, assetType: 'lesson',
+    title: lessonId, sourceRefs: [assetId]
+  });
+  await permissions.bind({
+    projectHash: 'project-1', requesterActorId: 'owner', assetId, actorId: 'agent-a',
+    injectionMode, priority, enabled
+  });
+}
+
+describe('CanonicalMemoryInjectionService', () => {
+  it('preserves the original candidate order in legacy mode', async () => {
+    const { store } = await createFixture();
+    try {
+      const service = new CanonicalMemoryInjectionService(store.getDatabase(), { mode: 'legacy' });
+      const selection = service.select({
+        projectHash: 'project-1', lane: 'context_pack', candidates: [
+          { canonicalType: 'lesson', canonicalId: 'second', value: 'second' },
+          { canonicalType: 'lesson', canonicalId: 'first', value: 'first' }
+        ]
+      });
+      expect(selection).toMatchObject({ mode: 'legacy' });
+      expect(selection.items).toEqual([
+        { value: 'second', injectionMode: 'direct', priority: 0 },
+        { value: 'first', injectionMode: 'direct', priority: 0 }
+      ]);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('requires an active binding for valid registrations and orders selected assets by priority', async () => {
+    const { store, permissions } = await createFixture();
+    try {
+      await registerLesson(permissions, 'direct', 'direct', 10);
+      await registerLesson(permissions, 'summary', 'summary', 5);
+      await registerLesson(permissions, 'reference', 'reference', 5);
+      await registerLesson(permissions, 'tool-only', 'tool', 50);
+      await registerLesson(permissions, 'disabled', 'direct', 20, false);
+      await registerLesson(permissions, 'archived', 'direct', 30);
+      await permissions.update({
+        projectHash: 'project-1', requesterActorId: 'owner', assetId: 'lesson:archived', status: 'archived'
+      });
+      await permissions.create({
+        projectHash: 'project-1', requesterActorId: 'owner', assetId: 'lesson:conflict',
+        assetType: 'wiki', title: 'conflict', sourceRefs: ['wiki:other']
+      });
+
+      const service = new CanonicalMemoryInjectionService(store.getDatabase(), { mode: 'registered' });
+      const selection = service.select({
+        projectHash: 'project-1', actorId: 'agent-a', lane: 'prompt', candidates: [
+          ...['direct', 'summary', 'reference', 'tool-only', 'disabled', 'archived', 'unregistered', 'conflict']
+            .map((canonicalId) => ({ canonicalType: 'lesson' as const, canonicalId, value: canonicalId }))
+        ]
+      });
+      expect(selection.items).toEqual([
+        { value: 'direct', injectionMode: 'direct', priority: 10 },
+        { value: 'summary', injectionMode: 'summary', priority: 5 },
+        { value: 'reference', injectionMode: 'reference', priority: 5 },
+        { value: 'unregistered', injectionMode: 'direct', priority: 0 }
+      ]);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('fails closed for missing actors and unregistered assets in strict mode', async () => {
+    const { store, permissions } = await createFixture();
+    try {
+      await registerLesson(permissions, 'bound', 'summary', 2);
+      const service = new CanonicalMemoryInjectionService(store.getDatabase(), { mode: 'strict' });
+      expect(() => service.select({
+        projectHash: 'project-1', lane: 'context_pack', candidates: []
+      })).toThrow('actor identity is required');
+
+      const selection = service.select({
+        projectHash: 'project-1', actorId: 'agent-a', lane: 'context_pack', candidates: [
+          { canonicalType: 'lesson', canonicalId: 'bound', value: 'bound' },
+          { canonicalType: 'lesson', canonicalId: 'unregistered', value: 'unregistered' }
+        ]
+      });
+      expect(selection.items).toEqual([{ value: 'bound', injectionMode: 'summary', priority: 2 }]);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('uses a hook input actor before the server fallback actor', () => {
+    expect(resolveCanonicalMemoryActorId('input-actor', {
+      [CANONICAL_MEMORY_ACTOR_ID_ENV]: 'env-actor'
+    })).toBe('input-actor');
+    expect(resolveCanonicalMemoryActorId(undefined, {
+      [CANONICAL_MEMORY_ACTOR_ID_ENV]: 'env-actor'
+    })).toBe('env-actor');
+    expect(resolveCanonicalMemoryActorId('   ', {})).toBeUndefined();
+  });
+});

--- a/tests/core/lesson-service.test.ts
+++ b/tests/core/lesson-service.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { LessonCandidateService, LessonService, type LessonCandidate } from '../../src/core/operations/index.js';
+import { LessonCandidateService, LessonRepository, LessonService, type LessonCandidate } from '../../src/core/operations/index.js';
 import { SQLiteEventStore } from '../../src/core/sqlite-event-store.js';
 import { sqliteAll, sqliteGet } from '../../src/core/sqlite-wrapper.js';
 import type { MemoryEvent } from '../../src/core/types.js';
@@ -152,6 +152,24 @@ afterEach(() => {
 });
 
 describe('LessonService manual promotion', () => {
+  it('pages lessons in stable confidence order for permission-filtered scans', async () => {
+    const { store, lessonService, cleanup } = await createFixture();
+    const projectHash = 'project-lesson-paging';
+    await lessonService.saveCurated({
+      projectHash, actor: 'operator', name: 'High confidence', trigger: 'When high', steps: ['High'], confidence: 0.9
+    });
+    await lessonService.saveCurated({
+      projectHash, actor: 'operator', name: 'Middle confidence', trigger: 'When middle', steps: ['Middle'], confidence: 0.8
+    });
+    await lessonService.saveCurated({
+      projectHash, actor: 'operator', name: 'Low confidence', trigger: 'When low', steps: ['Low'], confidence: 0.7
+    });
+
+    const page = await new LessonRepository(store.getDatabase()).list({ projectHash, limit: 1, offset: 1 });
+    await cleanup();
+    expect(page.map((lesson) => lesson.name)).toEqual(['Middle confidence']);
+  });
+
   it('captures an explicit curated lesson without a prior raw event and records stable provenance', async () => {
     const { store, lessonService, cleanup } = await createFixture();
     const projectHash = 'project-curated-capture';

--- a/tests/core/memory-asset-catalog-service.test.ts
+++ b/tests/core/memory-asset-catalog-service.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  MemoryAssetCatalogService,
+  canonicalMemoryAssetId
+} from '../../src/core/operations/memory-asset-catalog-service.js';
+import { MemoryAssetPermissionService } from '../../src/core/operations/memory-asset-permission-service.js';
+import { CoreMemoryBlockRepository } from '../../src/core/operations/core-memory-block-repository.js';
+import { LessonRepository } from '../../src/core/operations/lesson-repository.js';
+import { SQLiteEventStore } from '../../src/core/sqlite-event-store.js';
+import { sqliteAll, sqliteGet } from '../../src/core/sqlite-wrapper.js';
+
+const tempDirs: string[] = [];
+
+async function createFixture(): Promise<{
+  store: SQLiteEventStore;
+  catalog: MemoryAssetCatalogService;
+  lessons: LessonRepository;
+  blocks: CoreMemoryBlockRepository;
+}> {
+  const dir = mkdtempSync(join(tmpdir(), 'cml-memory-asset-catalog-'));
+  tempDirs.push(dir);
+  const store = new SQLiteEventStore(join(dir, 'events.sqlite'));
+  await store.initialize();
+  const db = store.getDatabase();
+  return {
+    store,
+    catalog: new MemoryAssetCatalogService(db),
+    lessons: new LessonRepository(db),
+    blocks: new CoreMemoryBlockRepository(db)
+  };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('MemoryAssetCatalogService', () => {
+  it('previews and idempotently registers canonical lessons and core blocks without copying content', async () => {
+    const { store, catalog, lessons, blocks } = await createFixture();
+    try {
+      const lesson = await lessons.upsert({
+        projectHash: 'project-1',
+        name: 'Release workflow',
+        trigger: 'when releasing',
+        steps: ['run tests'],
+        sourceEventIds: ['event-lesson'],
+        actor: 'curator'
+      });
+      await blocks.upsert({
+        projectHash: 'project-1',
+        blockKey: 'project',
+        content: 'Private canonical core-memory content',
+        sourceEventIds: ['event-project-block'],
+        updatedBy: 'curator'
+      });
+      await blocks.upsert({
+        projectHash: 'project-1',
+        blockKey: 'user',
+        content: '',
+        sourceEventIds: [],
+        updatedBy: 'curator'
+      });
+
+      const preview = await catalog.sync({
+        projectHash: 'project-1', requesterActorId: 'catalog-owner', apply: false, limit: 100
+      });
+      expect(preview).toMatchObject({
+        dryRun: true,
+        totalCandidates: 3,
+        scanned: 3,
+        truncated: false,
+        planned: 3,
+        created: 0,
+        existing: 0,
+        conflicts: 0
+      });
+      expect(sqliteGet<{ count: number }>(store.getDatabase(), `SELECT COUNT(*) AS count FROM memory_assets`)?.count).toBe(0);
+
+      const applied = await catalog.sync({
+        projectHash: 'project-1', requesterActorId: 'catalog-owner', apply: true, limit: 100
+      });
+      expect(applied).toMatchObject({ dryRun: false, planned: 3, created: 3, existing: 0, conflicts: 0 });
+
+      const assetRows = sqliteAll<{
+        asset_id: string;
+        asset_type: string;
+        title: string;
+        owner_actor_id: string;
+        status: string;
+        visibility: string;
+        source_refs_json: string;
+        metadata_json: string;
+      }>(store.getDatabase(), `SELECT * FROM memory_assets WHERE project_hash = ? ORDER BY asset_id`, ['project-1']);
+      expect(assetRows).toHaveLength(3);
+      expect(assetRows.map((row) => row.asset_id)).toEqual([
+        'core_memory_block:project',
+        'core_memory_block:user',
+        canonicalMemoryAssetId('lesson', lesson.lessonId)
+      ]);
+      expect(assetRows.every((row) => row.owner_actor_id === 'catalog-owner')).toBe(true);
+      expect(assetRows.every((row) => row.visibility === 'private')).toBe(true);
+      expect(assetRows.find((row) => row.asset_id === 'core_memory_block:user')?.status).toBe('archived');
+      expect(assetRows.find((row) => row.asset_id === 'core_memory_block:project')?.title).toBe('Core memory: project');
+      expect(JSON.stringify(assetRows)).not.toContain('Private canonical core-memory content');
+      expect(JSON.parse(assetRows.find((row) => row.asset_id.startsWith('lesson:'))!.source_refs_json)).toEqual([
+        canonicalMemoryAssetId('lesson', lesson.lessonId)
+      ]);
+
+      const canonicalBlock = await blocks.get({ projectHash: 'project-1', blockKey: 'project' });
+      expect(canonicalBlock?.content).toBe('Private canonical core-memory content');
+
+      const rerun = await catalog.sync({
+        projectHash: 'project-1', requesterActorId: 'different-caller', apply: true, limit: 100
+      });
+      expect(rerun).toMatchObject({ planned: 0, created: 0, existing: 3, conflicts: 0 });
+      expect(rerun.items.every((item) => !('asset' in item))).toBe(true);
+
+      const assetAudits = sqliteAll<{ operation: string }>(
+        store.getDatabase(),
+        `SELECT operation FROM memory_governance_audit WHERE operation = 'memory_asset_create'`
+      );
+      expect(assetAudits).toHaveLength(3);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('reports deterministic-id conflicts without overwriting an existing asset', async () => {
+    const { store, catalog, lessons } = await createFixture();
+    try {
+      const lesson = await lessons.upsert({
+        projectHash: 'project-1',
+        name: 'Conflicting lesson',
+        trigger: 'when conflict testing',
+        steps: ['do not overwrite'],
+        sourceEventIds: ['event-conflict']
+      });
+      const assetId = canonicalMemoryAssetId('lesson', lesson.lessonId);
+      const permissions = new MemoryAssetPermissionService(store.getDatabase());
+      await permissions.create({
+        projectHash: 'project-1',
+        requesterActorId: 'existing-owner',
+        assetId,
+        assetType: 'wiki',
+        title: 'Existing unrelated asset',
+        sourceRefs: ['wiki:unrelated']
+      });
+
+      const result = await catalog.sync({
+        projectHash: 'project-1', requesterActorId: 'catalog-owner', apply: true
+      });
+      expect(result).toMatchObject({ planned: 0, created: 0, existing: 0, conflicts: 1 });
+      expect(result.items[0]).toMatchObject({ action: 'conflict' });
+
+      const unchanged = await permissions.get({
+        projectHash: 'project-1', requesterActorId: 'existing-owner', assetId
+      });
+      expect(unchanged).toMatchObject({ assetType: 'wiki', title: 'Existing unrelated asset' });
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('keeps project scopes isolated and reports bounded scans as truncated', async () => {
+    const { store, catalog, lessons } = await createFixture();
+    try {
+      await lessons.upsert({
+        projectHash: 'project-1', name: 'One', trigger: 'one', steps: ['one'], sourceEventIds: ['event-1']
+      });
+      await lessons.upsert({
+        projectHash: 'project-1', name: 'Two', trigger: 'two', steps: ['two'], sourceEventIds: ['event-2']
+      });
+      await lessons.upsert({
+        projectHash: 'project-2', name: 'Other project', trigger: 'other', steps: ['other'], sourceEventIds: ['event-3']
+      });
+
+      const result = await catalog.sync({
+        projectHash: 'project-1', requesterActorId: 'owner', apply: false, limit: 1
+      });
+      expect(result).toMatchObject({ totalCandidates: 2, scanned: 1, truncated: true, planned: 1 });
+      expect(result.items[0].candidate.title).not.toBe('Other project');
+    } finally {
+      await store.close();
+    }
+  });
+});

--- a/tests/core/memory-asset-permission-service.test.ts
+++ b/tests/core/memory-asset-permission-service.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { MemoryAssetPermissionService } from '../../src/core/operations/memory-asset-permission-service.js';
+import { MemoryAssetPermissionDeniedError } from '../../src/core/operations/memory-asset-permissions.js';
+import { SQLiteEventStore } from '../../src/core/sqlite-event-store.js';
+import { sqliteAll, sqliteGet, sqliteRun } from '../../src/core/sqlite-wrapper.js';
+
+const tempDirs: string[] = [];
+
+async function createFixture(): Promise<{ store: SQLiteEventStore; service: MemoryAssetPermissionService }> {
+  const dir = mkdtempSync(join(tmpdir(), 'cml-memory-asset-permissions-'));
+  tempDirs.push(dir);
+  const store = new SQLiteEventStore(join(dir, 'events.sqlite'));
+  await store.initialize();
+  return { store, service: new MemoryAssetPermissionService(store.getDatabase()) };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('MemoryAssetPermissionService', () => {
+  it('creates a private owner asset and hides it from unauthorized reads and lists', async () => {
+    const { store, service } = await createFixture();
+    try {
+      const created = await service.create({
+        projectHash: 'project-1',
+        requesterActorId: 'owner',
+        assetType: 'lesson',
+        title: 'Safe deployment order',
+        sourceRefs: ['lesson-1']
+      });
+
+      expect(created).toMatchObject({ ownerActorId: 'owner', visibility: 'private', version: 1 });
+      expect(await service.get({ projectHash: 'project-1', assetId: created.assetId, requesterActorId: 'stranger' })).toBeNull();
+      expect(await service.list({ projectHash: 'project-1', requesterActorId: 'stranger' })).toEqual([]);
+      expect(await service.list({ projectHash: 'project-1', requesterActorId: 'owner' })).toHaveLength(1);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('grants exact capabilities and supports audited empty-set revocation', async () => {
+    const { store, service } = await createFixture();
+    try {
+      const asset = await service.create({
+        projectHash: 'project-1',
+        requesterActorId: 'owner',
+        assetType: 'memory',
+        title: 'Private memory'
+      });
+      await service.setGrant({
+        projectHash: 'project-1',
+        requesterActorId: 'owner',
+        assetId: asset.assetId,
+        actorId: 'editor',
+        permissions: ['read', 'write']
+      });
+
+      expect(service.check({
+        projectHash: 'project-1', assetId: asset.assetId, requesterActorId: 'editor', permission: 'write'
+      }).decision).toMatchObject({ allowed: true, source: 'grant' });
+      const updated = await service.update({
+        projectHash: 'project-1',
+        requesterActorId: 'editor',
+        assetId: asset.assetId,
+        expectedVersion: 1,
+        title: 'Edited memory'
+      });
+      expect(updated).toMatchObject({ title: 'Edited memory', version: 2 });
+
+      await service.setGrant({
+        projectHash: 'project-1',
+        requesterActorId: 'owner',
+        assetId: asset.assetId,
+        actorId: 'editor',
+        permissions: []
+      });
+      expect(service.check({
+        projectHash: 'project-1', assetId: asset.assetId, requesterActorId: 'editor', permission: 'read'
+      }).decision.allowed).toBe(false);
+
+      const audit = sqliteAll<{ operation: string }>(
+        store.getDatabase(),
+        `SELECT operation FROM memory_governance_audit WHERE target_id LIKE ? ORDER BY created_at`,
+        [`${asset.assetId}%`]
+      );
+      expect(audit.map((row) => row.operation)).toEqual([
+        'memory_asset_create',
+        'memory_asset_grant_set',
+        'memory_asset_update',
+        'memory_asset_grant_set'
+      ]);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('uses bindings for private read access without granting write access', async () => {
+    const { store, service } = await createFixture();
+    try {
+      const asset = await service.create({
+        projectHash: 'project-1', requesterActorId: 'owner', assetType: 'wiki', title: 'Runbook'
+      });
+      await service.bind({
+        projectHash: 'project-1', requesterActorId: 'owner', assetId: asset.assetId, actorId: 'agent-a'
+      });
+      expect(await service.get({
+        projectHash: 'project-1', assetId: asset.assetId, requesterActorId: 'agent-a'
+      })).toMatchObject({ assetId: asset.assetId });
+      await expect(service.update({
+        projectHash: 'project-1', requesterActorId: 'agent-a', assetId: asset.assetId, title: 'Nope'
+      })).rejects.toBeInstanceOf(MemoryAssetPermissionDeniedError);
+
+      await service.bind({
+        projectHash: 'project-1', requesterActorId: 'owner', assetId: asset.assetId, actorId: 'agent-a', enabled: false
+      });
+      expect(await service.get({
+        projectHash: 'project-1', assetId: asset.assetId, requesterActorId: 'agent-a'
+      })).toBeNull();
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('rejects stale versions and unauthorized grant delegation', async () => {
+    const { store, service } = await createFixture();
+    try {
+      const asset = await service.create({
+        projectHash: 'project-1', requesterActorId: 'owner', assetType: 'code_graph', title: 'Graph'
+      });
+      await expect(service.update({
+        projectHash: 'project-1', requesterActorId: 'owner', assetId: asset.assetId, expectedVersion: 99, title: 'Stale'
+      })).rejects.toThrow('version conflict');
+      await expect(service.setGrant({
+        projectHash: 'project-1', requesterActorId: 'stranger', assetId: asset.assetId, actorId: 'editor', permissions: ['read']
+      })).rejects.toBeInstanceOf(MemoryAssetPermissionDeniedError);
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('allows the same external asset id in different project scopes without leakage', async () => {
+    const { store, service } = await createFixture();
+    try {
+      await service.create({
+        projectHash: 'project-1', requesterActorId: 'owner-1', assetId: 'lesson:release', assetType: 'lesson', title: 'Project one'
+      });
+      await service.create({
+        projectHash: 'project-2', requesterActorId: 'owner-2', assetId: 'lesson:release', assetType: 'lesson', title: 'Project two'
+      });
+
+      expect(await service.get({
+        projectHash: 'project-1', requesterActorId: 'owner-1', assetId: 'lesson:release'
+      })).toMatchObject({ title: 'Project one' });
+      expect(await service.get({
+        projectHash: 'project-2', requesterActorId: 'owner-2', assetId: 'lesson:release'
+      })).toMatchObject({ title: 'Project two' });
+      expect(await service.get({
+        projectHash: 'project-2', requesterActorId: 'owner-1', assetId: 'lesson:release'
+      })).toBeNull();
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('does not reveal whether a denied asset exists through permission checks', async () => {
+    const { store, service } = await createFixture();
+    try {
+      const asset = await service.create({
+        projectHash: 'project-1', requesterActorId: 'owner', assetId: 'private-asset', assetType: 'memory', title: 'Private'
+      });
+      const denied = service.check({
+        projectHash: 'project-1', requesterActorId: 'stranger', assetId: asset.assetId, permission: 'read'
+      });
+      const missing = service.check({
+        projectHash: 'project-1', requesterActorId: 'stranger', assetId: 'missing-asset', permission: 'read'
+      });
+
+      expect(denied).toEqual(missing);
+      expect(denied.asset).toBeUndefined();
+      expect(denied.decision).toMatchObject({ allowed: false, source: 'none', reason: 'permission denied' });
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('continues paging until list reaches readable assets behind private rows', async () => {
+    const { store, service } = await createFixture();
+    try {
+      await service.create({
+        projectHash: 'project-1', requesterActorId: 'owner', assetId: 'zz-readable', assetType: 'memory',
+        title: 'Readable', visibility: 'project'
+      });
+      for (let index = 0; index < 101; index++) {
+        await service.create({
+          projectHash: 'project-1', requesterActorId: 'other-owner',
+          assetId: `private-${String(index).padStart(3, '0')}`, assetType: 'memory', title: `Private ${index}`
+        });
+      }
+      sqliteRun(store.getDatabase(), `UPDATE memory_assets SET updated_at = ? WHERE project_hash = ? AND asset_id = ?`, [
+        '2026-01-01T00:00:00.000Z', 'project-1', 'zz-readable'
+      ]);
+      sqliteRun(store.getDatabase(), `UPDATE memory_assets SET updated_at = ? WHERE project_hash = ? AND asset_id LIKE 'private-%'`, [
+        '2026-02-01T00:00:00.000Z', 'project-1'
+      ]);
+
+      const listed = await service.list({ projectHash: 'project-1', requesterActorId: 'viewer', limit: 1 });
+      expect(listed).toHaveLength(1);
+      expect(listed[0].assetId).toBe('zz-readable');
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('rolls back an asset mutation when its governance audit cannot be written', async () => {
+    const { store, service } = await createFixture();
+    try {
+      sqliteRun(store.getDatabase(), 'DROP TABLE memory_governance_audit');
+      await expect(service.create({
+        projectHash: 'project-1', requesterActorId: 'owner', assetId: 'must-rollback', assetType: 'memory', title: 'Rollback'
+      })).rejects.toThrow(/memory_governance_audit/);
+
+      const row = sqliteGet<{ count: number }>(
+        store.getDatabase(),
+        `SELECT COUNT(*) AS count FROM memory_assets WHERE project_hash = ? AND asset_id = ?`,
+        ['project-1', 'must-rollback']
+      );
+      expect(row?.count).toBe(0);
+    } finally {
+      await store.close();
+    }
+  });
+});

--- a/tests/core/memory-asset-permissions.test.ts
+++ b/tests/core/memory-asset-permissions.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  checkMemoryAssetPermission,
+  type MemoryAsset,
+  type MemoryAssetBinding,
+  type MemoryAssetGrant
+} from '../../src/core/operations/memory-asset-permissions.js';
+
+const asset: MemoryAsset = {
+  assetId: 'asset-1',
+  projectHash: 'project-1',
+  assetType: 'memory',
+  title: 'Release checklist',
+  ownerActorId: 'owner',
+  version: 1,
+  status: 'active',
+  visibility: 'private',
+  sourceRefs: ['lesson-1'],
+  createdAt: new Date('2026-08-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-08-01T00:00:00.000Z')
+};
+
+const binding: MemoryAssetBinding = {
+  projectHash: 'project-1',
+  assetId: 'asset-1',
+  actorId: 'reader',
+  injectionMode: 'reference',
+  priority: 0,
+  enabled: true,
+  createdAt: new Date('2026-08-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-08-01T00:00:00.000Z')
+};
+
+const grant: MemoryAssetGrant = {
+  projectHash: 'project-1',
+  assetId: 'asset-1',
+  actorId: 'editor',
+  permissions: ['read', 'write'],
+  createdBy: 'owner',
+  createdAt: new Date('2026-08-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-08-01T00:00:00.000Z')
+};
+
+describe('checkMemoryAssetPermission', () => {
+  it('gives the owner every permission', () => {
+    for (const permission of ['read', 'write', 'bind', 'grant'] as const) {
+      expect(checkMemoryAssetPermission({ asset, actorId: 'owner', permission })).toMatchObject({
+        allowed: true,
+        source: 'owner'
+      });
+    }
+  });
+
+  it('limits project/shared visibility to read permission', () => {
+    const visible = { ...asset, visibility: 'project' as const };
+    expect(checkMemoryAssetPermission({ asset: visible, actorId: 'viewer', permission: 'read' })).toMatchObject({
+      allowed: true,
+      source: 'visibility'
+    });
+    expect(checkMemoryAssetPermission({ asset: visible, actorId: 'viewer', permission: 'write' }).allowed).toBe(false);
+  });
+
+  it('lets an enabled binding read a private asset but never mutate it', () => {
+    expect(checkMemoryAssetPermission({ asset, actorId: 'reader', permission: 'read', binding })).toMatchObject({
+      allowed: true,
+      source: 'binding'
+    });
+    expect(checkMemoryAssetPermission({ asset, actorId: 'reader', permission: 'write', binding }).allowed).toBe(false);
+    expect(checkMemoryAssetPermission({
+      asset,
+      actorId: 'reader',
+      permission: 'read',
+      binding: { ...binding, enabled: false }
+    }).allowed).toBe(false);
+  });
+
+  it('applies only permissions present in an explicit grant', () => {
+    expect(checkMemoryAssetPermission({ asset, actorId: 'editor', permission: 'write', grant })).toMatchObject({
+      allowed: true,
+      source: 'grant'
+    });
+    expect(checkMemoryAssetPermission({ asset, actorId: 'editor', permission: 'grant', grant }).allowed).toBe(false);
+  });
+
+  it('uses a generic denial reason that does not disclose policy details', () => {
+    expect(checkMemoryAssetPermission({ asset, actorId: 'stranger', permission: 'read' })).toEqual({
+      allowed: false,
+      permission: 'read',
+      source: 'none',
+      reason: 'permission denied'
+    });
+  });
+});

--- a/tests/core/memory-service-config.test.ts
+++ b/tests/core/memory-service-config.test.ts
@@ -6,11 +6,14 @@ import {
   DEFAULT_ENABLED_SHARED_STORE_CONFIG as CONFIG_DEFAULT_ENABLED_SHARED_STORE_CONFIG,
   DISABLED_MEMORY_OPERATIONS_CONFIG,
   DISABLED_SHARED_STORE_CONFIG as CONFIG_DISABLED_SHARED_STORE_CONFIG,
-  DEFAULT_SHARED_STORAGE_PATH as CONFIG_DEFAULT_SHARED_STORAGE_PATH
+  DEFAULT_SHARED_STORAGE_PATH as CONFIG_DEFAULT_SHARED_STORAGE_PATH,
+  resolveSharedMemoryStoragePath,
+  SHARED_MEMORY_STORAGE_PATH_ENV
 } from '../../src/services/memory-service-config.js';
 import {
   DEFAULT_ENABLED_SHARED_STORE_CONFIG as FACADE_DEFAULT_ENABLED_SHARED_STORE_CONFIG,
-  DISABLED_SHARED_STORE_CONFIG as FACADE_DISABLED_SHARED_STORE_CONFIG
+  DISABLED_SHARED_STORE_CONFIG as FACADE_DISABLED_SHARED_STORE_CONFIG,
+  resolveSharedMemoryStoragePath as facadeResolveSharedMemoryStoragePath
 } from '../../src/services/memory-service.js';
 
 /**
@@ -69,6 +72,17 @@ describe('memory-service-config', () => {
       ...DISABLED_MEMORY_OPERATIONS_CONFIG,
       enabled: true
     });
+  });
+
+  it('allows MCP shared-store tools to use only an explicit absolute override path', () => {
+    expect(facadeResolveSharedMemoryStoragePath).toBe(resolveSharedMemoryStoragePath);
+    expect(resolveSharedMemoryStoragePath({})).toBe(CONFIG_DEFAULT_SHARED_STORAGE_PATH);
+    expect(resolveSharedMemoryStoragePath({
+      [SHARED_MEMORY_STORAGE_PATH_ENV]: '/tmp/cml-shared-store'
+    })).toBe('/tmp/cml-shared-store');
+    expect(() => resolveSharedMemoryStoragePath({
+      [SHARED_MEMORY_STORAGE_PATH_ENV]: 'relative/shared-store'
+    })).toThrow(`${SHARED_MEMORY_STORAGE_PATH_ENV} must be an absolute path`);
   });
 
   it('parses memory operations config defaults without enabling ranking-changing features', () => {

--- a/tests/core/shared-canonical-memory-asset-read-service.test.ts
+++ b/tests/core/shared-canonical-memory-asset-read-service.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { LessonRepository } from '../../src/core/operations/lesson-repository.js';
+import { CoreMemoryBlockRepository } from '../../src/core/operations/core-memory-block-repository.js';
+import { MemoryAssetPermissionService } from '../../src/core/operations/memory-asset-permission-service.js';
+import { SharedCanonicalMemoryAssetReadService } from '../../src/core/operations/shared-canonical-memory-asset-read-service.js';
+import { SQLiteEventStore } from '../../src/core/sqlite-event-store.js';
+
+const tempDirs: string[] = [];
+
+async function createFixture() {
+  const dir = mkdtempSync(join(tmpdir(), 'cml-shared-canonical-read-'));
+  tempDirs.push(dir);
+  const store = new SQLiteEventStore(join(dir, 'events.sqlite'));
+  await store.initialize();
+  return {
+    store,
+    lessons: new LessonRepository(store.getDatabase()),
+    blocks: new CoreMemoryBlockRepository(store.getDatabase()),
+    permissions: new MemoryAssetPermissionService(store.getDatabase()),
+    service: new SharedCanonicalMemoryAssetReadService(store.getDatabase())
+  };
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('SharedCanonicalMemoryAssetReadService', () => {
+  it('returns only active, shared, valid canonical source records', async () => {
+    const { store, lessons, permissions, service } = await createFixture();
+    try {
+      const lesson = await lessons.upsert({
+        projectHash: 'source-project', name: 'Shared deploy', trigger: 'deploy', steps: ['verify'], sourceEventIds: ['event-1']
+      });
+      const assetId = `lesson:${lesson.lessonId}`;
+      await permissions.create({
+        projectHash: 'source-project', requesterActorId: 'owner', assetId, assetType: 'lesson',
+        title: 'Shared deploy', visibility: 'shared', sourceRefs: [assetId]
+      });
+
+      await expect(service.get({
+        projectHash: 'source-project', actorId: 'source-actor', canonicalType: 'lesson', canonicalId: lesson.lessonId
+      })).resolves.toMatchObject({
+        asset: { assetId, visibility: 'shared', status: 'active' },
+        canonicalType: 'lesson',
+        value: { lessonId: lesson.lessonId, steps: ['verify'] }
+      });
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('fails closed for private, inactive, conflicting, and absent canonical records', async () => {
+    const { store, lessons, permissions, service } = await createFixture();
+    try {
+      const lesson = await lessons.upsert({
+        projectHash: 'source-project', name: 'Private deploy', trigger: 'deploy', steps: ['verify'], sourceEventIds: ['event-2']
+      });
+      const assetId = `lesson:${lesson.lessonId}`;
+      await permissions.create({
+        projectHash: 'source-project', requesterActorId: 'owner', assetId, assetType: 'lesson',
+        title: 'Private deploy', visibility: 'private', sourceRefs: [assetId]
+      });
+      await expect(service.get({
+        projectHash: 'source-project', actorId: 'owner', canonicalType: 'lesson', canonicalId: lesson.lessonId
+      })).resolves.toBeNull();
+
+      await permissions.update({
+        projectHash: 'source-project', requesterActorId: 'owner', assetId, visibility: 'shared', status: 'archived'
+      });
+      await expect(service.get({
+        projectHash: 'source-project', actorId: 'owner', canonicalType: 'lesson', canonicalId: lesson.lessonId
+      })).resolves.toBeNull();
+
+      await permissions.create({
+        projectHash: 'source-project', requesterActorId: 'owner', assetId: 'lesson:conflict', assetType: 'wiki',
+        title: 'Conflict', visibility: 'shared', sourceRefs: ['wiki:other']
+      });
+      await expect(service.get({
+        projectHash: 'source-project', actorId: 'owner', canonicalType: 'lesson', canonicalId: 'conflict'
+      })).resolves.toBeNull();
+      await expect(service.get({
+        projectHash: 'source-project', actorId: 'owner', canonicalType: 'lesson', canonicalId: 'missing'
+      })).resolves.toBeNull();
+    } finally {
+      await store.close();
+    }
+  });
+
+  it('loads a shared core-memory block only from its registered source project', async () => {
+    const { store, blocks, permissions, service } = await createFixture();
+    try {
+      await blocks.upsert({
+        projectHash: 'source-project', blockKey: 'project', content: 'Keep deploys reversible',
+        sourceEventIds: ['event-3'], updatedBy: 'owner'
+      });
+      await permissions.create({
+        projectHash: 'source-project', requesterActorId: 'owner', assetId: 'core_memory_block:project',
+        assetType: 'memory', title: 'Project core memory', visibility: 'shared',
+        sourceRefs: ['core_memory_block:project']
+      });
+
+      await expect(service.get({
+        projectHash: 'source-project', actorId: 'source-actor', canonicalType: 'core_memory_block', canonicalId: 'project'
+      })).resolves.toMatchObject({
+        canonicalType: 'core_memory_block', value: { content: 'Keep deploys reversible' }
+      });
+      await expect(service.get({
+        projectHash: 'another-project', actorId: 'source-actor', canonicalType: 'core_memory_block', canonicalId: 'project'
+      })).resolves.toBeNull();
+    } finally {
+      await store.close();
+    }
+  });
+});

--- a/tests/core/sqlite-event-store-operations-schema.test.ts
+++ b/tests/core/sqlite-event-store-operations-schema.test.ts
@@ -112,6 +112,38 @@ describe('SQLiteEventStore memory operations schema', () => {
     expect(indexes).toContain('idx_memory_governance_audit_target');
   });
 
+  it('creates memory asset, actor binding, and explicit grant tables with scoped indexes', async () => {
+    const dbPath = tempDbPath();
+    const store = new SQLiteEventStore(dbPath);
+    await store.initialize();
+
+    const db = new Database(dbPath);
+    const assets = db.prepare(`PRAGMA table_info(memory_assets)`).all().map((row: any) => row.name);
+    const bindings = db.prepare(`PRAGMA table_info(memory_asset_bindings)`).all().map((row: any) => row.name);
+    const grants = db.prepare(`PRAGMA table_info(memory_asset_grants)`).all().map((row: any) => row.name);
+    const assetIndexes = db.prepare(`PRAGMA index_list(memory_assets)`).all().map((row: any) => row.name);
+    const bindingIndexes = db.prepare(`PRAGMA index_list(memory_asset_bindings)`).all().map((row: any) => row.name);
+    const grantIndexes = db.prepare(`PRAGMA index_list(memory_asset_grants)`).all().map((row: any) => row.name);
+    db.close();
+    await store.close();
+
+    expect(assets).toEqual([
+      'asset_id', 'project_hash', 'asset_type', 'title', 'owner_actor_id', 'version',
+      'status', 'visibility', 'source_refs_json', 'metadata_json', 'created_at', 'updated_at'
+    ]);
+    expect(bindings).toEqual([
+      'project_hash', 'asset_id', 'actor_id', 'injection_mode', 'priority', 'enabled', 'created_at', 'updated_at'
+    ]);
+    expect(grants).toEqual([
+      'project_hash', 'asset_id', 'actor_id', 'permissions_json', 'created_by', 'created_at', 'updated_at'
+    ]);
+    expect(assetIndexes).toEqual(expect.arrayContaining([
+      'idx_memory_assets_project_status', 'idx_memory_assets_owner'
+    ]));
+    expect(bindingIndexes).toContain('idx_memory_asset_bindings_actor');
+    expect(grantIndexes).toContain('idx_memory_asset_grants_actor');
+  });
+
   it('creates memory action, lease, and checkpoint projection tables with lookup indexes', async () => {
     const dbPath = tempDbPath();
     const store = new SQLiteEventStore(dbPath);

--- a/tests/extensions/mcp-context-tools.test.ts
+++ b/tests/extensions/mcp-context-tools.test.ts
@@ -135,6 +135,10 @@ describe('MCP project context tools', () => {
     }
 
     const contextPackProperties = byName.get('mem-context-pack')?.inputSchema.properties as Record<string, unknown>;
+    expect(contextPackProperties.requesterActorId).toMatchObject({
+      type: 'string',
+      description: expect.stringContaining('canonical lesson injection')
+    });
     expect(contextPackProperties.refreshLatest).toMatchObject({
       type: 'boolean',
       description: expect.stringContaining('auto-refresh')
@@ -207,6 +211,21 @@ describe('MCP project context tools', () => {
       fredSeries: ['FEDFUNDS'],
       includeSnapshot: true
     }));
+  });
+
+  it('requires a caller identity for context-pack canonical injection in enforced modes', async () => {
+    const previous = process.env.CLAUDE_MEMORY_ASSET_PERMISSION_MODE;
+    process.env.CLAUDE_MEMORY_ASSET_PERMISSION_MODE = 'strict';
+    try {
+      const result = await handleToolCall('mem-context-pack', {
+        projectPath: '/repo/app', query: 'release workflow', refreshLatest: false
+      });
+      expect(result.isError).toBe(true);
+      expect(textOf(result)).toContain('requesterActorId is required');
+    } finally {
+      if (previous === undefined) delete process.env.CLAUDE_MEMORY_ASSET_PERMISSION_MODE;
+      else process.env.CLAUDE_MEMORY_ASSET_PERMISSION_MODE = previous;
+    }
   });
 
   it('rejects invalid external-market-context providers before external fetch or memory initialization', async () => {

--- a/tests/extensions/mcp-operation-tools.test.ts
+++ b/tests/extensions/mcp-operation-tools.test.ts
@@ -65,6 +65,9 @@ const mocks = vi.hoisted(() => {
     setGrant: vi.fn(),
     check: vi.fn()
   };
+  const memoryAssetCatalogService = {
+    sync: vi.fn()
+  };
   const identitySchema = { parse: vi.fn((value: unknown) => value) };
 
   return {
@@ -86,6 +89,7 @@ const mocks = vi.hoisted(() => {
     graphPathService,
     queryEntityExtractor,
     memoryAssetPermissionService,
+    memoryAssetCatalogService,
     FacetRepository: vi.fn(function FacetRepositoryMock() { return facetRepository; }),
     ActionRepository: vi.fn(function ActionRepositoryMock() { return actionRepository; }),
     FrontierService: vi.fn(function FrontierServiceMock() { return frontierService; }),
@@ -95,6 +99,7 @@ const mocks = vi.hoisted(() => {
     GraphPathService: vi.fn(function GraphPathServiceMock() { return graphPathService; }),
     QueryEntityExtractor: vi.fn(function QueryEntityExtractorMock() { return queryEntityExtractor; }),
     MemoryAssetPermissionService: vi.fn(function MemoryAssetPermissionServiceMock() { return memoryAssetPermissionService; }),
+    MemoryAssetCatalogService: vi.fn(function MemoryAssetCatalogServiceMock() { return memoryAssetCatalogService; }),
     identitySchema,
     runRetentionAudit: vi.fn()
   };
@@ -124,6 +129,7 @@ vi.mock('../../src/core/operations/index.js', () => ({
   GraphPathService: mocks.GraphPathService,
   QueryEntityExtractor: mocks.QueryEntityExtractor,
   MemoryAssetPermissionService: mocks.MemoryAssetPermissionService,
+  MemoryAssetCatalogService: mocks.MemoryAssetCatalogService,
   MemoryAssetPermissionSchema: mocks.identitySchema,
   MemoryAssetStatusSchema: mocks.identitySchema,
   MemoryAssetTypeSchema: mocks.identitySchema,
@@ -177,6 +183,7 @@ function resetOperationMocks() {
   mocks.GraphPathService.mockClear();
   mocks.QueryEntityExtractor.mockClear();
   mocks.MemoryAssetPermissionService.mockClear();
+  mocks.MemoryAssetCatalogService.mockClear();
   mocks.runRetentionAudit.mockReset();
 
   mocks.facetRepository.query.mockReset().mockResolvedValue([]);
@@ -271,6 +278,30 @@ function resetOperationMocks() {
     asset,
     decision: { allowed: true, permission: 'read', source: 'grant', reason: 'explicit actor grant' }
   });
+  mocks.memoryAssetCatalogService.sync.mockReset().mockResolvedValue({
+    dryRun: true,
+    projectHash: 'deadbeef',
+    totalCandidates: 1,
+    scanned: 1,
+    truncated: false,
+    planned: 1,
+    created: 0,
+    existing: 0,
+    conflicts: 0,
+    items: [{
+      action: 'create',
+      candidate: {
+        canonicalType: 'lesson',
+        canonicalId: 'lesson-1',
+        assetId: 'lesson:lesson-1',
+        assetType: 'lesson',
+        title: 'Safe deployment order',
+        status: 'active',
+        sourceRefs: ['lesson:lesson-1'],
+        metadata: { canonicalType: 'lesson', canonicalId: 'lesson-1' }
+      }
+    }]
+  });
   mocks.runRetentionAudit.mockReturnValue({
     dryRun: true,
     projectHash: 'deadbeef',
@@ -299,6 +330,7 @@ describe('MCP memory operation tool definitions', () => {
     'mem-asset-create',
     'mem-asset-get',
     'mem-asset-list',
+    'mem-asset-catalog-sync',
     'mem-asset-update',
     'mem-asset-bind',
     'mem-asset-grant-set',
@@ -409,6 +441,18 @@ describe('MCP memory operation tool definitions', () => {
       'projectPath', 'requesterActorId', 'assetId', 'targetActorId', 'permissions'
     ]));
   });
+
+  it('makes canonical asset catalog sync preview-only unless apply is explicit', () => {
+    const properties = propertiesFor('mem-asset-catalog-sync');
+    expect(requiredFor('mem-asset-catalog-sync')).toEqual(expect.arrayContaining([
+      'projectPath', 'requesterActorId'
+    ]));
+    expect(properties.apply).toMatchObject({
+      type: 'boolean',
+      description: expect.stringContaining('Default false')
+    });
+    expect(properties.limit).toMatchObject({ type: 'number', minimum: 1, maximum: 500 });
+  });
 });
 
 describe('MCP memory operation handlers', () => {
@@ -480,6 +524,26 @@ describe('MCP memory operation handlers', () => {
     expect(checked).toMatchObject({
       operation: 'mem-asset-check',
       decision: { allowed: true, source: 'grant' }
+    });
+  });
+
+  it('previews or applies canonical asset catalog registration through the project store', async () => {
+    const preview = jsonOf(await handleToolCall('mem-asset-catalog-sync', {
+      projectPath: '/repo/app', requesterActorId: 'catalog-owner', limit: 12
+    }));
+    expect(mocks.MemoryAssetCatalogService).toHaveBeenCalledWith(mocks.fakeDb);
+    expect(mocks.memoryAssetCatalogService.sync).toHaveBeenCalledWith({
+      projectHash: 'deadbeef', requesterActorId: 'catalog-owner', apply: false, limit: 12
+    });
+    expect(preview).toMatchObject({
+      operation: 'mem-asset-catalog-sync', dryRun: true, planned: 1, created: 0, returnedItems: 1
+    });
+
+    await handleToolCall('mem-asset-catalog-sync', {
+      projectPath: '/repo/app', requesterActorId: 'catalog-owner', apply: true
+    });
+    expect(mocks.memoryAssetCatalogService.sync).toHaveBeenLastCalledWith({
+      projectHash: 'deadbeef', requesterActorId: 'catalog-owner', apply: true, limit: 100
     });
   });
 

--- a/tests/extensions/mcp-operation-tools.test.ts
+++ b/tests/extensions/mcp-operation-tools.test.ts
@@ -394,7 +394,8 @@ describe('MCP memory operation tool definitions', () => {
       'mem-shared-actor-link',
       'mem-shared-actor-status',
       'mem-shared-actor-unlink',
-      'mem-shared-search'
+      'mem-shared-search',
+      'mem-shared-asset-get'
     ];
     const registered = tools.map((tool) => tool.name);
     for (const name of sharedToolNames) {
@@ -404,6 +405,12 @@ describe('MCP memory operation tool definitions', () => {
     expect(requiredFor('mem-shared-actor-link')).toContain('sharedPrincipalId');
     expect(requiredFor('mem-shared-search')).toContain('query');
     expect(String(toolByName('mem-shared-search')?.description)).toContain('explicitly linked');
+    expect(requiredFor('mem-shared-asset-get')).toEqual(expect.arrayContaining([
+      'sourceProjectPath', 'sourceActorId', 'canonicalType', 'canonicalId'
+    ]));
+    expect(propertiesFor('mem-shared-asset-get').canonicalType).toMatchObject({
+      enum: ['lesson', 'core_memory_block']
+    });
   });
 
   it('requires projectPath on all operation tools to avoid cross-project leakage', () => {

--- a/tests/extensions/mcp-operation-tools.test.ts
+++ b/tests/extensions/mcp-operation-tools.test.ts
@@ -56,6 +56,16 @@ const mocks = vi.hoisted(() => {
   const queryEntityExtractor = {
     extract: vi.fn()
   };
+  const memoryAssetPermissionService = {
+    create: vi.fn(),
+    get: vi.fn(),
+    list: vi.fn(),
+    update: vi.fn(),
+    bind: vi.fn(),
+    setGrant: vi.fn(),
+    check: vi.fn()
+  };
+  const identitySchema = { parse: vi.fn((value: unknown) => value) };
 
   return {
     fakeDb,
@@ -75,6 +85,7 @@ const mocks = vi.hoisted(() => {
     lessonService,
     graphPathService,
     queryEntityExtractor,
+    memoryAssetPermissionService,
     FacetRepository: vi.fn(function FacetRepositoryMock() { return facetRepository; }),
     ActionRepository: vi.fn(function ActionRepositoryMock() { return actionRepository; }),
     FrontierService: vi.fn(function FrontierServiceMock() { return frontierService; }),
@@ -83,6 +94,8 @@ const mocks = vi.hoisted(() => {
     LessonService: vi.fn(function LessonServiceMock() { return lessonService; }),
     GraphPathService: vi.fn(function GraphPathServiceMock() { return graphPathService; }),
     QueryEntityExtractor: vi.fn(function QueryEntityExtractorMock() { return queryEntityExtractor; }),
+    MemoryAssetPermissionService: vi.fn(function MemoryAssetPermissionServiceMock() { return memoryAssetPermissionService; }),
+    identitySchema,
     runRetentionAudit: vi.fn()
   };
 });
@@ -110,6 +123,11 @@ vi.mock('../../src/core/operations/index.js', () => ({
   LessonService: mocks.LessonService,
   GraphPathService: mocks.GraphPathService,
   QueryEntityExtractor: mocks.QueryEntityExtractor,
+  MemoryAssetPermissionService: mocks.MemoryAssetPermissionService,
+  MemoryAssetPermissionSchema: mocks.identitySchema,
+  MemoryAssetStatusSchema: mocks.identitySchema,
+  MemoryAssetTypeSchema: mocks.identitySchema,
+  MemoryAssetVisibilitySchema: mocks.identitySchema,
   runRetentionAudit: mocks.runRetentionAudit
 }));
 
@@ -158,6 +176,7 @@ function resetOperationMocks() {
   mocks.LessonService.mockClear();
   mocks.GraphPathService.mockClear();
   mocks.QueryEntityExtractor.mockClear();
+  mocks.MemoryAssetPermissionService.mockClear();
   mocks.runRetentionAudit.mockReset();
 
   mocks.facetRepository.query.mockReset().mockResolvedValue([]);
@@ -223,6 +242,35 @@ function resetOperationMocks() {
     query: 'empty',
     candidates: []
   });
+  const asset = {
+    assetId: 'asset-1',
+    projectHash: 'deadbeef',
+    assetType: 'lesson',
+    title: 'Safe deployment order',
+    ownerActorId: 'owner',
+    version: 1,
+    status: 'active',
+    visibility: 'private',
+    sourceRefs: ['lesson-1'],
+    createdAt: new Date('2026-05-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-05-01T00:00:00.000Z')
+  };
+  mocks.memoryAssetPermissionService.create.mockReset().mockResolvedValue(asset);
+  mocks.memoryAssetPermissionService.get.mockReset().mockResolvedValue(asset);
+  mocks.memoryAssetPermissionService.list.mockReset().mockResolvedValue([asset]);
+  mocks.memoryAssetPermissionService.update.mockReset().mockResolvedValue({ ...asset, version: 2 });
+  mocks.memoryAssetPermissionService.bind.mockReset().mockResolvedValue({
+    projectHash: 'deadbeef', assetId: 'asset-1', actorId: 'agent-a', injectionMode: 'reference', priority: 0, enabled: true,
+    createdAt: new Date('2026-05-01T00:00:00.000Z'), updatedAt: new Date('2026-05-01T00:00:00.000Z')
+  });
+  mocks.memoryAssetPermissionService.setGrant.mockReset().mockResolvedValue({
+    projectHash: 'deadbeef', assetId: 'asset-1', actorId: 'agent-a', permissions: ['read'], createdBy: 'owner',
+    createdAt: new Date('2026-05-01T00:00:00.000Z'), updatedAt: new Date('2026-05-01T00:00:00.000Z')
+  });
+  mocks.memoryAssetPermissionService.check.mockReset().mockReturnValue({
+    asset,
+    decision: { allowed: true, permission: 'read', source: 'grant', reason: 'explicit actor grant' }
+  });
   mocks.runRetentionAudit.mockReturnValue({
     dryRun: true,
     projectHash: 'deadbeef',
@@ -247,7 +295,14 @@ describe('MCP memory operation tool definitions', () => {
     'mem-retention-audit',
     'mem-graph-query',
     'mem-lesson-list',
-    'mem-lesson-save'
+    'mem-lesson-save',
+    'mem-asset-create',
+    'mem-asset-get',
+    'mem-asset-list',
+    'mem-asset-update',
+    'mem-asset-bind',
+    'mem-asset-grant-set',
+    'mem-asset-check'
   ];
 
   it('registers the curated memory operations tool surface exactly once', () => {
@@ -339,6 +394,21 @@ describe('MCP memory operation tool definitions', () => {
     expect(lessonSave.steps).toMatchObject({ type: 'array', maxItems: 100 });
     expect(lessonSave.confidence).toMatchObject({ type: 'number', minimum: 0, maximum: 1 });
   });
+
+  it('requires requester identity and exposes only the four minimal asset permissions', () => {
+    for (const name of operationToolNames.filter((toolName) => toolName.startsWith('mem-asset-'))) {
+      expect(requiredFor(name)).toContain('requesterActorId');
+    }
+    const checkPermission = propertiesFor('mem-asset-check').permission as { enum?: string[] };
+    expect(checkPermission.enum).toEqual(['read', 'write', 'bind', 'grant']);
+    const grantPermissions = propertiesFor('mem-asset-grant-set').permissions as {
+      items?: { enum?: string[] };
+    };
+    expect(grantPermissions.items?.enum).toEqual(['read', 'write', 'bind', 'grant']);
+    expect(requiredFor('mem-asset-grant-set')).toEqual(expect.arrayContaining([
+      'projectPath', 'requesterActorId', 'assetId', 'targetActorId', 'permissions'
+    ]));
+  });
 });
 
 describe('MCP memory operation handlers', () => {
@@ -354,6 +424,118 @@ describe('MCP memory operation handlers', () => {
     expect(mocks.getDefaultMemoryService).not.toHaveBeenCalled();
     expect(mocks.getMemoryServiceForProject).not.toHaveBeenCalled();
     expect(mocks.SQLiteEventStore).not.toHaveBeenCalled();
+  });
+
+  it('routes asset create, grant, and permission explanation through the project permission service', async () => {
+    const created = await handleToolCall('mem-asset-create', {
+      projectPath: '/repo/app',
+      requesterActorId: 'owner',
+      assetType: 'lesson',
+      title: 'Safe deployment order',
+      visibility: 'private',
+      sourceRefs: ['lesson-1']
+    });
+    expect(created.isError).not.toBe(true);
+    expect(mocks.MemoryAssetPermissionService).toHaveBeenCalledWith(mocks.fakeDb);
+    expect(mocks.memoryAssetPermissionService.create).toHaveBeenCalledWith({
+      projectHash: 'deadbeef',
+      requesterActorId: 'owner',
+      assetId: undefined,
+      assetType: 'lesson',
+      title: 'Safe deployment order',
+      status: undefined,
+      visibility: 'private',
+      sourceRefs: ['lesson-1'],
+      metadata: undefined
+    });
+
+    const granted = await handleToolCall('mem-asset-grant-set', {
+      projectPath: '/repo/app',
+      requesterActorId: 'owner',
+      assetId: 'asset-1',
+      targetActorId: 'agent-a',
+      permissions: ['read']
+    });
+    expect(granted.isError).not.toBe(true);
+    expect(mocks.memoryAssetPermissionService.setGrant).toHaveBeenCalledWith({
+      projectHash: 'deadbeef',
+      requesterActorId: 'owner',
+      assetId: 'asset-1',
+      actorId: 'agent-a',
+      permissions: ['read']
+    });
+
+    const checked = jsonOf(await handleToolCall('mem-asset-check', {
+      projectPath: '/repo/app',
+      requesterActorId: 'agent-a',
+      assetId: 'asset-1',
+      permission: 'read'
+    }));
+    expect(mocks.memoryAssetPermissionService.check).toHaveBeenCalledWith({
+      projectHash: 'deadbeef',
+      requesterActorId: 'agent-a',
+      assetId: 'asset-1',
+      permission: 'read'
+    });
+    expect(checked).toMatchObject({
+      operation: 'mem-asset-check',
+      decision: { allowed: true, source: 'grant' }
+    });
+  });
+
+  it('preserves requester principal ids instead of applying output sanitization to authorization input', async () => {
+    const requesterActorId = 'actor:/owner';
+    const result = await handleToolCall('mem-asset-create', {
+      projectPath: '/repo/app',
+      requesterActorId,
+      assetType: 'memory',
+      title: 'Principal identity test'
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(mocks.memoryAssetPermissionService.create).toHaveBeenCalledWith(expect.objectContaining({
+      requesterActorId
+    }));
+  });
+
+  it('rejects malformed asset metadata before invoking the permission service', async () => {
+    const result = await handleToolCall('mem-asset-create', {
+      projectPath: '/repo/app',
+      requesterActorId: 'owner',
+      assetType: 'memory',
+      title: 'Invalid metadata',
+      metadata: 'not-an-object'
+    });
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain('metadata must be an object');
+    expect(mocks.memoryAssetPermissionService.create).not.toHaveBeenCalled();
+  });
+
+  it('redacts sensitive metadata returned by core callers before MCP output', async () => {
+    mocks.memoryAssetPermissionService.get.mockResolvedValue({
+      assetId: 'asset-secret',
+      projectHash: 'deadbeef',
+      assetType: 'memory',
+      title: 'Safe title',
+      ownerActorId: 'owner',
+      version: 1,
+      status: 'active',
+      visibility: 'private',
+      sourceRefs: [],
+      metadata: { apiKey: 'fixture-secret-value', nested: { accessToken: 'another-secret-value' } },
+      createdAt: new Date('2026-05-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-05-01T00:00:00.000Z')
+    });
+
+    const result = await handleToolCall('mem-asset-get', {
+      projectPath: '/repo/app', requesterActorId: 'owner', assetId: 'asset-secret'
+    });
+    const output = textOf(result);
+    expect(result.isError).not.toBe(true);
+    expect(output).toContain('[REDACTED]');
+    expect(output).not.toContain('fixture-secret-value');
+    expect(output).not.toContain('another-secret-value');
   });
 
   it('queries facets through the project operation store and returns compact JSON without raw project paths', async () => {

--- a/tests/extensions/mcp-operation-tools.test.ts
+++ b/tests/extensions/mcp-operation-tools.test.ts
@@ -389,6 +389,23 @@ describe('MCP memory operation tool definitions', () => {
     }
   });
 
+  it('advertises an explicit actor mapping before scoped shared search', () => {
+    const sharedToolNames = [
+      'mem-shared-actor-link',
+      'mem-shared-actor-status',
+      'mem-shared-actor-unlink',
+      'mem-shared-search'
+    ];
+    const registered = tools.map((tool) => tool.name);
+    for (const name of sharedToolNames) {
+      expect(registered.filter((registeredName) => registeredName === name)).toHaveLength(1);
+      expect(requiredFor(name)).toEqual(expect.arrayContaining(['projectPath', 'requesterActorId']));
+    }
+    expect(requiredFor('mem-shared-actor-link')).toContain('sharedPrincipalId');
+    expect(requiredFor('mem-shared-search')).toContain('query');
+    expect(String(toolByName('mem-shared-search')?.description)).toContain('explicitly linked');
+  });
+
   it('requires projectPath on all operation tools to avoid cross-project leakage', () => {
     for (const name of operationToolNames) {
       const properties = propertiesFor(name);

--- a/tests/extensions/mcp-operation-tools.test.ts
+++ b/tests/extensions/mcp-operation-tools.test.ts
@@ -45,7 +45,8 @@ const mocks = vi.hoisted(() => {
     list: vi.fn()
   };
   const lessonRepository = {
-    list: vi.fn()
+    list: vi.fn(),
+    getByProjectAndName: vi.fn()
   };
   const lessonService = {
     saveCurated: vi.fn()
@@ -67,6 +68,18 @@ const mocks = vi.hoisted(() => {
   };
   const memoryAssetCatalogService = {
     sync: vi.fn()
+  };
+  const canonicalMemoryAccessService = {
+    mode: 'legacy' as 'legacy' | 'registered' | 'strict',
+    requireRequester: vi.fn(),
+    requireUnregisteredWrite: vi.fn(),
+    check: vi.fn(),
+    require: vi.fn()
+  };
+  const coreMemoryBlockRepository = {
+    get: vi.fn(),
+    listByProject: vi.fn(),
+    upsert: vi.fn()
   };
   const identitySchema = { parse: vi.fn((value: unknown) => value) };
 
@@ -90,6 +103,8 @@ const mocks = vi.hoisted(() => {
     queryEntityExtractor,
     memoryAssetPermissionService,
     memoryAssetCatalogService,
+    canonicalMemoryAccessService,
+    coreMemoryBlockRepository,
     FacetRepository: vi.fn(function FacetRepositoryMock() { return facetRepository; }),
     ActionRepository: vi.fn(function ActionRepositoryMock() { return actionRepository; }),
     FrontierService: vi.fn(function FrontierServiceMock() { return frontierService; }),
@@ -100,6 +115,8 @@ const mocks = vi.hoisted(() => {
     QueryEntityExtractor: vi.fn(function QueryEntityExtractorMock() { return queryEntityExtractor; }),
     MemoryAssetPermissionService: vi.fn(function MemoryAssetPermissionServiceMock() { return memoryAssetPermissionService; }),
     MemoryAssetCatalogService: vi.fn(function MemoryAssetCatalogServiceMock() { return memoryAssetCatalogService; }),
+    CanonicalMemoryAccessService: vi.fn(function CanonicalMemoryAccessServiceMock() { return canonicalMemoryAccessService; }),
+    CoreMemoryBlockRepository: vi.fn(function CoreMemoryBlockRepositoryMock() { return coreMemoryBlockRepository; }),
     identitySchema,
     runRetentionAudit: vi.fn()
   };
@@ -130,6 +147,8 @@ vi.mock('../../src/core/operations/index.js', () => ({
   QueryEntityExtractor: mocks.QueryEntityExtractor,
   MemoryAssetPermissionService: mocks.MemoryAssetPermissionService,
   MemoryAssetCatalogService: mocks.MemoryAssetCatalogService,
+  CanonicalMemoryAccessService: mocks.CanonicalMemoryAccessService,
+  CoreMemoryBlockRepository: mocks.CoreMemoryBlockRepository,
   MemoryAssetPermissionSchema: mocks.identitySchema,
   MemoryAssetStatusSchema: mocks.identitySchema,
   MemoryAssetTypeSchema: mocks.identitySchema,
@@ -184,6 +203,8 @@ function resetOperationMocks() {
   mocks.QueryEntityExtractor.mockClear();
   mocks.MemoryAssetPermissionService.mockClear();
   mocks.MemoryAssetCatalogService.mockClear();
+  mocks.CanonicalMemoryAccessService.mockClear();
+  mocks.CoreMemoryBlockRepository.mockClear();
   mocks.runRetentionAudit.mockReset();
 
   mocks.facetRepository.query.mockReset().mockResolvedValue([]);
@@ -225,6 +246,7 @@ function resetOperationMocks() {
   });
   mocks.checkpointRepository.list.mockReset().mockResolvedValue([]);
   mocks.lessonRepository.list.mockReset().mockResolvedValue([]);
+  mocks.lessonRepository.getByProjectAndName.mockReset().mockReturnValue(null);
   mocks.lessonService.saveCurated.mockReset().mockResolvedValue({
     lessonId: '33333333-3333-4333-8333-333333333333',
     projectHash: 'deadbeef',
@@ -301,6 +323,28 @@ function resetOperationMocks() {
         metadata: { canonicalType: 'lesson', canonicalId: 'lesson-1' }
       }
     }]
+  });
+  mocks.canonicalMemoryAccessService.mode = 'legacy';
+  mocks.canonicalMemoryAccessService.requireRequester.mockReset();
+  mocks.canonicalMemoryAccessService.requireUnregisteredWrite.mockReset().mockReturnValue({
+    allowed: true, mode: 'legacy', registered: false, source: 'legacy'
+  });
+  mocks.canonicalMemoryAccessService.check.mockReset().mockReturnValue({
+    allowed: true, mode: 'legacy', registered: false, source: 'legacy'
+  });
+  mocks.canonicalMemoryAccessService.require.mockReset().mockReturnValue({
+    allowed: true, mode: 'legacy', registered: false, source: 'legacy'
+  });
+  mocks.coreMemoryBlockRepository.get.mockReset().mockResolvedValue(null);
+  mocks.coreMemoryBlockRepository.listByProject.mockReset().mockResolvedValue([]);
+  mocks.coreMemoryBlockRepository.upsert.mockReset().mockResolvedValue({
+    projectHash: 'deadbeef',
+    blockKey: 'project',
+    content: 'Keep releases reversible',
+    sourceEventIds: [],
+    updatedBy: 'operator',
+    createdAt: new Date('2026-05-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-05-01T00:00:00.000Z')
   });
   mocks.runRetentionAudit.mockReturnValue({
     dryRun: true,
@@ -425,6 +469,14 @@ describe('MCP memory operation tool definitions', () => {
     ]));
     expect(lessonSave.steps).toMatchObject({ type: 'array', maxItems: 100 });
     expect(lessonSave.confidence).toMatchObject({ type: 'number', minimum: 0, maximum: 1 });
+
+    for (const name of ['mem-lesson-list', 'mem-lesson-save', 'mem-core-block-get', 'mem-core-block-update']) {
+      expect(propertiesFor(name).requesterActorId).toMatchObject({
+        type: 'string',
+        description: expect.stringContaining('permission checks')
+      });
+      expect(requiredFor(name)).not.toContain('requesterActorId');
+    }
   });
 
   it('requires requester identity and exposes only the four minimal asset permissions', () => {
@@ -669,6 +721,97 @@ describe('MCP memory operation handlers', () => {
       lesson: { sourceClass: 'curated', name: 'Deploy GPU before API' }
     });
     expect(JSON.stringify(payload)).not.toContain('/repo/app');
+  });
+
+  it('permission-filters registered lessons and reports the server-selected mode', async () => {
+    mocks.canonicalMemoryAccessService.mode = 'registered';
+    mocks.lessonRepository.list.mockResolvedValue([
+      { lessonId: 'lesson-private', projectHash: 'deadbeef', name: 'private', confidence: 1, steps: [], sourceEventIds: [], sourceSessionIds: [], failureModes: [], skillCandidate: false, createdAt: new Date('2026-05-01T00:00:00.000Z'), updatedAt: new Date('2026-05-01T00:00:00.000Z') },
+      { lessonId: 'lesson-readable', projectHash: 'deadbeef', name: 'readable', confidence: 1, steps: [], sourceEventIds: [], sourceSessionIds: [], failureModes: [], skillCandidate: false, createdAt: new Date('2026-05-01T00:00:00.000Z'), updatedAt: new Date('2026-05-01T00:00:00.000Z') }
+    ]);
+    mocks.canonicalMemoryAccessService.check.mockImplementation((input: { canonicalId: string }) => ({
+      allowed: input.canonicalId === 'lesson-readable',
+      mode: 'registered',
+      registered: true,
+      source: input.canonicalId === 'lesson-readable' ? 'grant' : 'none'
+    }));
+
+    const payload = jsonOf(await handleToolCall('mem-lesson-list', {
+      projectPath: '/repo/app', requesterActorId: 'reader', limit: 5
+    }));
+    expect(mocks.canonicalMemoryAccessService.requireRequester).toHaveBeenCalledWith('reader');
+    expect(mocks.lessonRepository.list).toHaveBeenCalledWith({ projectHash: 'deadbeef', limit: 100, offset: 0 });
+    expect(payload).toMatchObject({ operation: 'mem-lesson-list', permissionMode: 'registered', count: 1 });
+    expect(JSON.stringify(payload)).toContain('lesson-readable');
+    expect(JSON.stringify(payload)).not.toContain('lesson-private');
+  });
+
+  it('checks write permission before updating an existing curated lesson', async () => {
+    mocks.canonicalMemoryAccessService.mode = 'registered';
+    mocks.lessonRepository.getByProjectAndName.mockReturnValue({ lessonId: 'lesson-existing' });
+
+    const payload = jsonOf(await handleToolCall('mem-lesson-save', {
+      projectPath: '/repo/app',
+      requesterActorId: 'editor',
+      actor: 'editor',
+      name: 'Deploy GPU before API',
+      trigger: 'When rolling out a runtime split',
+      steps: ['Roll out GPU'],
+      sourceSessionIds: ['session-safe']
+    }));
+    expect(mocks.canonicalMemoryAccessService.require).toHaveBeenCalledWith({
+      projectHash: 'deadbeef', canonicalType: 'lesson', canonicalId: 'lesson-existing',
+      requesterActorId: 'editor', permission: 'write'
+    });
+    expect(mocks.canonicalMemoryAccessService.require.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.lessonService.saveCurated.mock.invocationCallOrder[0]
+    );
+    expect(payload).toMatchObject({ operation: 'mem-lesson-save', permissionMode: 'registered' });
+  });
+
+  it('rejects audit actor spoofing before an enforced canonical write', async () => {
+    mocks.canonicalMemoryAccessService.mode = 'registered';
+    const result = await handleToolCall('mem-lesson-save', {
+      projectPath: '/repo/app', requesterActorId: 'editor', actor: 'someone-else',
+      name: 'Protected lesson', trigger: 'When protected', steps: ['Stop'],
+      sourceSessionIds: ['session-safe']
+    });
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain('actor must match requesterActorId');
+    expect(mocks.lessonService.saveCurated).not.toHaveBeenCalled();
+  });
+
+  it('permission-filters core blocks and gates updates before the canonical write', async () => {
+    mocks.canonicalMemoryAccessService.mode = 'registered';
+    const block = {
+      projectHash: 'deadbeef', blockKey: 'project', content: 'Project private', sourceEventIds: [], updatedBy: 'operator',
+      createdAt: new Date('2026-05-01T00:00:00.000Z'), updatedAt: new Date('2026-05-01T00:00:00.000Z')
+    };
+    const userBlock = { ...block, blockKey: 'user', content: 'User readable' };
+    mocks.coreMemoryBlockRepository.listByProject.mockResolvedValue([block, userBlock]);
+    mocks.canonicalMemoryAccessService.check.mockImplementation((input: { canonicalId: string }) => ({
+      allowed: input.canonicalId === 'user', mode: 'registered', registered: true,
+      source: input.canonicalId === 'user' ? 'binding' : 'none'
+    }));
+
+    const read = jsonOf(await handleToolCall('mem-core-block-get', {
+      projectPath: '/repo/app', requesterActorId: 'reader'
+    }));
+    expect(read).toMatchObject({ operation: 'mem-core-block-get', permissionMode: 'registered' });
+    expect(read.blocks).toEqual([expect.objectContaining({ blockKey: 'user', content: 'User readable' })]);
+
+    const updated = jsonOf(await handleToolCall('mem-core-block-update', {
+      projectPath: '/repo/app', requesterActorId: 'editor', actor: 'editor',
+      blockKey: 'project', content: 'Keep releases reversible'
+    }));
+    expect(mocks.canonicalMemoryAccessService.require).toHaveBeenCalledWith({
+      projectHash: 'deadbeef', canonicalType: 'core_memory_block', canonicalId: 'project',
+      requesterActorId: 'editor', permission: 'write'
+    });
+    expect(mocks.canonicalMemoryAccessService.require.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.coreMemoryBlockRepository.upsert.mock.invocationCallOrder[0]
+    );
+    expect(updated).toMatchObject({ operation: 'mem-core-block-update', permissionMode: 'registered' });
   });
 
   it('routes state-changing tools with actor, projectHash, bounded evidence, and sanitized note metadata', async () => {

--- a/tests/extensions/mcp-perspective-tools.test.ts
+++ b/tests/extensions/mcp-perspective-tools.test.ts
@@ -42,6 +42,7 @@ const mocks = vi.hoisted(() => {
   const actorRepository = { list: vi.fn(), upsert: vi.fn(), get: vi.fn() };
   const actorCardRepository = { get: vi.fn(), upsert: vi.fn() };
   const perspectiveObservationRepository = { query: vi.fn(), create: vi.fn(), deleteSoft: vi.fn() };
+  const canonicalMemoryInjectionService = { select: vi.fn() };
 
   const noopRepository = { query: vi.fn(), assign: vi.fn(), list: vi.fn(), update: vi.fn(), create: vi.fn(), rank: vi.fn(), expand: vi.fn(), extract: vi.fn() };
 
@@ -58,6 +59,7 @@ const mocks = vi.hoisted(() => {
     actorRepository,
     actorCardRepository,
     perspectiveObservationRepository,
+    canonicalMemoryInjectionService,
     ActorRepository: vi.fn(function ActorRepositoryMock() { return actorRepository; }),
     ActorCardRepository: vi.fn(function ActorCardRepositoryMock() { return actorCardRepository; }),
     PerspectiveObservationRepository: vi.fn(function PerspectiveObservationRepositoryMock() { return perspectiveObservationRepository; }),
@@ -68,6 +70,8 @@ const mocks = vi.hoisted(() => {
     LessonRepository: vi.fn(function LessonRepositoryMock() { return noopRepository; }),
     GraphPathService: vi.fn(function GraphPathServiceMock() { return noopRepository; }),
     QueryEntityExtractor: vi.fn(function QueryEntityExtractorMock() { return noopRepository; }),
+    CanonicalMemoryInjectionService: vi.fn(function CanonicalMemoryInjectionServiceMock() { return canonicalMemoryInjectionService; }),
+    resolveCanonicalMemoryPermissionMode: vi.fn(() => 'legacy'),
     runRetentionAudit: vi.fn()
   };
 });
@@ -97,6 +101,8 @@ vi.mock('../../src/core/operations/index.js', () => ({
   LessonRepository: mocks.LessonRepository,
   GraphPathService: mocks.GraphPathService,
   QueryEntityExtractor: mocks.QueryEntityExtractor,
+  CanonicalMemoryInjectionService: mocks.CanonicalMemoryInjectionService,
+  resolveCanonicalMemoryPermissionMode: mocks.resolveCanonicalMemoryPermissionMode,
   RETENTION_POLICY_VERSION: 'retention-policy.v1',
   runRetentionAudit: mocks.runRetentionAudit
 }));
@@ -172,6 +178,9 @@ function resetMocks() {
   mocks.ActorRepository.mockClear();
   mocks.ActorCardRepository.mockClear();
   mocks.PerspectiveObservationRepository.mockClear();
+  mocks.CanonicalMemoryInjectionService.mockClear();
+  mocks.resolveCanonicalMemoryPermissionMode.mockClear().mockReturnValue('legacy');
+  mocks.canonicalMemoryInjectionService.select.mockReset().mockReturnValue({ mode: 'legacy', items: [] });
 
   mocks.actorRepository.list.mockReset().mockResolvedValue([
     {

--- a/tests/extensions/mcp-shared-asset-tools.test.ts
+++ b/tests/extensions/mcp-shared-asset-tools.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+vi.mock('../../src/core/registry/project-path.js', () => ({
+  hashProjectPath: (projectPath: string) => projectPath.endsWith('/source') ? 'source-project' : 'destination-project',
+  getProjectStoragePath: (projectPath: string) => `${projectPath}/.cml-memory`
+}));
+
+import { LessonRepository } from '../../src/core/operations/lesson-repository.js';
+import { MemoryAssetPermissionService } from '../../src/core/operations/memory-asset-permission-service.js';
+import { SQLiteEventStore } from '../../src/core/sqlite-event-store.js';
+import { SHARED_MEMORY_STORAGE_PATH_ENV } from '../../src/services/memory-service-config.js';
+import { handleToolCall } from '../../src/extensions/mcp/handlers.js';
+
+const tempDirs: string[] = [];
+const originalSharedPath = process.env[SHARED_MEMORY_STORAGE_PATH_ENV];
+
+function textOf(result: Awaited<ReturnType<typeof handleToolCall>>): string {
+  return String(result.content[0]?.text ?? '');
+}
+
+function jsonOf(result: Awaited<ReturnType<typeof handleToolCall>>): Record<string, unknown> {
+  return JSON.parse(textOf(result)) as Record<string, unknown>;
+}
+
+afterEach(() => {
+  if (originalSharedPath === undefined) delete process.env[SHARED_MEMORY_STORAGE_PATH_ENV];
+  else process.env[SHARED_MEMORY_STORAGE_PATH_ENV] = originalSharedPath;
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('MCP shared canonical asset reads', () => {
+  it('requires identity mapping and source shared state before returning a lesson', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'cml-mcp-shared-asset-'));
+    tempDirs.push(root);
+    const destinationProjectPath = join(root, 'destination');
+    const sourceProjectPath = join(root, 'source');
+    const sharedStorePath = join(root, 'shared');
+    process.env[SHARED_MEMORY_STORAGE_PATH_ENV] = sharedStorePath;
+
+    const sourceStore = new SQLiteEventStore(join(sourceProjectPath, '.cml-memory', 'events.sqlite'));
+    await sourceStore.initialize();
+    try {
+      const lessons = new LessonRepository(sourceStore.getDatabase());
+      const permissions = new MemoryAssetPermissionService(sourceStore.getDatabase());
+      const lesson = await lessons.upsert({
+        projectHash: 'source-project',
+        name: 'Shared deploy order', trigger: 'deployment', steps: ['verify first'], sourceEventIds: ['event-1']
+      });
+      const assetId = `lesson:${lesson.lessonId}`;
+      await permissions.create({
+        projectHash: lesson.projectHash!, requesterActorId: 'source-owner', assetId, assetType: 'lesson',
+        title: lesson.name, visibility: 'shared', sourceRefs: [assetId]
+      });
+
+      await handleToolCall('mem-shared-actor-link', {
+        projectPath: destinationProjectPath, requesterActorId: 'destination-actor', sharedPrincipalId: 'principal-a'
+      });
+      await handleToolCall('mem-shared-actor-link', {
+        projectPath: sourceProjectPath, requesterActorId: 'source-actor', sharedPrincipalId: 'principal-a'
+      });
+
+      const allowed = jsonOf(await handleToolCall('mem-shared-asset-get', {
+        projectPath: destinationProjectPath,
+        requesterActorId: 'destination-actor',
+        sourceProjectPath,
+        sourceActorId: 'source-actor',
+        canonicalType: 'lesson',
+        canonicalId: lesson.lessonId
+      }));
+      expect(allowed).toMatchObject({
+        operation: 'mem-shared-asset-get', found: true,
+        asset: { asset: { assetId, visibility: 'shared' }, canonical: { lessonId: lesson.lessonId } }
+      });
+
+      const wrongActor = jsonOf(await handleToolCall('mem-shared-asset-get', {
+        projectPath: destinationProjectPath,
+        requesterActorId: 'destination-actor',
+        sourceProjectPath,
+        sourceActorId: 'other-source-actor',
+        canonicalType: 'lesson',
+        canonicalId: lesson.lessonId
+      }));
+      expect(wrongActor).toEqual(expect.objectContaining({ found: false }));
+
+      await permissions.update({
+        projectHash: lesson.projectHash!, requesterActorId: 'source-owner', assetId, visibility: 'private'
+      });
+      const privateAsset = jsonOf(await handleToolCall('mem-shared-asset-get', {
+        projectPath: destinationProjectPath,
+        requesterActorId: 'destination-actor',
+        sourceProjectPath,
+        sourceActorId: 'source-actor',
+        canonicalType: 'lesson',
+        canonicalId: lesson.lessonId
+      }));
+      expect(privateAsset).toEqual(expect.objectContaining({ found: false }));
+    } finally {
+      await sourceStore.close();
+    }
+  });
+});

--- a/tests/extensions/mcp-shared-asset-tools.test.ts
+++ b/tests/extensions/mcp-shared-asset-tools.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -11,6 +11,7 @@ vi.mock('../../src/core/registry/project-path.js', () => ({
 import { LessonRepository } from '../../src/core/operations/lesson-repository.js';
 import { MemoryAssetPermissionService } from '../../src/core/operations/memory-asset-permission-service.js';
 import { SQLiteEventStore } from '../../src/core/sqlite-event-store.js';
+import { createSQLiteDatabase, sqliteClose, sqliteRun } from '../../src/core/sqlite-wrapper.js';
 import { SHARED_MEMORY_STORAGE_PATH_ENV } from '../../src/services/memory-service-config.js';
 import { handleToolCall } from '../../src/extensions/mcp/handlers.js';
 
@@ -100,5 +101,77 @@ describe('MCP shared canonical asset reads', () => {
     } finally {
       await sourceStore.close();
     }
+  });
+
+  it('returns found false when the source database predates the asset schema', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'cml-mcp-shared-asset-legacy-'));
+    tempDirs.push(root);
+    const destinationProjectPath = join(root, 'destination');
+    const sourceProjectPath = join(root, 'source');
+    process.env[SHARED_MEMORY_STORAGE_PATH_ENV] = join(root, 'shared');
+
+    await handleToolCall('mem-shared-actor-link', {
+      projectPath: destinationProjectPath, requesterActorId: 'destination-actor', sharedPrincipalId: 'principal-a'
+    });
+    await handleToolCall('mem-shared-actor-link', {
+      projectPath: sourceProjectPath, requesterActorId: 'source-actor', sharedPrincipalId: 'principal-a'
+    });
+
+    const sourceStoragePath = join(sourceProjectPath, '.cml-memory');
+    mkdirSync(sourceStoragePath, { recursive: true });
+    const legacyDb = createSQLiteDatabase(join(sourceStoragePath, 'events.sqlite'));
+    sqliteRun(legacyDb, `CREATE TABLE legacy_events (event_id TEXT PRIMARY KEY)`);
+    sqliteClose(legacyDb);
+
+    const result = await handleToolCall('mem-shared-asset-get', {
+      projectPath: destinationProjectPath,
+      requesterActorId: 'destination-actor',
+      sourceProjectPath,
+      sourceActorId: 'source-actor',
+      canonicalType: 'lesson',
+      canonicalId: 'legacy-lesson'
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(jsonOf(result)).toEqual(expect.objectContaining({ found: false }));
+    expect(textOf(result)).not.toContain('no such table');
+  });
+
+  it('does not create shared storage for status, search, unlink, or asset reads', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'cml-mcp-shared-readonly-'));
+    tempDirs.push(root);
+    const destinationProjectPath = join(root, 'destination');
+    const sourceProjectPath = join(root, 'source');
+    const sharedStorePath = join(root, 'shared');
+    process.env[SHARED_MEMORY_STORAGE_PATH_ENV] = sharedStorePath;
+
+    const status = jsonOf(await handleToolCall('mem-shared-actor-status', {
+      projectPath: destinationProjectPath, requesterActorId: 'destination-actor'
+    }));
+    const search = jsonOf(await handleToolCall('mem-shared-search', {
+      projectPath: destinationProjectPath, requesterActorId: 'destination-actor', query: 'timeout'
+    }));
+    const unlink = jsonOf(await handleToolCall('mem-shared-actor-unlink', {
+      projectPath: destinationProjectPath, requesterActorId: 'destination-actor'
+    }));
+    const asset = jsonOf(await handleToolCall('mem-shared-asset-get', {
+      projectPath: destinationProjectPath,
+      requesterActorId: 'destination-actor',
+      sourceProjectPath,
+      sourceActorId: 'source-actor',
+      canonicalType: 'lesson',
+      canonicalId: 'missing'
+    }));
+
+    expect(status).toEqual(expect.objectContaining({ linked: false }));
+    expect(search).toEqual(expect.objectContaining({ linked: false, count: 0, entries: [] }));
+    expect(unlink).toEqual(expect.objectContaining({ unlinked: false }));
+    expect(asset).toEqual(expect.objectContaining({ found: false }));
+    expect(existsSync(sharedStorePath)).toBe(false);
+
+    await handleToolCall('mem-shared-actor-link', {
+      projectPath: destinationProjectPath, requesterActorId: 'destination-actor', sharedPrincipalId: 'principal-a'
+    });
+    expect(existsSync(join(sharedStorePath, 'shared.duckdb'))).toBe(true);
   });
 });

--- a/tests/extensions/shared-memory-actor-adapter.test.ts
+++ b/tests/extensions/shared-memory-actor-adapter.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import { createSharedEventStore } from '../../src/core/shared-event-store.js';
+import { createSharedStore } from '../../src/core/shared-store.js';
+import { SharedMemoryActorAdapter } from '../../src/extensions/shared-memory/shared-memory-actor-adapter.js';
+
+async function createFixture() {
+  const eventStore = createSharedEventStore(':memory:');
+  await eventStore.initialize();
+  const store = createSharedStore(eventStore);
+  const adapter = new SharedMemoryActorAdapter(store);
+  return { eventStore, store, adapter };
+}
+
+async function promote(store: ReturnType<typeof createSharedStore>, projectHash: string, sourceEntryId: string, title: string) {
+  await store.promoteEntry({
+    sourceProjectHash: projectHash,
+    sourceEntryId,
+    title,
+    symptoms: ['timeout'],
+    rootCause: 'stale cache',
+    solution: 'clear cache',
+    topics: ['cache'],
+    confidence: 0.9
+  });
+}
+
+describe('SharedMemoryActorAdapter', () => {
+  it('returns only entries from explicitly linked projects', async () => {
+    const { eventStore, store, adapter } = await createFixture();
+    try {
+      await promote(store, 'project-a', 'entry-a', 'Project A timeout');
+      await promote(store, 'project-b', 'entry-b', 'Project B timeout');
+      await promote(store, 'project-c', 'entry-c', 'Project C timeout');
+
+      await adapter.link({ projectHash: 'project-a', actorId: 'alice', sharedPrincipalId: 'principal-alice' });
+      await adapter.link({ projectHash: 'project-b', actorId: 'alice', sharedPrincipalId: 'principal-alice' });
+
+      const result = await adapter.search({
+        projectHash: 'project-a', actorId: 'alice', query: 'timeout', topK: 10
+      });
+
+      expect(result.identity).toMatchObject({
+        projectHash: 'project-a', actorId: 'alice', sharedPrincipalId: 'principal-alice'
+      });
+      expect(result.sourceProjectHashes).toEqual(['project-a', 'project-b']);
+      expect(result.entries.map((entry) => entry.sourceProjectHash)).toEqual(['project-a', 'project-b']);
+    } finally {
+      await eventStore.close();
+    }
+  });
+
+  it('fails closed when the requester has no explicit identity link', async () => {
+    const { eventStore, store, adapter } = await createFixture();
+    try {
+      await promote(store, 'project-a', 'entry-a', 'Project A timeout');
+      await adapter.link({ projectHash: 'project-a', actorId: 'alice', sharedPrincipalId: 'principal-alice' });
+
+      await expect(adapter.search({
+        projectHash: 'project-a', actorId: 'unlinked', query: 'timeout'
+      })).resolves.toEqual({ identity: null, sourceProjectHashes: [], entries: [] });
+    } finally {
+      await eventStore.close();
+    }
+  });
+
+  it('revokes a prior principal on relink or unlink', async () => {
+    const { eventStore, store, adapter } = await createFixture();
+    try {
+      await promote(store, 'project-a', 'entry-a', 'Project A timeout');
+      await adapter.link({ projectHash: 'project-a', actorId: 'alice', sharedPrincipalId: 'principal-old' });
+      await adapter.link({ projectHash: 'project-b', actorId: 'alice', sharedPrincipalId: 'principal-old' });
+      await adapter.link({ projectHash: 'project-a', actorId: 'alice', sharedPrincipalId: 'principal-new' });
+
+      expect(await store.listProjectHashesForPrincipal('principal-old')).toEqual(['project-b']);
+      expect(await store.listProjectHashesForPrincipal('principal-new')).toEqual(['project-a']);
+      await expect(adapter.unlink({ projectHash: 'project-a', actorId: 'alice' })).resolves.toBe(true);
+      await expect(adapter.unlink({ projectHash: 'project-a', actorId: 'alice' })).resolves.toBe(false);
+      await expect(adapter.status({ projectHash: 'project-a', actorId: 'alice' })).resolves.toBeNull();
+    } finally {
+      await eventStore.close();
+    }
+  });
+});

--- a/tests/extensions/shared-memory-actor-adapter.test.ts
+++ b/tests/extensions/shared-memory-actor-adapter.test.ts
@@ -12,7 +12,13 @@ async function createFixture() {
   return { eventStore, store, adapter };
 }
 
-async function promote(store: ReturnType<typeof createSharedStore>, projectHash: string, sourceEntryId: string, title: string) {
+async function promote(
+  store: ReturnType<typeof createSharedStore>,
+  projectHash: string,
+  sourceEntryId: string,
+  title: string,
+  confidence = 0.9
+) {
   await store.promoteEntry({
     sourceProjectHash: projectHash,
     sourceEntryId,
@@ -21,7 +27,7 @@ async function promote(store: ReturnType<typeof createSharedStore>, projectHash:
     rootCause: 'stale cache',
     solution: 'clear cache',
     topics: ['cache'],
-    confidence: 0.9
+    confidence
   });
 }
 
@@ -64,6 +70,22 @@ describe('SharedMemoryActorAdapter', () => {
     }
   });
 
+  it('honors an explicit zero minimum confidence', async () => {
+    const { eventStore, store, adapter } = await createFixture();
+    try {
+      await promote(store, 'project-a', 'entry-low', 'Low confidence timeout', 0.2);
+      await adapter.link({ projectHash: 'project-a', actorId: 'alice', sharedPrincipalId: 'principal-alice' });
+
+      const result = await adapter.search({
+        projectHash: 'project-a', actorId: 'alice', query: 'timeout', minConfidence: 0
+      });
+
+      expect(result.entries.map((entry) => entry.sourceEntryId)).toEqual(['entry-low']);
+    } finally {
+      await eventStore.close();
+    }
+  });
+
   it('requires the explicitly named source actor to share the requester principal', async () => {
     const { eventStore, adapter } = await createFixture();
     try {
@@ -95,6 +117,21 @@ describe('SharedMemoryActorAdapter', () => {
       await expect(adapter.unlink({ projectHash: 'project-a', actorId: 'alice' })).resolves.toBe(true);
       await expect(adapter.unlink({ projectHash: 'project-a', actorId: 'alice' })).resolves.toBe(false);
       await expect(adapter.status({ projectHash: 'project-a', actorId: 'alice' })).resolves.toBeNull();
+
+      const auditRows = eventStore.getDatabase().prepare(
+        `SELECT operation, before_shared_principal_id, after_shared_principal_id
+         FROM shared_actor_identity_audit
+         WHERE project_hash = ? AND actor_id = ? ORDER BY created_at ASC, rowid ASC`
+      ).all('project-a', 'alice') as Array<{
+        operation: string;
+        before_shared_principal_id: string | null;
+        after_shared_principal_id: string | null;
+      }>;
+      expect(auditRows).toEqual([
+        { operation: 'link', before_shared_principal_id: null, after_shared_principal_id: 'principal-old' },
+        { operation: 'relink', before_shared_principal_id: 'principal-old', after_shared_principal_id: 'principal-new' },
+        { operation: 'unlink', before_shared_principal_id: 'principal-new', after_shared_principal_id: null }
+      ]);
     } finally {
       await eventStore.close();
     }

--- a/tests/extensions/shared-memory-actor-adapter.test.ts
+++ b/tests/extensions/shared-memory-actor-adapter.test.ts
@@ -64,6 +64,24 @@ describe('SharedMemoryActorAdapter', () => {
     }
   });
 
+  it('requires the explicitly named source actor to share the requester principal', async () => {
+    const { eventStore, adapter } = await createFixture();
+    try {
+      await adapter.link({ projectHash: 'project-a', actorId: 'alice', sharedPrincipalId: 'principal-alice' });
+      await adapter.link({ projectHash: 'project-b', actorId: 'alice-source', sharedPrincipalId: 'principal-alice' });
+      await adapter.link({ projectHash: 'project-b', actorId: 'bob-source', sharedPrincipalId: 'principal-bob' });
+
+      await expect(adapter.sharesPrincipalWith({
+        projectHash: 'project-a', actorId: 'alice', sourceProjectHash: 'project-b', sourceActorId: 'alice-source'
+      })).resolves.toBe(true);
+      await expect(adapter.sharesPrincipalWith({
+        projectHash: 'project-a', actorId: 'alice', sourceProjectHash: 'project-b', sourceActorId: 'bob-source'
+      })).resolves.toBe(false);
+    } finally {
+      await eventStore.close();
+    }
+  });
+
   it('revokes a prior principal on relink or unlink', async () => {
     const { eventStore, store, adapter } = await createFixture();
     try {


### PR DESCRIPTION
## Summary
- add explicit project actor-to-shared-principal mappings and actor-scoped shared troubleshooting search
- add read-only cross-project canonical lesson/core-memory lookup through the mem-shared-asset-get MCP tool
- revalidate same-principal source actor, source asset registration, active/shared state, source read policy, and live canonical source
- add dashboard Configuration controls to inspect and unlink a selected project actor mapping without exposing or storing the opaque shared principal
- fail closed for pre-asset-schema source databases and avoid creating shared storage from read-only MCP operations
- audit link, relink, and unlink transitions atomically in the shared store and preserve explicit zero confidence filters
- honor the injected environment consistently for permission mode and fallback actor resolution
- keep legacy shared retrieval and automatic injection unchanged

## Verification
- npm run test:run (194 files, 1242 tests)
- npm run typecheck
- npm run lint (0 errors; 44 existing warnings)
- npm run check:architecture
- npm run check:public-output-privacy
- npm run build