### PR TITLE
feat(maintenance): add opt-in periodic vector recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,13 @@ Claude Memory Layer는 AI 에이전트의 대화와 작업 이벤트를 프로�
 
 ```bash
 npm install -g claude-memory-layer@latest
+
+# 기본: Claude Code 훅만 설치
 claude-memory-layer install
+
+# 또는: 훅과 주기 maintenance를 한 번에 설치
+claude-memory-layer install --with-maintenance
+
 claude-memory-layer status
 
 # Codex에서도 자동 컨텍스트 적재/불러오기를 사용할 때
@@ -59,10 +65,34 @@ npx claude-memory-layer status
 ```
 
 - `install`은 **한 번만** 하면 됩니다(Claude Code hooks 등록).
+- `npm install`만으로는 백그라운드 서비스를 등록하지 않습니다. `maintenance install` 또는 `install --with-maintenance`를 사용자가 명시적으로 실행해야 합니다.
 - `codex hooks install`은 `~/.codex/hooks.json`에 SessionStart/UserPromptSubmit/SessionEnd 훅을 병합합니다. Codex를 재시작한 뒤 `/hooks`에서 새 훅 정의를 검토하고 신뢰해야 실행됩니다.
 - Embedding backend은 런타임 필수 기능이며, postinstall이 패키지 내부의 격리된 관리 디렉터리에 설치합니다. 이 경계에서 `sharp` 보안 버전을 강제하고, CUDA 11 환경에서는 `onnxruntime-node`를 CPU-only로 설치합니다.
 - 이후 프로젝트별로 메모리 저장소가 자동 분리됩니다.
-- `install` / `uninstall`은 `~/.claude/settings.json`을, `codex hooks install` / `uninstall`은 `~/.codex/hooks.json`을 수정합니다. 기존의 다른 훅은 보존합니다.
+- `install` / `uninstall`은 `~/.claude/settings.json`을, `codex hooks install` / `uninstall`은 `~/.codex/hooks.json`을 수정합니다. `maintenance install` / `uninstall`은 사용자 계정의 launchd/systemd 정의만 변경합니다. 기존의 다른 훅과 서비스는 보존합니다.
+
+#### 선택: 자동 maintenance
+
+프로젝트별 pending embedding/vector outbox와 5분 이상 멈춘 processing 작업을 주기적으로 처리하려면 최초 1회 활성화합니다.
+
+```bash
+# macOS: ~/Library/LaunchAgents에 사용자 LaunchAgent 등록
+# Linux: ~/.config/systemd/user에 systemd user timer 등록(sudo 불필요)
+claude-memory-layer maintenance install
+
+# 기본 5분 대신 15분 주기
+claude-memory-layer maintenance install --interval 900
+
+claude-memory-layer maintenance status
+claude-memory-layer maintenance run --json
+
+# 스케줄러 정의만 제거하며 메모리 데이터는 보존
+claude-memory-layer maintenance uninstall
+```
+
+각 실행은 최근 저장소부터 순차적으로 확인하고 프로젝트별 worker lock을 사용합니다. 기본적으로 저장소당 최대 4 processing round(각 vector schema당 최대 한 batch)를 처리해 장시간 자원 독점을 피합니다. pending, retry 가능한 failed, 5분 이상 멈춘 processing 작업만 자동 복구하며 재시도 한도를 넘은 quarantined 작업은 무한 반복하지 않고 상태에 남깁니다.
+
+systemd user session이 없는 최소 Linux, 컨테이너, 일부 WSL 환경에서는 스케줄러 설치 대신 `claude-memory-layer maintenance run`을 기존 cron/작업 스케줄러에서 호출할 수 있습니다.
 
 #### CUDA 11 / `onnxruntime-node` 설치 에러
 
@@ -159,7 +189,7 @@ claude-memory-layer search "배포 이슈"
 - 특정 프로젝트를 명시하고 싶으면 대부분 명령에 `--project <path>` 사용 가능
 - 대규모 리임포트가 필요하면 `import --force` 사용
 - 최근 일부만 가져오고 싶으면 `--session-limit <n>` 또는 `--limit <n>` 사용
-- 백그라운드 worker가 못 처리한 임베딩은 `process`로 수동 처리
+- 백그라운드 worker가 못 처리한 임베딩은 opt-in `maintenance install`로 주기 처리하거나 `process`로 수동 처리
 - 상태 점검:
   - `GET /health` (서버 헬스)
   - `GET /api/health` (outbox pending/failed 포함 상세 헬스)
@@ -518,6 +548,12 @@ claude-memory-layer hermes import --project /path/to/project --verbose
 claude-memory-layer process --project /path/to/project
 claude-memory-layer process --project /path/to/project --dry-run-recovery
 claude-memory-layer vector-status --project /path/to/project
+
+# 머신 전체 프로젝트 저장소의 bounded maintenance
+claude-memory-layer maintenance run
+claude-memory-layer maintenance install --interval 300
+claude-memory-layer maintenance status
+claude-memory-layer maintenance uninstall
 
 # Perspective Memory actor/session membership backfill
 claude-memory-layer actors repair --project /path/to/project --dry-run

--- a/src/apps/cli/index.ts
+++ b/src/apps/cli/index.ts
@@ -138,6 +138,20 @@ import {
   resolveProcessCommandOptions
 } from './process-command.js';
 import {
+  formatMaintenanceLastRunStatus,
+  formatMaintenanceRunReport,
+  readMaintenanceLastRunStatus,
+  runMaintenanceCycle,
+  writeMaintenanceLastRunStatus
+} from './maintenance-runner.js';
+import {
+  formatMaintenanceSchedulerStatus,
+  getMaintenanceSchedulerStatus,
+  installMaintenanceScheduler,
+  parseMaintenanceInterval,
+  uninstallMaintenanceScheduler
+} from './maintenance-scheduler.js';
+import {
   formatImportLockBusy,
   resolveImportCommandLockOptions
 } from './import-command.js';
