### PR TITLE
feat: automate Codex session memory ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Claude Memory Layer는 AI 에이전트의 대화와 작업 이벤트를 프로�
 npm install -g claude-memory-layer@latest
 claude-memory-layer install
 claude-memory-layer status
+
+# Codex에서도 자동 컨텍스트 적재/불러오기를 사용할 때
+claude-memory-layer codex hooks install
+claude-memory-layer codex hooks status
 ```
 
 로컬 개발 checkout에서 설치할 때:
@@ -55,9 +59,10 @@ npx claude-memory-layer status
 ```
 
 - `install`은 **한 번만** 하면 됩니다(Claude Code hooks 등록).
+- `codex hooks install`은 `~/.codex/hooks.json`에 SessionStart/SessionEnd 훅을 병합합니다. Codex를 재시작한 뒤 `/hooks`에서 새 훅 정의를 검토하고 신뢰해야 실행됩니다.
 - Embedding backend은 런타임 필수 기능이며, postinstall이 패키지 내부의 격리된 관리 디렉터리에 설치합니다. 이 경계에서 `sharp` 보안 버전을 강제하고, CUDA 11 환경에서는 `onnxruntime-node`를 CPU-only로 설치합니다.
 - 이후 프로젝트별로 메모리 저장소가 자동 분리됩니다.
-- `install` / `uninstall`은 `~/.claude/settings.json`을 수정합니다.
+- `install` / `uninstall`은 `~/.claude/settings.json`을, `codex hooks install` / `uninstall`은 `~/.codex/hooks.json`을 수정합니다. 기존의 다른 훅은 보존합니다.
 
 #### CUDA 11 / `onnxruntime-node` 설치 에러
 
@@ -323,7 +328,7 @@ MCP client가 환경에 따라 PATH를 못 찾으면 `command -v claude-memory-l
 - **Citations System**: 검색 결과를 `[mem:abc123]` 형태로 추적하고 `source`/`mem-source-ref`로 근거 확인
 - **Source Neighbor Expansion**: `mem-source-ref(includeNeighbors=true, neighborWindow=1..5)`로 MemPalace식 hit 주변 세션 이벤트를 privacy-safe preview로 함께 확인
 - **Progressive Disclosure**: index → timeline → details 순서로 필요한 만큼만 확장해 토큰 비용 절감
-- **Codex/Hermes Importers**: read-only validate/replay 후 explicit import로만 mutation 수행
+- **Codex/Hermes Importers**: read-only validate/replay와 explicit import 지원; Codex는 사용자가 설치한 lifecycle hook을 통한 프로젝트별 자동 import도 지원
 - **Perspective Query Agent**: 관점별 observation + raw memory를 읽기 전용으로 조합하고 source refs를 유지
 - **Governance Audit**: facet/action/checkpoint/perspective mutation은 actor/evidence metadata와 함께 기록
 - **Privacy Guardrails**: `<private>` 태그, credential/path redaction, aggregate-only dashboard/API/CLI 출력
@@ -341,7 +346,7 @@ MCP client가 환경에 따라 PATH를 못 찾으면 `command -v claude-memory-l
 | Vector Outbox V2 | Implemented | transactional enqueue, worker lock, stale recovery, `vector-status`, dashboard Vector Health |
 | Progressive disclosure / retrieval traces | Implemented | `search --disclosure`, `expand`, `source`, score breakdown, privacy-safe lanes, aggregate-only strategy/context-pack telemetry |
 | MCP server | Implemented | package bin `claude-memory-layer-mcp`, project-aware read tools + audited operation tools |
-| Codex/Hermes session ingestion | Implemented | validate/replay는 read-only, import는 명시적 mutation |
+| Codex/Hermes session ingestion | Implemented | validate/replay는 read-only, explicit import 지원; Codex는 opt-in SessionEnd 자동 import 지원 |
 | Memory Operations layer | Implemented | facets/actions/frontier/checkpoints/retention/graph/lessons |
 | Perspective Memory | Implemented P0/P1 | actors, actor cards, perspective observations, context-pack lanes, aggregate dashboard |
 | Dashboard | Implemented | local-only default bind, optional password, vector/perspective/trace panels |
@@ -807,7 +812,7 @@ Embeddings processed: 342
 
 ### Codex 세션 임포트
 
-Codex CLI 기록(`~/.codex/sessions`)은 기본적으로 read-only validate/replay로 먼저 확인하고, 명시적 import 명령으로만 메모리에 저장합니다:
+Codex CLI 기록(`~/.codex/sessions`)은 기본적으로 read-only validate/replay로 먼저 확인하고, 명시적 import 명령으로 메모리에 저장할 수 있습니다:
 
 ```bash
 # 읽기 전용 검증/리포트
@@ -825,6 +830,27 @@ npx claude-memory-layer codex import --all --verbose
 ```
 
 옵션: `--sessions-dir`, `--limit`, `--force`, `--no-process-embeddings`.
+
+#### Codex 자동 적재와 자동 컨텍스트 주입
+
+Codex lifecycle hook을 opt-in으로 설치하면 프로젝트별 자동 메모리를 사용할 수 있습니다.
+
+```bash
+# 최초 1회
+claude-memory-layer codex hooks install
+
+# Codex를 재시작하고 /hooks에서 정의를 검토·신뢰한 뒤 상태 확인
+claude-memory-layer codex hooks status --project /path/to/project
+
+# 제거 시 다른 Codex 훅은 보존되고 CML 훅만 제거됨
+claude-memory-layer codex hooks uninstall
+```
+
+- `SessionStart`: 해당 프로젝트의 core memory와 최근 작업 컨텍스트를 Codex에 주입합니다. 새 세션뿐 아니라 resume/clear/compact에도 적용됩니다.
+- `SessionEnd`: 완료된 현재 transcript 하나만 별도 worker에 전달해 프로젝트 저장소로 적재합니다. Codex 종료, 대화 archive/delete, 또는 열려 있지 않은 대화의 30분 유휴 종료 시 실행됩니다.
+- 자동 import는 콘텐츠 해시로 중복을 건너뛰며, embedding 계산은 hook 제한 시간 밖의 기존 vector worker가 처리합니다.
+- `codex hooks status --project <path>`는 해당 프로젝트의 마지막 자동 import 성공/실패 시각과 집계 결과를 보여줍니다. transcript 본문은 상태 파일에 기록하지 않습니다.
+- Codex transcript 형식은 Codex의 안정된 공개 API가 아니므로, `codex validate`와 importer 회귀 테스트를 함께 유지해야 합니다.
 
 ### Hermes 세션 임포트
 

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -79,6 +79,9 @@ async function build() {
     'post-tool-use',
     'stop',
     'session-end',
+    'codex-session-start',
+    'codex-session-end',
+    'codex-session-import-worker',
     'semantic-daemon'
   ];
 

--- a/src/adapters/codex/hooks/session-end.ts
+++ b/src/adapters/codex/hooks/session-end.ts
@@ -1,0 +1,76 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import * as nodeUrl from 'node:url';
+import * as path from 'node:path';
+
+import { readStdin } from '../../claude/hooks/hook-runtime.js';
+
+export interface CodexSessionEndHookInput {
+  session_id: string;
+  transcript_path: string | null;
+  cwd: string;
+  hook_event_name?: string;
+}
+
+export interface CodexSessionImportJob {
+  transcriptPath: string;
+  projectPath: string;
+}
+
+export interface CodexSessionEndHookDeps {
+  spawnWorker: (
+    executable: string,
+    args: string[],
+    options: {
+      detached: boolean;
+      stdio: ['pipe', 'ignore', 'ignore'];
+    }
+  ) => Pick<ChildProcess, 'stdin' | 'unref'>;
+  workerPath: string;
+}
+
+function defaultWorkerPath(): string {
+  return path.join(path.dirname(nodeUrl.fileURLToPath(import.meta.url)), 'codex-session-import-worker.js');
+}
+
+const realDeps: CodexSessionEndHookDeps = {
+  spawnWorker: spawn,
+  workerPath: defaultWorkerPath()
+};
+
+export function normalizeCodexSessionImportJob(input: CodexSessionEndHookInput): CodexSessionImportJob | null {
+  const transcriptPath = typeof input.transcript_path === 'string' ? input.transcript_path.trim() : '';
+  const projectPath = typeof input.cwd === 'string' ? input.cwd.trim() : '';
+  if (!transcriptPath || !projectPath || !path.isAbsolute(projectPath)) return null;
+  return { transcriptPath, projectPath };
+}
+
+export function launchCodexSessionImport(
+  input: CodexSessionEndHookInput,
+  deps: CodexSessionEndHookDeps = realDeps
+): boolean {
+  const job = normalizeCodexSessionImportJob(input);
+  if (!job) return false;
+
+  const child = deps.spawnWorker(process.execPath, [deps.workerPath], {
+    detached: process.platform !== 'win32',
+    stdio: ['pipe', 'ignore', 'ignore']
+  });
+  child.stdin?.on('error', () => {
+    // Codex must not fail its lifecycle when a detached worker exits early.
+  });
+  child.stdin?.end(JSON.stringify(job));
+  child.unref();
+  return true;
+}
+
+export async function main(): Promise<string> {
+  try {
+    const input = JSON.parse(await readStdin()) as CodexSessionEndHookInput;
+    launchCodexSessionImport(input);
+  } catch (error) {
+    if (process.env.CLAUDE_MEMORY_DEBUG) {
+      console.error('Codex memory hook error:', error);
+    }
+  }
+  return JSON.stringify({});
+}