@@ -185,6 +199,18 @@ function getPluginPath(): string {
 
   // Fallback to npm global installation path
   return path.join(os.homedir(), '.npm-global', 'lib', 'node_modules', 'claude-memory-layer', 'dist');
+}
+
+function getMaintenanceCliPath(): string {
+  const candidates = [
+    process.argv[1]?.endsWith('.js') ? path.resolve(process.argv[1]) : '',
+    path.join(getPluginPath(), 'cli', 'index.js')
+  ];
+  const cliPath = candidates.find((candidate) => candidate && fs.existsSync(candidate));
+  if (!cliPath) {
+    throw new Error('Built CLI entrypoint not found. Run "npm run build" before installing maintenance.');
+  }
+  return cliPath;
 }
 
 function loadClaudeSettings(): ClaudeSettings {
@@ -855,6 +881,8 @@ program
   .command('install')
   .description('Install hooks into Claude Code settings')
   .option('--path <path>', 'Custom plugin path (defaults to auto-detect)')
+  .option('--with-maintenance', 'Also install the opt-in periodic maintenance scheduler')
+  .option('--maintenance-interval <seconds>', 'Maintenance interval in seconds', '300')
   .action(async (options) => {
     try {
       const pluginPath = options.path || getPluginPath();
@@ -879,6 +907,20 @@ program
       // Save settings
       saveClaudeSettings(nextSettings);
 
+      let maintenanceStatus: ReturnType<typeof installMaintenanceScheduler> | null = null;
+      if (options.withMaintenance === true) {
+        try {
+          maintenanceStatus = installMaintenanceScheduler({
+            intervalSeconds: parseMaintenanceInterval(options.maintenanceInterval),
+            nodePath: process.execPath,
+            cliPath: getMaintenanceCliPath()
+          });
+        } catch (error) {
+          const detail = error instanceof Error ? error.message : String(error);
+          throw new Error(`Claude hooks were installed, but periodic maintenance setup failed: ${detail}`);
+        }
+      }
+
       console.log('\n✅ Claude Memory Layer installed!\n');
       console.log('Hooks registered:');
       console.log('  - SessionStart: Register session -> project mapping');
@@ -887,6 +929,9 @@ program
       console.log('  - Stop: Store assistant responses');
       console.log('  - SessionEnd: Persist session summary\n');
       console.log('Plugin path:', pluginPath);
+      if (maintenanceStatus) {
+        console.log(`Maintenance: ${maintenanceStatus.active ? 'installed and active' : 'installed'}`);
+      }
       console.log('\n⚠️  Restart Claude Code for changes to take effect.\n');
       console.log('Commands:');
       console.log('  claude-memory-layer dashboard  - Open web dashboard');
@@ -1299,6 +1344,87 @@ program
 /**
  * Process command - manually process pending embeddings and bounded derivation
  */
+const maintenanceCommand = program
+  .command('maintenance')
+  .description('Run and manage opt-in periodic maintenance for all local project stores');
+
+maintenanceCommand
+  .command('run')
+  .description('Run one bounded, lock-safe maintenance cycle')
+  .option('-p, --project <path>', 'Process only one project instead of scanning all stores')
+  .option('--max-projects <count>', 'Maximum most-recent stores to scan')
+  .option('--max-batches <count>', 'Maximum processing rounds per store (one batch per vector schema)', '4')
+  .option('--json', 'Print a structured aggregate-only report')
+  .option('--quiet', 'Print only failures (used by periodic schedulers)')
+  .action(async (options) => {
+    try {
+      const maxProjects = options.maxProjects === undefined
+        ? undefined
+        : Number(options.maxProjects);
+      const maxBatches = Number(options.maxBatches);
+      const report = await runMaintenanceCycle({
+        projectPath: options.project,
+        maxProjects,
+        maxBatches
+      });
+      writeMaintenanceLastRunStatus(report);
+      if (options.quiet !== true) {
+        console.log(options.json ? JSON.stringify(report) : formatMaintenanceRunReport(report));
+      } else if (report.errors > 0) {
+        console.error(formatMaintenanceRunReport(report));
+      }
+      if (report.errors > 0) process.exitCode = 1;
+    } catch (error) {
+      console.error('Maintenance run failed:', error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
+    }
+  });
+
+maintenanceCommand
+  .command('install')
+  .description('Install a launchd (macOS) or systemd-user (Linux) periodic job')
+  .option('--interval <seconds>', 'Maintenance interval in seconds', '300')
+  .action((options) => {
+    try {
+      const status = installMaintenanceScheduler({
+        intervalSeconds: parseMaintenanceInterval(options.interval),
+        nodePath: process.execPath,
+        cliPath: getMaintenanceCliPath()
+      });
+      console.log(formatMaintenanceSchedulerStatus(status));
+    } catch (error) {
+      console.error('Maintenance install failed:', error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
+    }
+  });
+
+maintenanceCommand
+  .command('status')
+  .description('Check whether periodic maintenance is installed and active')
+  .action(() => {
+    try {
+      console.log(formatMaintenanceSchedulerStatus(getMaintenanceSchedulerStatus()));
+      console.log(formatMaintenanceLastRunStatus(readMaintenanceLastRunStatus()));
+    } catch (error) {
+      console.error('Maintenance status failed:', error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
+    }
+  });
+
+maintenanceCommand
+  .command('uninstall')
+  .description('Disable and remove only the periodic maintenance scheduler')
+  .action(() => {
+    try {
+      const status = uninstallMaintenanceScheduler();
+      console.log(formatMaintenanceSchedulerStatus(status));
+      console.log('Maintenance scheduler definitions were removed; memory data was preserved.');
+    } catch (error) {
+      console.error('Maintenance uninstall failed:', error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
+    }
+  });
+
 program
   .command('process')
   .description('Process pending embeddings and run one bounded graduation pass')

--- a/src/apps/cli/maintenance-runner.ts
+++ b/src/apps/cli/maintenance-runner.ts
@@ -1,0 +1,420 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { SQLiteEventStore } from '../../core/sqlite-event-store.js';
+import type { OutboxRecoveryResult, OutboxStats } from '../../core/types.js';
+import { WorkerLock } from '../../core/worker-lock.js';
+import { loadSessionRegistry } from '../../core/registry/session-registry.js';
+import { getProjectStoragePath } from '../../core/registry/project-path.js';
+import { DISABLED_SHARED_STORE_CONFIG, MemoryService } from '../../services/memory-service.js';
+
+export interface MaintenanceTarget {
+  key: string;
+  storagePath: string;
+  projectHash?: string;
+  projectPath?: string;
+  modifiedAtMs: number;
+}
+
+export interface MaintenanceTargetResult {
+  key: string;
+  status: 'healthy' | 'processed' | 'busy' | 'needs-attention' | 'error';
+  processed: number;
+  recovered: number;
+  pendingBefore: number;
+  retryableBefore: number;
+  pendingAfter: number;
+  retryableAfter: number;
+  quarantined: number;
+  error?: string;
+}
+
+export interface MaintenanceRunReport {
+  startedAt: string;
+  finishedAt: string;
+  scanned: number;
+  processed: number;
+  recovered: number;
+  busy: number;
+  errors: number;
+  pendingRemaining: number;
+  retryableRemaining: number;
+  quarantined: number;
+  results: MaintenanceTargetResult[];
+}
+
+export type MaintenanceLastRunStatus = Omit<MaintenanceRunReport, 'results'> & { version: 1 };
+
+export interface MaintenanceRunOptions {
+  homeDir?: string;
+  projectPath?: string;
+  maxProjects?: number;
+  maxBatches?: number;
+}
+
+export interface MaintenanceRunnerDeps {
+  discoverTargets?: (options: MaintenanceRunOptions) => MaintenanceTarget[];
+  inspectTarget?: (target: MaintenanceTarget) => Promise<OutboxStats>;
+  processTarget?: (target: MaintenanceTarget) => Promise<{
+    processed: number;
+    recovery: OutboxRecoveryResult;
+    stats: OutboxStats;
+  }>;
+  now?: () => Date;
+}
+
+export function discoverMaintenanceTargets(options: MaintenanceRunOptions = {}): MaintenanceTarget[] {
+  if (options.projectPath) {
+    const projectPath = path.resolve(options.projectPath);
+    const storagePath = getProjectStoragePath(projectPath);
+    return fs.existsSync(path.join(storagePath, 'events.sqlite'))
+      ? [{
+        key: path.basename(storagePath),
+        storagePath,
+        projectHash: path.basename(storagePath),
+        projectPath,
+        modifiedAtMs: getStoreModifiedAtMs(storagePath)
+      }]
+      : [];
+  }
+
+  const homeDir = options.homeDir ?? os.homedir();
+  const memoryRoot = path.join(homeDir, '.claude-code', 'memory');
+  const registry = loadSessionRegistry({ homeDir });
+  const latestByHash = new Map<string, { projectPath: string; registeredAt: string }>();
+  for (const entry of Object.values(registry.sessions)) {
+    const existing = latestByHash.get(entry.projectHash);
+    if (!existing || entry.registeredAt > existing.registeredAt) {
+      latestByHash.set(entry.projectHash, entry);
+    }
+  }
+
+  const targets: MaintenanceTarget[] = [];
+  const globalDb = path.join(memoryRoot, 'events.sqlite');
+  if (fs.existsSync(globalDb)) {
+    targets.push({
+      key: '__global__',
+      storagePath: memoryRoot,
+      modifiedAtMs: getStoreModifiedAtMs(memoryRoot)
+    });
+  }
+
+  const projectsRoot = path.join(memoryRoot, 'projects');
+  if (fs.existsSync(projectsRoot)) {
+    for (const projectHash of fs.readdirSync(projectsRoot)) {
+      if (!/^[a-f0-9]{8}$/.test(projectHash)) continue;
+      const storagePath = path.join(projectsRoot, projectHash);
+      const dbPath = path.join(storagePath, 'events.sqlite');
+      if (!isLocalProjectStore(storagePath, dbPath)) continue;
+      targets.push({
+        key: projectHash,
+        storagePath,
+        projectHash,
+        projectPath: latestByHash.get(projectHash)?.projectPath,
+        modifiedAtMs: getStoreModifiedAtMs(storagePath)
+      });
+    }
+  }
+
+  const maxProjects = normalizeMaxProjects(options.maxProjects);
+  return targets
+    .sort((a, b) => b.modifiedAtMs - a.modifiedAtMs || a.key.localeCompare(b.key))
+    .slice(0, maxProjects);
+}
+
+export async function runMaintenanceCycle(
+  options: MaintenanceRunOptions = {},
+  deps: MaintenanceRunnerDeps = {}
+): Promise<MaintenanceRunReport> {
+  const now = deps.now ?? (() => new Date());
+  const startedAt = now().toISOString();
+  const targets = (deps.discoverTargets ?? discoverMaintenanceTargets)(options);
+  const inspect = deps.inspectTarget ?? inspectMaintenanceTarget;
+  const maxBatches = normalizeMaxBatches(options.maxBatches);
+  const processTarget = deps.processTarget ?? ((target) => processMaintenanceTarget(target, maxBatches));
+  const results: MaintenanceTargetResult[] = [];
+
+  for (const target of targets) {
+    let pendingBefore = 0;
+    let retryableBefore = 0;
+    let quarantined = 0;
+    try {
+      const stats = await inspect(target);
+      pendingBefore = pendingCount(stats);
+      retryableBefore = retryableCount(stats);
+      quarantined = quarantinedCount(stats);
+      const stuck = stuckCount(stats);
+      if (pendingBefore === 0 && retryableBefore === 0 && stuck === 0) {
+        results.push({
+          key: target.key,
+          status: quarantined > 0 ? 'needs-attention' : 'healthy',
+          processed: 0,
+          recovered: 0,
+          pendingBefore,
+          retryableBefore,
+          pendingAfter: pendingBefore,
+          retryableAfter: retryableBefore,
+          quarantined
+        });
+        continue;
+      }
+
+      const result = await processTarget(target);
+      const recovered = recoveryCount(result.recovery);
+      const pendingAfter = pendingCount(result.stats);
+      const retryableAfter = retryableCount(result.stats);
+      const remainingQuarantined = quarantinedCount(result.stats);
+      results.push({
+        key: target.key,
+        status: remainingQuarantined > 0 ? 'needs-attention' : 'processed',
+        processed: result.processed,
+        recovered,
+        pendingBefore,
+        retryableBefore,
+        pendingAfter,
+        retryableAfter,
+        quarantined: remainingQuarantined
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.startsWith('worker busy:')) {
+        results.push({
+          key: target.key,
+          status: 'busy',
+          processed: 0,
+          recovered: 0,
+          pendingBefore,
+          retryableBefore,
+          pendingAfter: pendingBefore,
+          retryableAfter: retryableBefore,
+          quarantined
+        });
+      } else {
+        results.push({
+          key: target.key,
+          status: 'error',
+          processed: 0,
+          recovered: 0,
+          pendingBefore,
+          retryableBefore,
+          pendingAfter: pendingBefore,
+          retryableAfter: retryableBefore,
+          quarantined,
+          error: sanitizeMaintenanceError(message)
+        });
+      }
+    }
+  }
+
+  return {
+    startedAt,
+    finishedAt: now().toISOString(),
+    scanned: targets.length,
+    processed: results.reduce((sum, item) => sum + item.processed, 0),
+    recovered: results.reduce((sum, item) => sum + item.recovered, 0),
+    busy: results.filter((item) => item.status === 'busy').length,
+    errors: results.filter((item) => item.status === 'error').length,
+    pendingRemaining: results.reduce((sum, item) => sum + item.pendingAfter, 0),
+    retryableRemaining: results.reduce((sum, item) => sum + item.retryableAfter, 0),
+    quarantined: results.reduce((sum, item) => sum + item.quarantined, 0),
+    results
+  };
+}
+
+export function formatMaintenanceRunReport(report: MaintenanceRunReport): string {
+  const attention = report.results.filter((item) => item.status === 'needs-attention').length;
+  return [
+    'Claude Memory Layer maintenance',
+    `Scanned stores: ${report.scanned}`,
+    `Processed embeddings: ${report.processed}`,
+    `Recovered outbox jobs: ${report.recovered}`,
+    `Busy stores skipped: ${report.busy}`,
+    `Pending jobs remaining: ${report.pendingRemaining}`,
+    `Retryable failures remaining: ${report.retryableRemaining}`,
+    `Stores needing attention: ${attention}`,
+    `Quarantined jobs: ${report.quarantined}`,
+    `Errors: ${report.errors}`
+  ].join('\n');
+}
+
+export function writeMaintenanceLastRunStatus(
+  report: MaintenanceRunReport,
+  homeDir: string = os.homedir()
+): string {
+  const filePath = getMaintenanceLastRunStatusPath(homeDir);
+  const status: MaintenanceLastRunStatus = {
+    version: 1,
+    startedAt: report.startedAt,
+    finishedAt: report.finishedAt,
+    scanned: report.scanned,
+    processed: report.processed,
+    recovered: report.recovered,
+    busy: report.busy,
+    errors: report.errors,
+    pendingRemaining: report.pendingRemaining,
+    retryableRemaining: report.retryableRemaining,
+    quarantined: report.quarantined
+  };
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tempPath = `${filePath}.tmp-${process.pid}`;
+  fs.writeFileSync(tempPath, `${JSON.stringify(status, null, 2)}\n`, { mode: 0o600 });
+  fs.renameSync(tempPath, filePath);
+  return filePath;
+}
+
+export function readMaintenanceLastRunStatus(
+  homeDir: string = os.homedir()
+): MaintenanceLastRunStatus | null {
+  try {
+    const value = JSON.parse(fs.readFileSync(getMaintenanceLastRunStatusPath(homeDir), 'utf8')) as Partial<MaintenanceLastRunStatus>;
+    if (value.version !== 1 || typeof value.startedAt !== 'string' || typeof value.finishedAt !== 'string') return null;
+    const numericKeys = [
+      'scanned',
+      'processed',
+      'recovered',
+      'busy',
+      'errors',
+      'pendingRemaining',
+      'retryableRemaining',
+      'quarantined'
+    ] as const;
+    if (numericKeys.some((key) => !Number.isFinite(value[key]))) return null;
+    return value as MaintenanceLastRunStatus;
+  } catch {
+    return null;
+  }
+}
+
+export function formatMaintenanceLastRunStatus(status: MaintenanceLastRunStatus | null): string {
+  if (!status) return 'Last maintenance run: none';
+  return [
+    `Last maintenance run: ${status.finishedAt}`,
+    `  scanned=${status.scanned} processed=${status.processed} recovered=${status.recovered}`,
+    `  busy=${status.busy} errors=${status.errors} pending=${status.pendingRemaining} retryable=${status.retryableRemaining} quarantined=${status.quarantined}`
+  ].join('\n');
+}
+
+function getMaintenanceLastRunStatusPath(homeDir: string): string {
+  return path.join(homeDir, '.claude-code', 'memory', 'maintenance-status.json');
+}
+
+async function inspectMaintenanceTarget(target: MaintenanceTarget): Promise<OutboxStats> {
+  const store = new SQLiteEventStore(path.join(target.storagePath, 'events.sqlite'), { readonly: true });
+  try {
+    await store.initialize();
+    return await store.getOutboxStats();
+  } catch (error) {
+    if (!String(error).toLowerCase().includes('no such table')) throw error;
+  } finally {
+    await store.close().catch(() => undefined);
+  }
+
+  // A pre-outbox store cannot be inspected read-only until current tables are
+  // present. Maintenance is already an explicit writable operation, so run the
+  // normal idempotent schema initializer once and then continue.
+  const migratingStore = new SQLiteEventStore(path.join(target.storagePath, 'events.sqlite'));
+  try {
+    await migratingStore.initialize();
+    return await migratingStore.getOutboxStats();
+  } finally {
+    await migratingStore.close().catch(() => undefined);
+  }
+}
+
+async function processMaintenanceTarget(target: MaintenanceTarget, maxBatches: number): Promise<{
+  processed: number;
+  recovery: OutboxRecoveryResult;
+  stats: OutboxStats;
+}> {
+  const workerLock = new WorkerLock(path.join(target.storagePath, 'vector-worker.lock'));
+  const lockResult = workerLock.acquire();
+  if (!lockResult.acquired) {
+    throw new Error(`worker busy:${lockResult.holderPid ?? 'unknown'}`);
+  }
+
+  const service = new MemoryService({
+    storagePath: target.storagePath,
+    projectHash: target.projectHash,
+    projectPath: target.projectPath,
+    embeddingOnly: true,
+    analyticsEnabled: false,
+    sharedStoreConfig: DISABLED_SHARED_STORE_CONFIG
+  });
+  try {
+    await service.initialize();
+    const recovery = await service.recoverStuckOutboxItems();
+    const processed = await service.processPendingEmbeddings(maxBatches);
+    const stats = await service.getOutboxStats();
+    return { processed, recovery, stats };
+  } finally {
+    await service.shutdown().catch(() => undefined);
+    workerLock.release();
+  }
+}
+
+function pendingCount(stats: OutboxStats): number {
+  return stats.embedding.pending + stats.vector.pending;
+}
+
+function retryableCount(stats: OutboxStats): number {
+  return (stats.embedding.retryableFailed ?? 0) + (stats.vector.retryableFailed ?? 0);
+}
+
+function quarantinedCount(stats: OutboxStats): number {
+  return (stats.embedding.quarantinedFailed ?? 0) + (stats.vector.quarantinedFailed ?? 0);
+}
+
+function stuckCount(stats: OutboxStats): number {
+  return stats.embedding.stuckProcessing + stats.vector.stuckProcessing;
+}
+
+function recoveryCount(result: OutboxRecoveryResult): number {
+  return result.embedding.recoveredProcessing
+    + result.embedding.retriedFailed
+    + result.vector.recoveredProcessing
+    + result.vector.retriedFailed;
+}
+
+function normalizeMaxProjects(value: number | undefined): number {
+  if (value === undefined) return Number.MAX_SAFE_INTEGER;
+  if (!Number.isSafeInteger(value) || value < 1) throw new Error('--max-projects must be a positive integer');
+  return value;
+}
+
+function normalizeMaxBatches(value: number | undefined): number {
+  if (value === undefined) return 4;
+  if (!Number.isSafeInteger(value) || value < 1 || value > 100) {
+    throw new Error('--max-batches must be an integer between 1 and 100');
+  }
+  return value;
+}
+
+function getStoreModifiedAtMs(storagePath: string): number {
+  return ['events.sqlite', 'events.sqlite-wal']
+    .map((name) => path.join(storagePath, name))
+    .filter((file) => fs.existsSync(file))
+    .reduce((latest, file) => Math.max(latest, fs.statSync(file).mtimeMs), 0);
+}
+
+function isLocalProjectStore(storagePath: string, dbPath: string): boolean {
+  try {
+    return fs.lstatSync(storagePath).isDirectory() && fs.lstatSync(dbPath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function sanitizeMaintenanceError(message: string): string {
+  const normalized = message.toLowerCase();
+  if (normalized.includes('embedding backend') || normalized.includes('onnx')) {
+    return 'embedding backend unavailable';
+  }
+  if (normalized.includes('lance') || normalized.includes('vector')) {
+    return 'vector store maintenance failed';
+  }
+  if (normalized.includes('sqlite') || normalized.includes('database')) {
+    return 'SQLite maintenance failed';
+  }
+  return 'maintenance operation failed';
+}

--- a/src/apps/cli/maintenance-scheduler.ts
+++ b/src/apps/cli/maintenance-scheduler.ts
@@ -1,0 +1,350 @@
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+export const MAINTENANCE_LABEL = 'com.claude-memory-layer.maintenance';
+export const DEFAULT_MAINTENANCE_INTERVAL_SECONDS = 300;
+export const MIN_MAINTENANCE_INTERVAL_SECONDS = 60;
+
+export type MaintenancePlatform = 'darwin' | 'linux';
+
+export interface MaintenanceSchedulerPaths {
+  platform: MaintenancePlatform;
+  definitionPaths: string[];
+  logPath: string;
+}
+
+export interface MaintenanceSchedulerStatus {
+  platform: MaintenancePlatform;
+  installed: boolean;
+  active: boolean;
+  definitionPaths: string[];
+  logPath: string;
+}
+
+export interface MaintenanceSchedulerOptions {
+  platform?: NodeJS.Platform;
+  homeDir?: string;
+  intervalSeconds?: number;
+  nodePath: string;
+  cliPath: string;
+  uid?: number;
+}
+
+export interface MaintenanceSchedulerDeps {
+  execFileSync?: typeof execFileSync;
+}
+
+export function parseMaintenanceInterval(value: string | number | undefined): number {
+  if (value === undefined) return DEFAULT_MAINTENANCE_INTERVAL_SECONDS;
+  const parsed = typeof value === 'number' ? value : Number(value.trim());
+  if (!Number.isSafeInteger(parsed)
+    || parsed < MIN_MAINTENANCE_INTERVAL_SECONDS
+    || parsed > 86400) {
+    throw new Error(`maintenance interval must be between ${MIN_MAINTENANCE_INTERVAL_SECONDS} and 86400 seconds`);
+  }
+  return parsed;
+}
+
+export function resolveMaintenancePlatform(platform: NodeJS.Platform = process.platform): MaintenancePlatform {
+  if (platform === 'darwin' || platform === 'linux') return platform;
+  throw new Error(`maintenance scheduling is not supported on ${platform}; use "claude-memory-layer maintenance run" from your scheduler`);
+}
+
+export function getMaintenanceSchedulerPaths(
+  platform: NodeJS.Platform = process.platform,
+  homeDir: string = os.homedir()
+): MaintenanceSchedulerPaths {
+  const supported = resolveMaintenancePlatform(platform);
+  const logPath = path.join(homeDir, '.claude-code', 'memory', 'logs', 'maintenance.log');
+  if (supported === 'darwin') {
+    return {
+      platform: supported,
+      definitionPaths: [path.join(homeDir, 'Library', 'LaunchAgents', `${MAINTENANCE_LABEL}.plist`)],
+      logPath
+    };
+  }
+  return {
+    platform: supported,
+    definitionPaths: [
+      path.join(homeDir, '.config', 'systemd', 'user', 'claude-memory-layer-maintenance.service'),
+      path.join(homeDir, '.config', 'systemd', 'user', 'claude-memory-layer-maintenance.timer')
+    ],
+    logPath
+  };
+}
+
+export function buildLaunchdPlist(input: {
+  nodePath: string;
+  cliPath: string;
+  intervalSeconds: number;
+  logPath: string;
+}): string {
+  const args = [input.nodePath, input.cliPath, 'maintenance', 'run', '--quiet'];
+  const argXml = args.map((arg) => `      <string>${escapeXml(arg)}</string>`).join('\n');
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>${MAINTENANCE_LABEL}</string>
+    <key>ProgramArguments</key>
+    <array>
+${argXml}
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StartInterval</key>
+    <integer>${input.intervalSeconds}</integer>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>StandardOutPath</key>
+    <string>${escapeXml(input.logPath)}</string>
+    <key>StandardErrorPath</key>
+    <string>${escapeXml(input.logPath)}</string>
+  </dict>
+</plist>
+`;
+}
+
+export function buildSystemdUnits(input: {
+  nodePath: string;
+  cliPath: string;
+  intervalSeconds: number;
+}): { service: string; timer: string } {
+  const execStart = [input.nodePath, input.cliPath, 'maintenance', 'run', '--quiet']
+    .map(systemdQuote)
+    .join(' ');
+  return {
+    service: `[Unit]
+Description=Claude Memory Layer maintenance
+
+[Service]
+Type=oneshot
+ExecStart=${execStart}
+Nice=10
+
+[Install]
+WantedBy=default.target
+`,
+    timer: `[Unit]
+Description=Run Claude Memory Layer maintenance periodically
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=${input.intervalSeconds}s
+RandomizedDelaySec=30s
+Persistent=true
+Unit=claude-memory-layer-maintenance.service
+
+[Install]
+WantedBy=timers.target
+`
+  };
+}
+
+export function installMaintenanceScheduler(
+  options: MaintenanceSchedulerOptions,
+  deps: MaintenanceSchedulerDeps = {}
+): MaintenanceSchedulerStatus {
+  const platform = resolveMaintenancePlatform(options.platform);
+  const homeDir = options.homeDir ?? os.homedir();
+  const intervalSeconds = parseMaintenanceInterval(options.intervalSeconds);
+  validateExecutablePath(options.nodePath, 'Node executable');
+  validateExecutablePath(options.cliPath, 'CLI entrypoint');
+  const paths = getMaintenanceSchedulerPaths(platform, homeDir);
+  fs.mkdirSync(path.dirname(paths.logPath), { recursive: true });
+  const previousDefinitions = snapshotDefinitions(paths.definitionPaths);
+
+  if (platform === 'darwin') {
+    const [plistPath] = paths.definitionPaths;
+    writeAtomic(plistPath, buildLaunchdPlist({
+      nodePath: path.resolve(options.nodePath),
+      cliPath: path.resolve(options.cliPath),
+      intervalSeconds,
+      logPath: paths.logPath
+    }));
+    const runner = deps.execFileSync ?? execFileSync;
+    const domain = launchdDomain(options.uid);
+    tryExec(runner, 'launchctl', ['bootout', domain, plistPath]);
+    try {
+      run(runner, 'launchctl', ['bootstrap', domain, plistPath], 'Could not register the launchd maintenance job');
+    } catch (error) {
+      restoreDefinitions(previousDefinitions);
+      if (previousDefinitions.some((definition) => definition.content !== null)) {
+        tryExec(runner, 'launchctl', ['bootstrap', domain, plistPath]);
+      }
+      throw error;
+    }
+    return getMaintenanceSchedulerStatus({ platform, homeDir, uid: options.uid }, deps);
+  }
+
+  const [servicePath, timerPath] = paths.definitionPaths;
+  const units = buildSystemdUnits({
+    nodePath: path.resolve(options.nodePath),
+    cliPath: path.resolve(options.cliPath),
+    intervalSeconds
+  });
+  writeAtomic(servicePath, units.service);
+  writeAtomic(timerPath, units.timer);
+  const runner = deps.execFileSync ?? execFileSync;
+  try {
+    run(runner, 'systemctl', ['--user', 'daemon-reload'], systemdUnavailableMessage());
+    run(runner, 'systemctl', ['--user', 'enable', path.basename(timerPath)], systemdUnavailableMessage());
+    run(runner, 'systemctl', ['--user', 'restart', path.basename(timerPath)], systemdUnavailableMessage());
+  } catch (error) {
+    if (previousDefinitions.some((definition) => definition.content === null)) {
+      tryExec(runner, 'systemctl', ['--user', 'disable', '--now', path.basename(timerPath)]);
+    }
+    restoreDefinitions(previousDefinitions);
+    tryExec(runner, 'systemctl', ['--user', 'daemon-reload']);
+    if (previousDefinitions.every((definition) => definition.content !== null)) {
+      tryExec(runner, 'systemctl', ['--user', 'restart', path.basename(timerPath)]);
+    }
+    throw error;
+  }
+  return getMaintenanceSchedulerStatus({ platform, homeDir }, deps);
+}
+
+export function getMaintenanceSchedulerStatus(
+  options: Pick<MaintenanceSchedulerOptions, 'platform' | 'homeDir' | 'uid'> = {},
+  deps: MaintenanceSchedulerDeps = {}
+): MaintenanceSchedulerStatus {
+  const platform = resolveMaintenancePlatform(options.platform);
+  const paths = getMaintenanceSchedulerPaths(platform, options.homeDir ?? os.homedir());
+  const installed = paths.definitionPaths.every((file) => fs.existsSync(file));
+  if (!installed) return { ...paths, installed: false, active: false };
+  const runner = deps.execFileSync ?? execFileSync;
+  const active = platform === 'darwin'
+    ? tryExec(runner, 'launchctl', ['print', `${launchdDomain(options.uid)}/${MAINTENANCE_LABEL}`])
+    : tryExec(runner, 'systemctl', ['--user', 'is-active', '--quiet', 'claude-memory-layer-maintenance.timer']);
+  return { ...paths, installed, active };
+}
+
+export function uninstallMaintenanceScheduler(
+  options: Pick<MaintenanceSchedulerOptions, 'platform' | 'homeDir' | 'uid'> = {},
+  deps: MaintenanceSchedulerDeps = {}
+): MaintenanceSchedulerStatus {
+  const platform = resolveMaintenancePlatform(options.platform);
+  const paths = getMaintenanceSchedulerPaths(platform, options.homeDir ?? os.homedir());
+  const runner = deps.execFileSync ?? execFileSync;
+  if (platform === 'darwin') {
+    const [plistPath] = paths.definitionPaths;
+    tryExec(runner, 'launchctl', ['bootout', launchdDomain(options.uid), plistPath]);
+  } else {
+    tryExec(runner, 'systemctl', ['--user', 'disable', '--now', 'claude-memory-layer-maintenance.timer']);
+  }
+  for (const file of paths.definitionPaths) {
+    try {
+      fs.unlinkSync(file);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+  }
+  if (platform === 'linux') {
+    tryExec(runner, 'systemctl', ['--user', 'daemon-reload']);
+  }
+  return { ...paths, installed: false, active: false };
+}
+
+export function formatMaintenanceSchedulerStatus(status: MaintenanceSchedulerStatus): string {
+  return [
+    `Maintenance scheduler (${status.platform})`,
+    `Installed: ${status.installed ? 'yes' : 'no'}`,
+    `Active: ${status.active ? 'yes' : 'no'}`,
+    ...status.definitionPaths.map((file) => `Definition: ${file}`),
+    `Log: ${status.logPath}`
+  ].join('\n');
+}
+
+function validateExecutablePath(value: string, label: string): void {
+  if (!value || !path.isAbsolute(value) || !fs.existsSync(value)) {
+    throw new Error(`${label} must be an existing absolute path: ${value || '(empty)'}`);
+  }
+}
+
+function writeAtomic(file: string, content: string): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const tempPath = `${file}.tmp-${process.pid}`;
+  fs.writeFileSync(tempPath, content, { mode: 0o644 });
+  fs.renameSync(tempPath, file);
+}
+
+interface DefinitionSnapshot {
+  file: string;
+  content: Buffer | null;
+}
+
+function snapshotDefinitions(files: string[]): DefinitionSnapshot[] {
+  return files.map((file) => ({
+    file,
+    content: fs.existsSync(file) ? fs.readFileSync(file) : null
+  }));
+}
+
+function restoreDefinitions(definitions: DefinitionSnapshot[]): void {
+  for (const definition of definitions) {
+    if (definition.content === null) {
+      try {
+        fs.unlinkSync(definition.file);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      }
+      continue;
+    }
+    fs.mkdirSync(path.dirname(definition.file), { recursive: true });
+    const tempPath = `${definition.file}.rollback-${process.pid}`;
+    fs.writeFileSync(tempPath, definition.content, { mode: 0o644 });
+    fs.renameSync(tempPath, definition.file);
+  }
+}
+
+function launchdDomain(uid: number | undefined): string {
+  const resolved = uid ?? process.getuid?.();
+  if (!Number.isSafeInteger(resolved) || (resolved ?? -1) < 0) {
+    throw new Error('Could not determine the current user id for launchd');
+  }
+  return `gui/${resolved}`;
+}
+
+function run(
+  runner: typeof execFileSync,
+  command: string,
+  args: string[],
+  failureMessage: string
+): void {
+  try {
+    runner(command, args, { stdio: 'ignore' });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`${failureMessage}: ${detail}`);
+  }
+}
+
+function tryExec(runner: typeof execFileSync, command: string, args: string[]): boolean {
+  try {
+    runner(command, args, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function systemdQuote(value: string): string {
+  if (/\r|\n/.test(value)) throw new Error('systemd command arguments must not contain newlines');
+  return `"${value.replace(/([\\"])/g, '\\$1')}"`;
+}
+
+function systemdUnavailableMessage(): string {
+  return 'Could not register the systemd user timer. Ensure systemd --user is available, or schedule "claude-memory-layer maintenance run" with cron';
+}

--- a/src/core/engine/memory-runtime-service.ts
+++ b/src/core/engine/memory-runtime-service.ts
@@ -62,7 +62,7 @@ export interface MemoryRuntimeServicesDeps {
 export interface MemoryRuntimeService {
   initialize(): Promise<void>;
   shutdown(): Promise<void>;
-  processPendingEmbeddings(): Promise<number>;
+  processPendingEmbeddings(maxBatches?: number): Promise<number>;
   forceGraduation(): Promise<GraduationRunResult>;
   recordMemoryAccess(eventId: string, sessionId: string, confidence?: number): void;
   getVectorWorker(): VectorWorker | null;
@@ -163,8 +163,18 @@ export function createMemoryRuntimeService(deps: MemoryRuntimeServicesDeps): Mem
       }
     },
 
-    async processPendingEmbeddings(): Promise<number> {
+    async processPendingEmbeddings(maxBatches?: number): Promise<number> {
       let processed = 0;
+      if (maxBatches !== undefined) {
+        const limit = Math.max(0, Math.floor(maxBatches));
+        for (let batch = 0; batch < limit; batch += 1) {
+          const batchProcessed = (vectorWorker ? await vectorWorker.processBatch() : 0)
+            + (vectorWorkerV2 ? await vectorWorkerV2.processBatch() : 0);
+          processed += batchProcessed;
+          if (batchProcessed === 0) break;
+        }
+        return processed;
+      }
       if (vectorWorker) {
         processed += await vectorWorker.processAll();
       }

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -425,8 +425,8 @@ export class MemoryService {
   /**
    * Process pending embeddings
    */
-  async processPendingEmbeddings(): Promise<number> {
-    return this.runtimeService.processPendingEmbeddings();
+  async processPendingEmbeddings(maxBatches?: number): Promise<number> {
+    return this.runtimeService.processPendingEmbeddings(maxBatches);
   }
 
   /**

--- a/tests/apps/maintenance-runner.test.ts
+++ b/tests/apps/maintenance-runner.test.ts
@@ -1,0 +1,204 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, utimesSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  discoverMaintenanceTargets,
+  formatMaintenanceLastRunStatus,
+  formatMaintenanceRunReport,
+  readMaintenanceLastRunStatus,
+  runMaintenanceCycle,
+  writeMaintenanceLastRunStatus,
+  type MaintenanceTarget
+} from '../../src/apps/cli/maintenance-runner.js';
+import type { OutboxStats } from '../../src/core/types.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('maintenance runner', () => {
+  it('discovers global and validated project stores without following arbitrary directories', () => {
+    const homeDir = mkdtempSync(path.join(tmpdir(), 'cml-maintenance-runner-'));
+    tempDirs.push(homeDir);
+    const memoryRoot = path.join(homeDir, '.claude-code', 'memory');
+    mkdirSync(path.join(memoryRoot, 'projects', 'deadbeef'), { recursive: true });
+    mkdirSync(path.join(memoryRoot, 'projects', 'not-a-hash'), { recursive: true });
+    const externalStore = path.join(homeDir, 'external-store');
+    mkdirSync(externalStore);
+    writeFileSync(path.join(memoryRoot, 'events.sqlite'), '');
+    writeFileSync(path.join(memoryRoot, 'projects', 'deadbeef', 'events.sqlite'), '');
+    writeFileSync(path.join(memoryRoot, 'projects', 'not-a-hash', 'events.sqlite'), '');
+    writeFileSync(path.join(externalStore, 'events.sqlite'), '');
+    symlinkSync(externalStore, path.join(memoryRoot, 'projects', 'cafebabe'));
+    writeFileSync(path.join(memoryRoot, 'session-registry.json'), JSON.stringify({
+      version: 1,
+      sessions: {
+        old: { projectPath: '/repo/old', projectHash: 'deadbeef', registeredAt: '2026-01-01T00:00:00Z' },
+        recent: { projectPath: '/repo/new', projectHash: 'deadbeef', registeredAt: '2026-01-02T00:00:00Z' }
+      }
+    }));
+
+    const targets = discoverMaintenanceTargets({ homeDir });
+    expect(targets.map((target) => target.key).sort()).toEqual(['__global__', 'deadbeef']);
+    expect(targets.find((target) => target.key === 'deadbeef')?.projectPath).toBe('/repo/new');
+  });
+
+  it('processes actionable stores, preserves quarantined jobs, and continues past busy/error stores', async () => {
+    const targets: MaintenanceTarget[] = ['pending', 'quarantined', 'busy', 'error'].map((key) => ({
+      key,
+      storagePath: `/private/${key}`,
+      modifiedAtMs: 1
+    }));
+    const report = await runMaintenanceCycle({}, {
+      discoverTargets: () => targets,
+      inspectTarget: async (target) => {
+        if (target.key === 'pending') return stats({ embeddingPending: 5 });
+        if (target.key === 'quarantined') return stats({ embeddingFailed: 3, embeddingQuarantined: 3 });
+        if (target.key === 'busy') return stats({ vectorPending: 2 });
+        throw new Error('/Users/private/secret/database failed with PRIVATE_PAYLOAD');
+      },
+      processTarget: async (target) => {
+        if (target.key === 'busy') throw new Error('worker busy:123');
+        return {
+          processed: 5,
+          recovery: {
+            embedding: { recoveredProcessing: 1, retriedFailed: 0 },
+            vector: { recoveredProcessing: 0, retriedFailed: 0 }
+          },
+          stats: stats({})
+        };
+      },
+      now: () => new Date('2026-08-11T00:00:00Z')
+    });
+
+    expect(report).toMatchObject({
+      scanned: 4,
+      processed: 5,
+      recovered: 1,
+      busy: 1,
+      errors: 1,
+      pendingRemaining: 2,
+      retryableRemaining: 0,
+      quarantined: 3
+    });
+    expect(report.results.find((item) => item.key === 'quarantined')?.status).toBe('needs-attention');
+    expect(report.results.find((item) => item.key === 'busy')?.status).toBe('busy');
+    expect(report.results.find((item) => item.key === 'busy')).toMatchObject({
+      pendingBefore: 2,
+      pendingAfter: 2
+    });
+    const error = report.results.find((item) => item.key === 'error')?.error ?? '';
+    expect(error).toBe('SQLite maintenance failed');
+    expect(error).not.toContain('/Users/private/secret');
+    expect(JSON.stringify(report)).not.toContain('PRIVATE_PAYLOAD');
+
+    const output = formatMaintenanceRunReport(report);
+    expect(output).toContain('Quarantined jobs: 3');
+    expect(output).not.toContain('PRIVATE_PAYLOAD');
+  });
+
+  it('rejects invalid scan and batch bounds before processing', async () => {
+    expect(() => discoverMaintenanceTargets({ homeDir: '/tmp', maxProjects: 0 })).toThrow('--max-projects');
+    await expect(runMaintenanceCycle({ maxBatches: 0 }, { discoverTargets: () => [] }))
+      .rejects.toThrow('--max-batches');
+  });
+
+  it('uses WAL activity when limiting scans to the most recently written stores', () => {
+    const homeDir = mkdtempSync(path.join(tmpdir(), 'cml-maintenance-wal-'));
+    tempDirs.push(homeDir);
+    const projectsRoot = path.join(homeDir, '.claude-code', 'memory', 'projects');
+    const oldDbStore = path.join(projectsRoot, '11111111');
+    const activeWalStore = path.join(projectsRoot, '22222222');
+    mkdirSync(oldDbStore, { recursive: true });
+    mkdirSync(activeWalStore, { recursive: true });
+    const oldDb = path.join(oldDbStore, 'events.sqlite');
+    const activeDb = path.join(activeWalStore, 'events.sqlite');
+    const activeWal = `${activeDb}-wal`;
+    writeFileSync(oldDb, '');
+    writeFileSync(activeDb, '');
+    writeFileSync(activeWal, '');
+    utimesSync(oldDb, new Date('2026-08-10T00:00:00Z'), new Date('2026-08-10T00:00:00Z'));
+    utimesSync(activeDb, new Date('2026-08-09T00:00:00Z'), new Date('2026-08-09T00:00:00Z'));
+    utimesSync(activeWal, new Date('2026-08-11T00:00:00Z'), new Date('2026-08-11T00:00:00Z'));
+
+    expect(discoverMaintenanceTargets({ homeDir, maxProjects: 1 })[0]?.key).toBe('22222222');
+  });
+
+  it('persists only aggregate last-run status without project results or payloads', () => {
+    const homeDir = mkdtempSync(path.join(tmpdir(), 'cml-maintenance-status-'));
+    tempDirs.push(homeDir);
+    const report = {
+      startedAt: '2026-08-11T00:00:00.000Z',
+      finishedAt: '2026-08-11T00:01:00.000Z',
+      scanned: 2,
+      processed: 5,
+      recovered: 1,
+      busy: 0,
+      errors: 0,
+      pendingRemaining: 2,
+      retryableRemaining: 1,
+      quarantined: 3,
+      results: [{
+        key: 'PRIVATE_PROJECT_HASH',
+        status: 'needs-attention' as const,
+        processed: 0,
+        recovered: 0,
+        pendingBefore: 0,
+        retryableBefore: 0,
+        pendingAfter: 0,
+        retryableAfter: 0,
+        quarantined: 3,
+        error: 'PRIVATE_PAYLOAD'
+      }]
+    };
+
+    const statusPath = writeMaintenanceLastRunStatus(report, homeDir);
+    const persisted = readMaintenanceLastRunStatus(homeDir);
+    expect(persisted).toMatchObject({ processed: 5, quarantined: 3 });
+    expect(formatMaintenanceLastRunStatus(persisted)).toContain('quarantined=3');
+    const raw = requireStatusFile(statusPath);
+    expect(raw).not.toContain('PRIVATE_PROJECT_HASH');
+    expect(raw).not.toContain('PRIVATE_PAYLOAD');
+  });
+});
+
+function stats(input: {
+  embeddingPending?: number;
+  vectorPending?: number;
+  embeddingFailed?: number;
+  embeddingQuarantined?: number;
+}): OutboxStats {
+  return {
+    embedding: {
+      pending: input.embeddingPending ?? 0,
+      processing: 0,
+      failed: input.embeddingFailed ?? 0,
+      retryableFailed: 0,
+      quarantinedFailed: input.embeddingQuarantined ?? 0,
+      total: (input.embeddingPending ?? 0) + (input.embeddingFailed ?? 0),
+      stuckProcessing: 0,
+      oldestProcessingAgeMs: null
+    },
+    vector: {
+      pending: input.vectorPending ?? 0,
+      processing: 0,
+      failed: 0,
+      retryableFailed: 0,
+      quarantinedFailed: 0,
+      total: input.vectorPending ?? 0,
+      stuckProcessing: 0,
+      oldestProcessingAgeMs: null
+    }
+  };
+}
+
+function requireStatusFile(filePath: string): string {
+  return readFileSync(filePath, 'utf8');
+}

--- a/tests/apps/maintenance-scheduler.test.ts
+++ b/tests/apps/maintenance-scheduler.test.ts
@@ -1,0 +1,185 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  buildLaunchdPlist,
+  buildSystemdUnits,
+  getMaintenanceSchedulerPaths,
+  installMaintenanceScheduler,
+  parseMaintenanceInterval,
+  uninstallMaintenanceScheduler
+} from '../../src/apps/cli/maintenance-scheduler.js';
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'cml-maintenance-scheduler-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function makeExecutables(root: string): { nodePath: string; cliPath: string } {
+  const nodePath = path.join(root, 'node');
+  const cliPath = path.join(root, 'cli', 'index.js');
+  writeFileSync(nodePath, 'node');
+  writeFileSync(cliPath, 'cli');
+  return { nodePath, cliPath };
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('maintenance scheduler', () => {
+  it('validates bounded scheduler intervals', () => {
+    expect(parseMaintenanceInterval(undefined)).toBe(300);
+    expect(parseMaintenanceInterval('600')).toBe(600);
+    expect(() => parseMaintenanceInterval('invalid')).toThrow('between 60 and 86400');
+    expect(() => parseMaintenanceInterval(300.5)).toThrow('between 60 and 86400');
+    expect(() => parseMaintenanceInterval('59')).toThrow('between 60 and 86400');
+    expect(() => parseMaintenanceInterval('86401')).toThrow('between 60 and 86400');
+  });
+
+  it('renders launchd and systemd definitions with absolute command arguments', () => {
+    const plist = buildLaunchdPlist({
+      nodePath: '/opt/node & tools/node',
+      cliPath: '/opt/cml/index.js',
+      intervalSeconds: 300,
+      logPath: '/tmp/cml.log'
+    });
+    expect(plist).toContain('<integer>300</integer>');
+    expect(plist).toContain('/opt/node &amp; tools/node');
+    expect(plist).toContain('<string>maintenance</string>');
+    expect(plist).toContain('<string>run</string>');
+    expect(plist).toContain('<string>--quiet</string>');
+
+    const units = buildSystemdUnits({
+      nodePath: '/opt/node path/node',
+      cliPath: '/opt/cml/index.js',
+      intervalSeconds: 900
+    });
+    expect(units.service).toContain('ExecStart="/opt/node path/node" "/opt/cml/index.js" "maintenance" "run" "--quiet"');
+    expect(units.timer).toContain('OnUnitActiveSec=900s');
+    expect(units.timer).toContain('Persistent=true');
+  });
+
+  it('installs and uninstalls an explicit macOS LaunchAgent without touching memory data', () => {
+    const homeDir = makeTempDir();
+    const binDir = path.join(homeDir, 'bin');
+    const cliDir = path.join(binDir, 'cli');
+    requireDirectories(binDir, cliDir);
+    const executable = makeExecutables(binDir);
+    const calls: Array<{ command: string; args: readonly string[] }> = [];
+    const runner = ((command: string, args: readonly string[]) => {
+      calls.push({ command, args });
+      if (args.includes('bootout')) throw new Error('not loaded');
+      return Buffer.from('ok');
+    }) as typeof import('node:child_process').execFileSync;
+
+    const installed = installMaintenanceScheduler({
+      platform: 'darwin',
+      homeDir,
+      intervalSeconds: 300,
+      uid: 501,
+      ...executable
+    }, { execFileSync: runner });
+
+    expect(installed).toMatchObject({ platform: 'darwin', installed: true, active: true });
+    const [plistPath] = getMaintenanceSchedulerPaths('darwin', homeDir).definitionPaths;
+    expect(readFileSync(plistPath, 'utf8')).toContain(executable.cliPath);
+    expect(calls.some((call) => call.command === 'launchctl' && call.args.includes('bootstrap'))).toBe(true);
+
+    const removed = uninstallMaintenanceScheduler({ platform: 'darwin', homeDir, uid: 501 }, { execFileSync: runner });
+    expect(removed).toMatchObject({ installed: false, active: false });
+    expect(existsSync(plistPath)).toBe(false);
+  });
+
+  it('installs a Linux systemd user timer and enables it without sudo', () => {
+    const homeDir = makeTempDir();
+    const binDir = path.join(homeDir, 'bin');
+    const cliDir = path.join(binDir, 'cli');
+    requireDirectories(binDir, cliDir);
+    const executable = makeExecutables(binDir);
+    const calls: Array<{ command: string; args: readonly string[] }> = [];
+    const runner = ((command: string, args: readonly string[]) => {
+      calls.push({ command, args });
+      return Buffer.from('ok');
+    }) as typeof import('node:child_process').execFileSync;
+
+    const installed = installMaintenanceScheduler({
+      platform: 'linux',
+      homeDir,
+      intervalSeconds: 600,
+      ...executable
+    }, { execFileSync: runner });
+
+    expect(installed).toMatchObject({ platform: 'linux', installed: true, active: true });
+    const [servicePath, timerPath] = getMaintenanceSchedulerPaths('linux', homeDir).definitionPaths;
+    expect(readFileSync(servicePath, 'utf8')).toContain('Type=oneshot');
+    expect(readFileSync(timerPath, 'utf8')).toContain('OnUnitActiveSec=600s');
+    expect(calls).toContainEqual({ command: 'systemctl', args: ['--user', 'enable', 'claude-memory-layer-maintenance.timer'] });
+    expect(calls).toContainEqual({ command: 'systemctl', args: ['--user', 'restart', 'claude-memory-layer-maintenance.timer'] });
+    expect(calls.some((call) => call.command === 'sudo')).toBe(false);
+  });
+
+  it('restores the previous scheduler definition when OS registration fails', () => {
+    const homeDir = makeTempDir();
+    const binDir = path.join(homeDir, 'bin');
+    const cliDir = path.join(binDir, 'cli');
+    requireDirectories(binDir, cliDir);
+    const executable = makeExecutables(binDir);
+    const [plistPath] = getMaintenanceSchedulerPaths('darwin', homeDir).definitionPaths;
+    requireDirectories(path.dirname(plistPath));
+    writeFileSync(plistPath, 'PREVIOUS_PLIST');
+    const runner = ((_command: string, args: readonly string[]) => {
+      if (args.includes('bootstrap')) throw new Error('registration failed');
+      return Buffer.from('ok');
+    }) as typeof import('node:child_process').execFileSync;
+
+    expect(() => installMaintenanceScheduler({
+      platform: 'darwin',
+      homeDir,
+      intervalSeconds: 300,
+      uid: 501,
+      ...executable
+    }, { execFileSync: runner })).toThrow('Could not register');
+    expect(readFileSync(plistPath, 'utf8')).toBe('PREVIOUS_PLIST');
+  });
+
+  it('disables a newly enabled Linux timer when registration rolls back', () => {
+    const homeDir = makeTempDir();
+    const binDir = path.join(homeDir, 'bin');
+    const cliDir = path.join(binDir, 'cli');
+    requireDirectories(binDir, cliDir);
+    const executable = makeExecutables(binDir);
+    const calls: Array<{ command: string; args: readonly string[] }> = [];
+    const runner = ((command: string, args: readonly string[]) => {
+      calls.push({ command, args });
+      if (args.includes('restart')) throw new Error('start failed');
+      return Buffer.from('ok');
+    }) as typeof import('node:child_process').execFileSync;
+
+    expect(() => installMaintenanceScheduler({
+      platform: 'linux',
+      homeDir,
+      intervalSeconds: 300,
+      ...executable
+    }, { execFileSync: runner })).toThrow('Could not register');
+
+    const definitionPaths = getMaintenanceSchedulerPaths('linux', homeDir).definitionPaths;
+    expect(definitionPaths.every((file) => !existsSync(file))).toBe(true);
+    expect(calls).toContainEqual({
+      command: 'systemctl',
+      args: ['--user', 'disable', '--now', 'claude-memory-layer-maintenance.timer']
+    });
+  });
+});
+
+function requireDirectories(...dirs: string[]): void {
+  for (const dir of dirs) mkdirSync(dir, { recursive: true });
+}

--- a/tests/core/memory-runtime-service.test.ts
+++ b/tests/core/memory-runtime-service.test.ts
@@ -37,6 +37,10 @@ function makeHarness(options?: { readOnly?: boolean; lightweightMode?: boolean; 
     start: () => { calls.push('vectorWorker.start'); },
     stop: () => { calls.push('vectorWorker.stop'); },
     waitForIdle: async () => { calls.push('vectorWorker.waitForIdle'); },
+    processBatch: async () => {
+      calls.push('vectorWorker.processBatch');
+      return 3;
+    },
     processAll: async () => {
       calls.push('vectorWorker.processAll');
       return 3;
@@ -46,6 +50,10 @@ function makeHarness(options?: { readOnly?: boolean; lightweightMode?: boolean; 
     start: () => { calls.push('vectorWorkerV2.start'); },
     stop: () => { calls.push('vectorWorkerV2.stop'); },
     waitForIdle: async () => { calls.push('vectorWorkerV2.waitForIdle'); },
+    processBatch: async () => {
+      calls.push('vectorWorkerV2.processBatch');
+      return 5;
+    },
     processAll: async () => {
       calls.push('vectorWorkerV2.processAll');
       return 5;
@@ -202,6 +210,20 @@ describe('createMemoryRuntimeService', () => {
       'vectorWorkerV2.waitForIdle',
       'shared.close',
       'sqlite.close'
+    ]);
+  });
+
+  it('bounds explicit embedding processing by batch count for periodic maintenance', async () => {
+    const harness = makeHarness({ enableV2: true });
+    await harness.service.initialize();
+    harness.calls.length = 0;
+
+    await expect(harness.service.processPendingEmbeddings(2)).resolves.toBe(16);
+    expect(harness.calls).toEqual([
+      'vectorWorker.processBatch',
+      'vectorWorkerV2.processBatch',
+      'vectorWorker.processBatch',
+      'vectorWorkerV2.processBatch'
     ]);
   });
 


### PR DESCRIPTION
## Summary

- add explicit `maintenance run/install/status/uninstall` CLI commands
- support opt-in macOS launchd and Linux systemd user timers without npm-install side effects
- scan local project stores safely and process recovery work with per-store locks and bounded rounds
- persist privacy-safe aggregate status and document activation, Linux fallback, and uninstall behavior
- harden scheduler rollback, WAL activity ordering, numeric validation, and symlink traversal boundaries

## Validation

- `npm run typecheck`
- `npm run test:run` (200 files, 1273 tests)
- `npm run lint -- --quiet`
- `npm run check:architecture`
- `npm run check:public-output-privacy`
- `npm run build`
- isolated-HOME maintenance CLI smoke
- `npm pack --dry-run --json`
- `git diff --check`