--- a/src/apps/cli/codex-hooks-config.ts
+++ b/src/apps/cli/codex-hooks-config.ts
@@ -1,0 +1,187 @@
+import * as path from 'node:path';
+
+import { shellQuotePathForNode } from './claude-settings-hooks.js';
+
+export interface CodexHookCommand {
+  type: string;
+  command?: string;
+  commandWindows?: string;
+  timeout?: number;
+  statusMessage?: string;
+  additionalContextLimit?: number;
+  [key: string]: unknown;
+}
+
+export interface CodexHookEntry {
+  matcher?: string;
+  hooks: CodexHookCommand[];
+  [key: string]: unknown;
+}
+
+export interface CodexHooksConfig {
+  description?: string;
+  hooks?: Record<string, CodexHookEntry[] | undefined>;
+  [key: string]: unknown;
+}
+
+export const REQUIRED_CODEX_HOOK_FILES = [
+  'codex-session-start.js',
+  'codex-session-end.js',
+  'codex-session-import-worker.js'
+] as const;
+
+const CODEX_HOOK_FILES = {
+  SessionStart: 'codex-session-start.js',
+  SessionEnd: 'codex-session-end.js'
+} as const;
+
+export type CodexMemoryHookName = keyof typeof CODEX_HOOK_FILES;
+
+export function buildCodexHookCommand(pluginPath: string, fileName: string): string {
+  const absolutePluginPath = path.resolve(pluginPath);
+  return `node ${shellQuotePathForNode(path.join(absolutePluginPath, 'hooks', fileName))}`;
+}
+
+export function buildCodexHookWindowsCommand(pluginPath: string, fileName: string): string {
+  const absolutePluginPath = path.resolve(pluginPath);
+  return `node "${path.join(absolutePluginPath, 'hooks', fileName).replace(/"/g, '""')}"`;
+}
+
+export function getCodexMemoryHooks(pluginPath: string): Record<CodexMemoryHookName, CodexHookEntry[]> {
+  return {
+    SessionStart: [
+      {
+        matcher: 'startup|resume|clear|compact',
+        hooks: [
+          {
+            type: 'command',
+            command: buildCodexHookCommand(pluginPath, CODEX_HOOK_FILES.SessionStart),
+            commandWindows: buildCodexHookWindowsCommand(pluginPath, CODEX_HOOK_FILES.SessionStart),
+            statusMessage: 'Loading project memory',
+            additionalContextLimit: 5000
+          }
+        ]
+      }
+    ],
+    SessionEnd: [
+      {
+        hooks: [
+          {
+            type: 'command',
+            command: buildCodexHookCommand(pluginPath, CODEX_HOOK_FILES.SessionEnd),
+            commandWindows: buildCodexHookWindowsCommand(pluginPath, CODEX_HOOK_FILES.SessionEnd),
+            statusMessage: 'Saving session memory',
+            timeout: 3
+          }
+        ]
+      }
+    ]
+  };
+}
+
+export function isCodexMemoryHookCommand(command: string | undefined, pluginPath?: string): boolean {
+  if (!command) return false;
+  const normalized = command.replace(/\\/g, '/');
+  const normalizedPluginPath = pluginPath?.replace(/\\/g, '/').replace(/\/$/, '');
+
+  return Object.values(CODEX_HOOK_FILES).some((fileName) => {
+    if (normalizedPluginPath && normalized.includes(`${normalizedPluginPath}/hooks/${fileName}`)) {
+      return true;
+    }
+    return normalized.includes('claude-memory-layer') && normalized.includes(`/hooks/${fileName}`);
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Validate only the structural fields we mutate, preserving newer Codex fields. */
+export function parseCodexHooksConfig(value: unknown): CodexHooksConfig {
+  if (!isRecord(value)) {
+    throw new Error('Codex hooks config must be a JSON object');
+  }
+  if (value.hooks === undefined) return value as CodexHooksConfig;
+  if (!isRecord(value.hooks)) {
+    throw new Error('Codex hooks config "hooks" must be a JSON object');
+  }
+
+  for (const [eventName, entries] of Object.entries(value.hooks)) {
+    if (!Array.isArray(entries)) {
+      throw new Error(`Codex hooks config "hooks.${eventName}" must be an array`);
+    }
+    for (const [entryIndex, entry] of entries.entries()) {
+      if (!isRecord(entry) || !Array.isArray(entry.hooks)) {
+        throw new Error(`Codex hooks config "hooks.${eventName}[${entryIndex}].hooks" must be an array`);
+      }
+      for (const [hookIndex, hook] of entry.hooks.entries()) {
+        if (!isRecord(hook)) {
+          throw new Error(`Codex hook "hooks.${eventName}[${entryIndex}].hooks[${hookIndex}]" must be a JSON object`);
+        }
+        if (hook.command !== undefined && typeof hook.command !== 'string') {
+          throw new Error(`Codex hook "hooks.${eventName}[${entryIndex}].hooks[${hookIndex}].command" must be a string`);
+        }
+      }
+    }
+  }
+  return value as CodexHooksConfig;
+}
+
+export function removeCodexMemoryHooks<T extends CodexHooksConfig>(config: T, pluginPath?: string): T {
+  const next = { ...config };
+  if (!config.hooks) return next;
+
+  const hooks = { ...config.hooks };
+  for (const hookName of Object.keys(CODEX_HOOK_FILES) as CodexMemoryHookName[]) {
+    const entries = hooks[hookName] ?? [];
+    const cleaned = entries
+      .map((entry) => ({
+        ...entry,
+        hooks: (entry.hooks ?? []).filter((hook) => (
+          !isCodexMemoryHookCommand(hook.command, pluginPath)
+          && !isCodexMemoryHookCommand(hook.commandWindows, pluginPath)
+        ))
+      }))
+      .filter((entry) => entry.hooks.length > 0);
+
+    if (cleaned.length > 0) {
+      hooks[hookName] = cleaned;
+    } else {
+      delete hooks[hookName];
+    }
+  }
+
+  if (Object.keys(hooks).length > 0) {
+    next.hooks = hooks;
+  } else {
+    delete next.hooks;
+  }
+  return next;
+}
+
+export function mergeCodexMemoryHooks<T extends CodexHooksConfig>(config: T, pluginPath: string): T {
+  const cleaned = removeCodexMemoryHooks(config, pluginPath);
+  const next = { ...cleaned, hooks: { ...(cleaned.hooks ?? {}) } };
+  const pluginHooks = getCodexMemoryHooks(pluginPath);
+
+  for (const hookName of Object.keys(CODEX_HOOK_FILES) as CodexMemoryHookName[]) {
+    next.hooks[hookName] = [
+      ...(next.hooks[hookName] ?? []),
+      ...pluginHooks[hookName]
+    ];
+  }
+  return next;
+}
+
+export function hasCodexMemoryHook(
+  config: CodexHooksConfig,
+  hookName: CodexMemoryHookName,
+  pluginPath?: string
+): boolean {
+  return (config.hooks?.[hookName] ?? []).some((entry) => (
+    entry.hooks.some((hook) => (
+      isCodexMemoryHookCommand(hook.command, pluginPath)
+      || isCodexMemoryHookCommand(hook.commandWindows, pluginPath)
+    ))
+  ));
+}

--- a/src/apps/cli/index.ts
+++ b/src/apps/cli/index.ts
@@ -76,6 +76,14 @@ import {
   type ClaudeSettingsWithHooks
 } from './claude-settings-hooks.js';
 import {
+  hasCodexMemoryHook,
+  mergeCodexMemoryHooks,
+  parseCodexHooksConfig,
+  removeCodexMemoryHooks,
+  REQUIRED_CODEX_HOOK_FILES,
+  type CodexHooksConfig
+} from './codex-hooks-config.js';
+import {
   formatCodexValidationReport,
   writeCodexValidationReport,
   type CodexValidationReportFormat
@@ -86,6 +94,7 @@ import {
   type HermesValidationReportFormat
 } from './hermes-validation-output.js';
 import { runCodexImportOnce } from './codex-import-runner.js';
+import { readCodexAutoImportStatus } from '../../services/codex-session-auto-import.js';
 import { runHermesImportOnce } from './hermes-import-runner.js';
 import { resolveDashboardCommandOptions } from './dashboard-command.js';
 import {
@@ -155,6 +164,7 @@ import { WorkerLock } from '../../core/worker-lock.js';
 // ============================================================
 
 const CLAUDE_SETTINGS_PATH = path.join(os.homedir(), '.claude', 'settings.json');
+const CODEX_HOOKS_PATH = path.join(os.homedir(), '.codex', 'hooks.json');
 
 type ClaudeSettings = ClaudeSettingsWithHooks;
 
@@ -199,6 +209,29 @@ function saveClaudeSettings(settings: ClaudeSettings): void {
   const tempPath = CLAUDE_SETTINGS_PATH + '.tmp';
   fs.writeFileSync(tempPath, JSON.stringify(settings, null, 2));
   fs.renameSync(tempPath, CLAUDE_SETTINGS_PATH);
+}
+
+function loadCodexHooksConfig(configPath = CODEX_HOOKS_PATH): CodexHooksConfig {
+  try {
+    if (fs.existsSync(configPath)) {
+      return parseCodexHooksConfig(JSON.parse(fs.readFileSync(configPath, 'utf-8')));
+    }
+  } catch (error) {
+    throw new Error(`Could not read Codex hooks config at ${configPath}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  return {};
+}
+
+function saveCodexHooksConfig(config: CodexHooksConfig, configPath = CODEX_HOOKS_PATH): void {
+  const dir = path.dirname(configPath);
+  fs.mkdirSync(dir, { recursive: true });
+  const tempPath = `${configPath}.${process.pid}.tmp`;
+  try {
+    fs.writeFileSync(tempPath, `${JSON.stringify(config, null, 2)}\n`);
+    fs.renameSync(tempPath, configPath);
+  } finally {
+    if (fs.existsSync(tempPath)) fs.unlinkSync(tempPath);
+  }
 }
 
 type CodexValidateCommandOptions = {
@@ -2528,7 +2561,112 @@ program
 
 const codexCmd = program
   .command('codex')
-  .description('Read-only Codex session scan/replay validation');
+  .description('Codex session import, validation, and lifecycle hook integration');
+
+const codexHooksCmd = codexCmd
+  .command('hooks')
+  .description('Manage Codex lifecycle hooks for automatic memory loading and ingestion');
+
+codexHooksCmd
+  .command('install')
+  .description('Install Codex SessionStart and SessionEnd memory hooks')
+  .option('--path <path>', 'Custom plugin path (defaults to auto-detect)')
+  .option('--config-path <path>', 'Codex hooks config path (default: ~/.codex/hooks.json)')
+  .action(async (options: { path?: string; configPath?: string }) => {
+    try {
+      const pluginPath = path.resolve(options.path || getPluginPath());
+      const configPath = options.configPath || CODEX_HOOKS_PATH;
+      const missingHooks = REQUIRED_CODEX_HOOK_FILES.filter((file) => (
+        !fs.existsSync(path.join(pluginPath, 'hooks', file))
+      ));
+      if (missingHooks.length > 0) {
+        throw new Error(`Codex hook files not found at ${pluginPath}; missing: ${missingHooks.join(', ')}`);
+      }
+
+      const config = loadCodexHooksConfig(configPath);
+      saveCodexHooksConfig(mergeCodexMemoryHooks(config, pluginPath), configPath);
+
+      console.log('\n✅ Codex automatic memory hooks installed!\n');
+      console.log('  SessionStart: Load project memory into Codex context');
+      console.log('  SessionEnd: Import the completed Codex transcript');
+      console.log(`  Config: ${configPath}`);
+      console.log(`  Plugin path: ${pluginPath}`);
+      console.log('\n⚠️  Restart Codex, open /hooks, and trust the new hook definitions.\n');
+    } catch (error) {
+      console.error('Codex hooks install failed:', error instanceof Error ? error.message : error);
+      process.exitCode = 1;
+    }
+  });
+
+codexHooksCmd
+  .command('status')
+  .description('Check Codex automatic memory hook status')
+  .option('--path <path>', 'Custom plugin path (defaults to auto-detect)')
+  .option('--config-path <path>', 'Codex hooks config path (default: ~/.codex/hooks.json)')
+  .option('-p, --project <path>', 'Project whose most recent automatic import status should be shown (default: cwd)')
+  .action(async (options: { path?: string; configPath?: string; project?: string }) => {
+    try {
+      const pluginPath = path.resolve(options.path || getPluginPath());
+      const configPath = options.configPath || CODEX_HOOKS_PATH;
+      const config = loadCodexHooksConfig(configPath);
+      const sessionStart = hasCodexMemoryHook(config, 'SessionStart', pluginPath);
+      const sessionEnd = hasCodexMemoryHook(config, 'SessionEnd', pluginPath);
+      const filesExist = REQUIRED_CODEX_HOOK_FILES.every((file) => (
+        fs.existsSync(path.join(pluginPath, 'hooks', file))
+      ));
+
+      console.log('\n🧠 Codex Automatic Memory Status\n');
+      console.log(`  SessionStart: ${sessionStart ? '✅ Installed' : '❌ Not installed'}`);
+      console.log(`  SessionEnd: ${sessionEnd ? '✅ Installed' : '❌ Not installed'}`);
+      console.log(`  Hook files: ${filesExist ? '✅ Found' : '❌ Not found'}`);
+      console.log(`  Config: ${configPath}`);
+      const importStatus = readCodexAutoImportStatus(path.resolve(options.project || process.cwd()));
+      if (importStatus) {
+        const counts = importStatus.status === 'success'
+          ? ` · ${importStatus.importedPrompts ?? 0} prompts · ${importStatus.importedResponses ?? 0} responses · ${importStatus.skippedDuplicates ?? 0} duplicates`
+          : ` · ${importStatus.error ?? 'unknown error'}`;
+        console.log(`  Last auto-import: ${importStatus.status === 'success' ? '✅' : '❌'} ${importStatus.status} at ${importStatus.updatedAt}${counts}`);
+      } else {
+        console.log('  Last auto-import: — No recorded run for this project');
+      }
+      if (sessionStart && sessionEnd && filesExist) {
+        console.log('\n✅ Automatic loading and ingestion are configured. Verify trust with /hooks in Codex.\n');
+      } else {
+        console.log('\n💡 Run "claude-memory-layer codex hooks install" to configure automatic memory.\n');
+      }
+    } catch (error) {
+      console.error('Codex hooks status failed:', error instanceof Error ? error.message : error);
+      process.exitCode = 1;
+    }
+  });
+
+codexHooksCmd
+  .command('uninstall')
+  .description('Remove only claude-memory-layer hooks from Codex')
+  .option('--path <path>', 'Custom plugin path (defaults to auto-detect)')
+  .option('--config-path <path>', 'Codex hooks config path (default: ~/.codex/hooks.json)')
+  .action(async (options: { path?: string; configPath?: string }) => {
+    try {
+      const pluginPath = path.resolve(options.path || getPluginPath());
+      const configPath = options.configPath || CODEX_HOOKS_PATH;
+      if (!fs.existsSync(configPath)) {
+        console.log('\n📋 No Codex memory hooks installed.\n');
+        return;
+      }
+      const config = loadCodexHooksConfig(configPath);
+      const nextConfig = removeCodexMemoryHooks(config, pluginPath);
+      if (Object.keys(nextConfig).length === 0) {
+        fs.unlinkSync(configPath);
+      } else {
+        saveCodexHooksConfig(nextConfig, configPath);
+      }
+      console.log('\n✅ Claude Memory Layer hooks removed from Codex.\n');
+      console.log('Memory data was preserved. Restart Codex for the change to take effect.\n');
+    } catch (error) {
+      console.error('Codex hooks uninstall failed:', error instanceof Error ? error.message : error);
+      process.exitCode = 1;
+    }
+  });
 
 codexCmd
   .command('validate')

--- a/src/hooks/codex-session-end.ts
+++ b/src/hooks/codex-session-end.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+import { main } from '../adapters/codex/hooks/session-end.js';
+import { runHook } from '../adapters/claude/hooks/hook-runtime.js';
+
+void runHook({ name: 'codex-session-end', fallbackOutput: '{}', timeoutMs: 2_500 }, main);

--- a/src/hooks/codex-session-import-worker.ts
+++ b/src/hooks/codex-session-import-worker.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+import { readStdin } from '../adapters/claude/hooks/hook-runtime.js';
+import { importCodexSessionAtEnd, type CodexSessionAutoImportInput } from '../services/codex-session-auto-import.js';
+
+async function main(): Promise<void> {
+  try {
+    const input = JSON.parse(await readStdin()) as CodexSessionAutoImportInput;
+    if (!input.transcriptPath || !input.projectPath) return;
+    await importCodexSessionAtEnd(input);
+  } catch (error) {
+    if (process.env.CLAUDE_MEMORY_DEBUG) {
+      console.error('Codex session import worker error:', error);
+    }
+  }
+}
+
+void main();

--- a/src/hooks/codex-session-start.ts
+++ b/src/hooks/codex-session-start.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+/**
+ * Codex and Claude Code currently share the SessionStart input/output envelope.
+ * Keep a Codex-specific executable path so installation, trust, and removal do
+ * not rely on identifying a generic Claude hook filename.
+ */
+import { main } from '../adapters/claude/hooks/session-start.js';
+import { runHook } from '../adapters/claude/hooks/hook-runtime.js';
+
+void runHook({
+  name: 'codex-session-start',
+  fallbackOutput: '{"hookSpecificOutput":{"hookEventName":"SessionStart"}}'
+}, main);

--- a/src/services/codex-session-auto-import.ts
+++ b/src/services/codex-session-auto-import.ts
@@ -1,0 +1,168 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { getProjectStoragePath } from '../core/registry/project-path.js';
+import {
+  createCodexSessionHistoryImporter,
+  type CodexSessionHistoryImporter,
+  type CodexSessionHistoryImporterOptions
+} from './codex-session-history-importer.js';
+import {
+  getMemoryServiceForProject,
+  type MemoryService
+} from './memory-service.js';
+import type { ImportResult } from './session-history-importer.js';
+
+export interface CodexSessionAutoImportInput {
+  transcriptPath: string;
+  projectPath: string;
+}
+
+export interface CodexSessionAutoImportResult {
+  result: ImportResult;
+}
+
+export interface CodexAutoImportStatus {
+  status: 'success' | 'failed';
+  updatedAt: string;
+  importedPrompts?: number;
+  importedResponses?: number;
+  skippedDuplicates?: number;
+  error?: string;
+}
+
+export interface CodexSessionAutoImportDeps {
+  getMemoryServiceForProject: (projectPath: string) => MemoryService;
+  createImporter: (
+    memoryService: MemoryService,
+    options?: CodexSessionHistoryImporterOptions
+  ) => Pick<CodexSessionHistoryImporter, 'importSessionFile'>;
+  statTranscript: (transcriptPath: string) => Pick<fs.Stats, 'isFile'>;
+  writeStatus: (projectPath: string, status: CodexAutoImportStatus) => void;
+}
+
+const realDeps: CodexSessionAutoImportDeps = {
+  getMemoryServiceForProject,
+  createImporter: createCodexSessionHistoryImporter,
+  statTranscript: fs.statSync,
+  writeStatus: writeCodexAutoImportStatus
+};
+
+export function getCodexAutoImportStatusPath(projectPath: string): string {
+  return path.join(getProjectStoragePath(projectPath), 'codex-auto-import-status.json');
+}
+
+export function writeCodexAutoImportStatus(projectPath: string, status: CodexAutoImportStatus): void {
+  const statusPath = getCodexAutoImportStatusPath(projectPath);
+  fs.mkdirSync(path.dirname(statusPath), { recursive: true });
+  const tempPath = `${statusPath}.${process.pid}.tmp`;
+  try {
+    fs.writeFileSync(tempPath, `${JSON.stringify(status, null, 2)}\n`);
+    fs.renameSync(tempPath, statusPath);
+  } finally {
+    if (fs.existsSync(tempPath)) fs.unlinkSync(tempPath);
+  }
+}
+
+export function readCodexAutoImportStatus(projectPath: string): CodexAutoImportStatus | null {
+  try {
+    const value = JSON.parse(fs.readFileSync(getCodexAutoImportStatusPath(projectPath), 'utf8')) as Partial<CodexAutoImportStatus>;
+    if ((value.status !== 'success' && value.status !== 'failed') || typeof value.updatedAt !== 'string') return null;
+    return value as CodexAutoImportStatus;
+  } catch {
+    return null;
+  }
+}
+
+function statusError(error: unknown): string {
+  return (error instanceof Error ? error.message : String(error)).replace(/\s+/g, ' ').slice(0, 500);
+}
+
+function writeStatusBestEffort(
+  deps: CodexSessionAutoImportDeps,
+  projectPath: string,
+  status: CodexAutoImportStatus
+): void {
+  try {
+    deps.writeStatus(projectPath, status);
+  } catch {
+    // Status is diagnostic only and must never change import success/failure.
+  }
+}
+
+/**
+ * Import one completed Codex transcript without doing embedding work in the
+ * short-lived hook worker. Appends enqueue their own vector work; the regular
+ * semantic daemon processes that queue independently.
+ */
+export async function importCodexSessionAtEnd(
+  input: CodexSessionAutoImportInput,
+  deps: CodexSessionAutoImportDeps = realDeps
+): Promise<CodexSessionAutoImportResult> {
+  if (!path.isAbsolute(input.projectPath)) {
+    throw new Error('Codex auto-import requires an absolute project path');
+  }
+  let transcriptStat: Pick<fs.Stats, 'isFile'>;
+  try {
+    transcriptStat = deps.statTranscript(input.transcriptPath);
+  } catch (error) {
+    writeStatusBestEffort(deps, input.projectPath, {
+      status: 'failed',
+      updatedAt: new Date().toISOString(),
+      error: 'Codex auto-import transcript does not exist'
+    });
+    throw new Error('Codex auto-import transcript does not exist', { cause: error });
+  }
+  if (!transcriptStat.isFile()) {
+    writeStatusBestEffort(deps, input.projectPath, {
+      status: 'failed',
+      updatedAt: new Date().toISOString(),
+      error: 'Codex auto-import transcript must be a file'
+    });
+    throw new Error('Codex auto-import transcript must be a file');
+  }
+
+  const memoryService = deps.getMemoryServiceForProject(input.projectPath);
+  const importer = deps.createImporter(memoryService);
+  let operationFailed = false;
+
+  try {
+    await memoryService.initialize();
+    await memoryService.ensureEmbeddingModelForImport({ autoMigrate: true });
+    const result = await importer.importSessionFile(input.transcriptPath, {
+      projectPath: input.projectPath
+    });
+    if (result.errors.length > 0) {
+      throw new Error(`Codex transcript import reported ${result.errors.length} error(s): ${result.errors[0]}`);
+    }
+    writeStatusBestEffort(deps, input.projectPath, {
+      status: 'success',
+      updatedAt: new Date().toISOString(),
+      importedPrompts: result.importedPrompts,
+      importedResponses: result.importedResponses,
+      skippedDuplicates: result.skippedDuplicates
+    });
+    return { result };
+  } catch (error) {
+    operationFailed = true;
+    writeStatusBestEffort(deps, input.projectPath, {
+      status: 'failed',
+      updatedAt: new Date().toISOString(),
+      error: statusError(error)
+    });
+    throw error;
+  } finally {
+    try {
+      await memoryService.shutdown();
+    } catch (error) {
+      if (!operationFailed) {
+        writeStatusBestEffort(deps, input.projectPath, {
+          status: 'failed',
+          updatedAt: new Date().toISOString(),
+          error: statusError(error)
+        });
+        throw error;
+      }
+    }
+  }
+}

--- a/tests/adapters/codex-session-end-hook.test.ts
+++ b/tests/adapters/codex-session-end-hook.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  launchCodexSessionImport,
+  normalizeCodexSessionImportJob,
+  type CodexSessionEndHookInput
+} from '../../src/adapters/codex/hooks/session-end.js';
+
+const validInput: CodexSessionEndHookInput = {
+  session_id: 'thr-123',
+  transcript_path: '/tmp/codex/rollout.jsonl',
+  cwd: '/repo/project',
+  hook_event_name: 'SessionEnd'
+};
+
+describe('Codex SessionEnd hook', () => {
+  it('normalizes the official Codex hook fields into a project-scoped import job', () => {
+    expect(normalizeCodexSessionImportJob(validInput)).toEqual({
+      transcriptPath: '/tmp/codex/rollout.jsonl',
+      projectPath: '/repo/project'
+    });
+  });
+
+  it('ignores missing transcripts and non-absolute project scopes', () => {
+    expect(normalizeCodexSessionImportJob({ ...validInput, transcript_path: null })).toBeNull();
+    expect(normalizeCodexSessionImportJob({ ...validInput, cwd: 'relative/project' })).toBeNull();
+  });
+
+  it('hands work to a detached worker and closes the payload pipe', () => {
+    const on = vi.fn();
+    const end = vi.fn();
+    const unref = vi.fn();
+    const spawnWorker = vi.fn(() => ({ stdin: { on, end }, unref }));
+
+    const launched = launchCodexSessionImport(validInput, {
+      spawnWorker: spawnWorker as never,
+      workerPath: '/plugin/hooks/codex-session-import-worker.js'
+    });
+
+    expect(launched).toBe(true);
+    expect(spawnWorker).toHaveBeenCalledWith(
+      process.execPath,
+      ['/plugin/hooks/codex-session-import-worker.js'],
+      {
+        detached: process.platform !== 'win32',
+        stdio: ['pipe', 'ignore', 'ignore']
+      }
+    );
+    expect(on).toHaveBeenCalledWith('error', expect.any(Function));
+    expect(JSON.parse(end.mock.calls[0][0])).toEqual({
+      transcriptPath: '/tmp/codex/rollout.jsonl',
+      projectPath: '/repo/project'
+    });
+    expect(unref).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/apps/codex-hooks-config.test.ts
+++ b/tests/apps/codex-hooks-config.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildCodexHookCommand,
+  buildCodexHookWindowsCommand,
+  getCodexMemoryHooks,
+  hasCodexMemoryHook,
+  mergeCodexMemoryHooks,
+  parseCodexHooksConfig,
+  removeCodexMemoryHooks,
+  type CodexHooksConfig
+} from '../../src/apps/cli/codex-hooks-config.js';
+
+describe('Codex memory hook config', () => {
+  it('builds lifecycle hooks with the Codex timeout and context limits', () => {
+    const hooks = getCodexMemoryHooks('/tmp/cml dist');
+
+    expect(buildCodexHookCommand('/tmp/cml dist', 'codex-session-start.js'))
+      .toBe("node '/tmp/cml dist/hooks/codex-session-start.js'");
+    expect(buildCodexHookWindowsCommand('/tmp/cml dist', 'codex-session-start.js'))
+      .toBe('node "/tmp/cml dist/hooks/codex-session-start.js"');
+    expect(hooks.SessionStart[0]).toMatchObject({
+      matcher: 'startup|resume|clear|compact',
+      hooks: [{
+        command: "node '/tmp/cml dist/hooks/codex-session-start.js'",
+        commandWindows: 'node "/tmp/cml dist/hooks/codex-session-start.js"',
+        additionalContextLimit: 5000
+      }]
+    });
+    expect(hooks.SessionEnd[0]).toMatchObject({
+      hooks: [{
+        command: "node '/tmp/cml dist/hooks/codex-session-end.js'",
+        timeout: 3
+      }]
+    });
+  });
+
+  it('resolves relative plugin paths because Codex runs hooks from the session cwd', () => {
+    expect(buildCodexHookCommand('relative-dist', 'codex-session-end.js'))
+      .toBe(`node '${process.cwd()}/relative-dist/hooks/codex-session-end.js'`);
+  });
+
+  it('rejects malformed config structures before installation can overwrite them', () => {
+    expect(() => parseCodexHooksConfig([])).toThrow('must be a JSON object');
+    expect(() => parseCodexHooksConfig({ hooks: [] })).toThrow('"hooks" must be a JSON object');
+    expect(() => parseCodexHooksConfig({ hooks: { SessionEnd: {} } }))
+      .toThrow('"hooks.SessionEnd" must be an array');
+    expect(() => parseCodexHooksConfig({ hooks: { SessionEnd: [{ hooks: [{ command: 42 }] }] } }))
+      .toThrow('.command" must be a string');
+    expect(parseCodexHooksConfig({ hooks: { SessionEnd: [{ hooks: [{ type: 'prompt' }] }] } }))
+      .toBeTruthy();
+  });
+
+  it('merges idempotently while preserving unrelated Codex hooks and top-level config', () => {
+    const original: CodexHooksConfig = {
+      description: 'personal hooks',
+      custom: { keep: true },
+      hooks: {
+        SessionStart: [{ hooks: [{ type: 'command', command: 'node /other/start.js' }] }],
+        Stop: [{ hooks: [{ type: 'command', command: 'node /other/stop.js' }] }]
+      }
+    };
+
+    const once = mergeCodexMemoryHooks(original, '/opt/claude-memory-layer/dist');
+    const twice = mergeCodexMemoryHooks(once, '/opt/claude-memory-layer/dist');
+
+    expect(twice).toEqual(once);
+    expect(twice.custom).toEqual({ keep: true });
+    expect(twice.hooks?.SessionStart?.[0].hooks[0].command).toBe('node /other/start.js');
+    expect(twice.hooks?.Stop).toEqual(original.hooks?.Stop);
+    expect(hasCodexMemoryHook(twice, 'SessionStart', '/opt/claude-memory-layer/dist')).toBe(true);
+    expect(hasCodexMemoryHook(twice, 'SessionEnd', '/opt/claude-memory-layer/dist')).toBe(true);
+  });
+
+  it('removes only claude-memory-layer handlers, including mixed matcher groups', () => {
+    const config: CodexHooksConfig = {
+      hooks: {
+        SessionEnd: [{
+          matcher: 'other',
+          hooks: [
+            {
+              type: 'command',
+              command: 'node /opt/claude-memory-layer/dist/hooks/codex-session-end.js',
+              commandWindows: 'node "C:\\other\\end.js"'
+            },
+            { type: 'command', command: 'node /other/end.js' }
+          ]
+        }],
+        UserPromptSubmit: [{ hooks: [{ type: 'command', command: 'node /other/prompt.js' }] }]
+      }
+    };
+
+    const removed = removeCodexMemoryHooks(config, '/opt/claude-memory-layer/dist');
+
+    expect(removed.hooks?.SessionEnd).toEqual([{
+      matcher: 'other',
+      hooks: [{ type: 'command', command: 'node /other/end.js' }]
+    }]);
+    expect(removed.hooks?.UserPromptSubmit).toEqual(config.hooks?.UserPromptSubmit);
+  });
+});

--- a/tests/services/codex-session-auto-import.test.ts
+++ b/tests/services/codex-session-auto-import.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { importCodexSessionAtEnd } from '../../src/services/codex-session-auto-import.js';
+import type { ImportResult } from '../../src/services/session-history-importer.js';
+
+function result(): ImportResult {
+  return {
+    totalSessions: 1,
+    totalMessages: 4,
+    importedPrompts: 1,
+    importedResponses: 1,
+    skippedDuplicates: 0,
+    errors: []
+  };
+}
+
+describe('Codex session automatic import', () => {
+  it('imports only the completed transcript into its project store without embedding in the hook worker', async () => {
+    const memoryService = {
+      initialize: vi.fn(async () => undefined),
+      ensureEmbeddingModelForImport: vi.fn(async () => ({ changed: false })),
+      shutdown: vi.fn(async () => undefined)
+    };
+    const importer = {
+      importSessionFile: vi.fn(async () => result())
+    };
+    const getMemoryServiceForProject = vi.fn(() => memoryService);
+    const createImporter = vi.fn(() => importer);
+    const writeStatus = vi.fn();
+
+    const outcome = await importCodexSessionAtEnd({
+      transcriptPath: '/tmp/codex/rollout.jsonl',
+      projectPath: '/repo/project'
+    }, {
+      getMemoryServiceForProject: getMemoryServiceForProject as never,
+      createImporter: createImporter as never,
+      statTranscript: () => ({ isFile: () => true }),
+      writeStatus
+    });
+
+    expect(getMemoryServiceForProject).toHaveBeenCalledWith('/repo/project');
+    expect(memoryService.initialize).toHaveBeenCalledTimes(1);
+    expect(memoryService.ensureEmbeddingModelForImport).toHaveBeenCalledWith({ autoMigrate: true });
+    expect(importer.importSessionFile).toHaveBeenCalledWith('/tmp/codex/rollout.jsonl', {
+      projectPath: '/repo/project'
+    });
+    expect(memoryService.shutdown).toHaveBeenCalledTimes(1);
+    expect(writeStatus).toHaveBeenCalledWith('/repo/project', expect.objectContaining({
+      status: 'success',
+      importedPrompts: 1,
+      importedResponses: 1
+    }));
+    expect(outcome.result.importedResponses).toBe(1);
+  });
+
+  it('always closes the project service when import fails', async () => {
+    const memoryService = {
+      initialize: vi.fn(async () => undefined),
+      ensureEmbeddingModelForImport: vi.fn(async () => ({ changed: false })),
+      shutdown: vi.fn(async () => undefined)
+    };
+    const importer = {
+      importSessionFile: vi.fn(async () => { throw new Error('broken transcript'); })
+    };
+    const writeStatus = vi.fn();
+
+    await expect(importCodexSessionAtEnd({
+      transcriptPath: '/tmp/codex/rollout.jsonl',
+      projectPath: '/repo/project'
+    }, {
+      getMemoryServiceForProject: (() => memoryService) as never,
+      createImporter: (() => importer) as never,
+      statTranscript: () => ({ isFile: () => true }),
+      writeStatus
+    })).rejects.toThrow('broken transcript');
+
+    expect(memoryService.shutdown).toHaveBeenCalledTimes(1);
+    expect(writeStatus).toHaveBeenCalledWith('/repo/project', expect.objectContaining({
+      status: 'failed',
+      error: 'broken transcript'
+    }));
+  });
+
+  it('does not initialize project storage when the transcript is missing', async () => {
+    const getMemoryServiceForProject = vi.fn();
+    const writeStatus = vi.fn();
+
+    await expect(importCodexSessionAtEnd({
+      transcriptPath: '/tmp/codex/missing.jsonl',
+      projectPath: '/repo/project'
+    }, {
+      getMemoryServiceForProject: getMemoryServiceForProject as never,
+      createImporter: vi.fn() as never,
+      statTranscript: () => { throw new Error('ENOENT'); },
+      writeStatus
+    })).rejects.toThrow('transcript does not exist');
+
+    expect(getMemoryServiceForProject).not.toHaveBeenCalled();
+    expect(writeStatus).toHaveBeenCalledWith('/repo/project', expect.objectContaining({ status: 'failed' }));
+  });
+
+  it('treats importer error results as failed automatic imports', async () => {
+    const memoryService = {
+      initialize: vi.fn(async () => undefined),
+      ensureEmbeddingModelForImport: vi.fn(async () => ({ changed: false })),
+      shutdown: vi.fn(async () => undefined)
+    };
+    const writeStatus = vi.fn();
+
+    await expect(importCodexSessionAtEnd({
+      transcriptPath: '/tmp/codex/rollout.jsonl',
+      projectPath: '/repo/project'
+    }, {
+      getMemoryServiceForProject: (() => memoryService) as never,
+      createImporter: (() => ({ importSessionFile: async () => resultWithErrors() })) as never,
+      statTranscript: () => ({ isFile: () => true }),
+      writeStatus
+    })).rejects.toThrow('reported 1 error');
+
+    expect(writeStatus).toHaveBeenCalledWith('/repo/project', expect.objectContaining({ status: 'failed' }));
+    expect(memoryService.shutdown).toHaveBeenCalledTimes(1);
+  });
+});
+
+function resultWithErrors(): ImportResult {
+  return { ...result(), errors: ['parse failure'] };
+}


### PR DESCRIPTION
## Summary
- add opt-in Codex SessionStart/SessionEnd hooks for automatic memory context and transcript ingestion
- preserve and validate existing Codex hook configuration, including Windows command support
- record project-scoped automatic import status and expose it via the Codex hooks status command

## Verification
- npm run test:run (197 files, 1254 tests)
- npm run typecheck
- npm run check:architecture
- build plus hook syntax checks and install/status/uninstall smoke test