### PR TITLE
Harden MCP lifecycle and runtime maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,16 @@ claude-memory-layer maintenance install --interval 900
 claude-memory-layer maintenance status
 claude-memory-layer maintenance run --json
 
+# 기본 5 GiB보다 넉넉한 여유 공간을 요구할 때
+claude-memory-layer maintenance run --min-free-gb 10
+
 # 스케줄러 정의만 제거하며 메모리 데이터는 보존
 claude-memory-layer maintenance uninstall
 ```
 
 각 실행은 최근 저장소부터 순차적으로 확인하고 프로젝트별 worker lock을 사용합니다. 기본적으로 저장소당 최대 4 processing round(각 vector schema당 최대 한 batch)를 처리해 장시간 자원 독점을 피합니다. pending, retry 가능한 failed, 5분 이상 멈춘 processing 작업만 자동 복구하며 재시도 한도를 넘은 quarantined 작업은 무한 반복하지 않고 상태에 남깁니다.
+
+maintenance는 메모리 루트가 있는 파일시스템의 여유 공간이 기본 5 GiB 미만이면 쓰기 작업을 `blocked`로 기록하고 큐 현황만 보고합니다. 기준은 `maintenance run --min-free-gb <GiB>`로 조정할 수 있으며, `0`은 이 보호 장치를 명시적으로 끕니다. 예약 실행도 같은 기본값을 사용합니다.
 
 systemd user session이 없는 최소 Linux, 컨테이너, 일부 WSL 환경에서는 스케줄러 설치 대신 `claude-memory-layer maintenance run`을 기존 cron/작업 스케줄러에서 호출할 수 있습니다.
 
@@ -315,6 +320,9 @@ claude-memory-layer stats --project "$VERIFY_PROJECT"
 claude-memory-layer search "최근에 하던 작업" --project "$VERIFY_PROJECT" --top-k 5
 claude-memory-layer dashboard --no-open --port 37777
 # 다른 터미널에서: curl http://localhost:37777/api/health
+
+# 프로젝트 저장소 분리 상태를 aggregate-only 리포트로 점검
+claude-memory-layer project scope-audit --days 7
 ```
 
 ### 5) MCP/다른 agent에 연결
@@ -337,6 +345,8 @@ hermes mcp add claude-memory-layer --command claude-memory-layer-mcp
 ```
 
 MCP client가 환경에 따라 PATH를 못 찾으면 `command -v claude-memory-layer-mcp`로 절대 경로를 확인해서 command에 넣으세요.
+
+MCP 서버는 client의 stdio가 닫히거나 부모 프로세스가 사라지면 자원을 정리하고 종료합니다. 연결은 유지됐지만 호출이 없을 때는 기본 10분 후 embedding 모델/native 자원을 해제하며, 다음 호출에서 자동으로 다시 준비합니다. 필요하면 `CLAUDE_MEMORY_MCP_IDLE_RELEASE_MS`를 60000~86400000ms 범위에서 지정할 수 있습니다.
 
 ---
 
@@ -551,9 +561,14 @@ claude-memory-layer vector-status --project /path/to/project
 
 # 머신 전체 프로젝트 저장소의 bounded maintenance
 claude-memory-layer maintenance run
+claude-memory-layer maintenance run --min-free-gb 10
 claude-memory-layer maintenance install --interval 300
 claude-memory-layer maintenance status
 claude-memory-layer maintenance uninstall
+
+# registry/canonical store 분리 상태의 aggregate-only 감사
+claude-memory-layer project scope-audit --days 7
+claude-memory-layer project scope-audit --days 7 --json
 
 # Perspective Memory actor/session membership backfill
 claude-memory-layer actors repair --project /path/to/project --dry-run
@@ -755,6 +770,8 @@ hermes mcp add claude-memory-layer --command node --args /path/to/claude-memory-
 ```bash
 node dist/mcp/index.js
 ```
+
+MCP 서버는 stdio 종료·부모 프로세스 소실 시 함께 종료됩니다. 유휴 상태에서는 기본 10분 후 embedding 모델/native 자원을 반납하고 다음 도구 호출에서 다시 적재합니다. 유휴 해제 시간은 `CLAUDE_MEMORY_MCP_IDLE_RELEASE_MS`(60000~86400000ms)로 조정할 수 있습니다.
 
 ### 제공되는 MCP 도구
 

--- a/src/apps/cli/dashboard-command.ts
+++ b/src/apps/cli/dashboard-command.ts
@@ -41,3 +41,9 @@ export function resolveDashboardCommandOptions(options: DashboardCommandInput): 
     dashboardUrl: `http://localhost:${port}`
   };
 }
+
+export function formatDashboardStatus(running: boolean, port = 37777): string {
+  return running
+    ? `Dashboard (port ${port}): ✅ Running at http://localhost:${port}`
+    : `Dashboard (port ${port}): ⏹️  Not detected (custom-port instances are not checked)`;
+}

--- a/src/apps/cli/index.ts
+++ b/src/apps/cli/index.ts
@@ -96,7 +96,7 @@ import {
 import { runCodexImportOnce } from './codex-import-runner.js';
 import { readCodexAutoImportStatus } from '../../services/codex-session-auto-import.js';
 import { runHermesImportOnce } from './hermes-import-runner.js';
-import { resolveDashboardCommandOptions } from './dashboard-command.js';
+import { formatDashboardStatus, resolveDashboardCommandOptions } from './dashboard-command.js';
 import {
   formatLegacyProjectScopeRepairResult,
   resolveLegacyProjectScopeRepairOptions
@@ -140,6 +140,8 @@ import {
 import {
   formatMaintenanceLastRunStatus,
   formatMaintenanceRunReport,
+  maintenanceRunRequiresAttention,
+  parseMaintenanceMinFreeBytes,
   readMaintenanceLastRunStatus,
   runMaintenanceCycle,
   writeMaintenanceLastRunStatus
@@ -155,6 +157,11 @@ import {
   formatImportLockBusy,
   resolveImportCommandLockOptions
 } from './import-command.js';
+import {
+  auditProjectScope,
+  formatProjectScopeAudit,
+  parseProjectScopeAuditDays
+} from './project-scope-audit.js';
 import {
   formatVectorStatusJsonReport,
   formatVectorStatusReport,
@@ -1011,7 +1018,7 @@ program
 
       // Check dashboard
       const dashboardRunning = await isServerRunning(37777);
-      console.log(`\nDashboard: ${dashboardRunning ? '✅ Running at http://localhost:37777' : '⏹️  Not running'}`);
+      console.log(`\n${formatDashboardStatus(dashboardRunning, 37777)}`);
 
       if (!hasSessionStartHook || !hasUserPromptHook || !hasPostToolHook || !hasStopHook || !hasSessionEndHook) {
         console.log('\n💡 Run "claude-memory-layer install" to set up hooks.\n');
@@ -1354,6 +1361,7 @@ maintenanceCommand
   .option('-p, --project <path>', 'Process only one project instead of scanning all stores')
   .option('--max-projects <count>', 'Maximum most-recent stores to scan')
   .option('--max-batches <count>', 'Maximum processing rounds per store (one batch per vector schema)', '4')
+  .option('--min-free-gb <gb>', 'Block maintenance writes below this free disk space', '5')
   .option('--json', 'Print a structured aggregate-only report')
   .option('--quiet', 'Print only failures (used by periodic schedulers)')
   .action(async (options) => {
@@ -1362,18 +1370,21 @@ maintenanceCommand
         ? undefined
         : Number(options.maxProjects);
       const maxBatches = Number(options.maxBatches);
+      const minFreeBytes = parseMaintenanceMinFreeBytes(options.minFreeGb);
       const report = await runMaintenanceCycle({
         projectPath: options.project,
         maxProjects,
-        maxBatches
+        maxBatches,
+        minFreeBytes
       });
       writeMaintenanceLastRunStatus(report);
+      const requiresAttention = maintenanceRunRequiresAttention(report);
       if (options.quiet !== true) {
         console.log(options.json ? JSON.stringify(report) : formatMaintenanceRunReport(report));
-      } else if (report.errors > 0) {
+      } else if (requiresAttention) {
         console.error(formatMaintenanceRunReport(report));
       }
-      if (report.errors > 0) process.exitCode = 1;
+      if (requiresAttention) process.exitCode = 1;
     } catch (error) {
       console.error('Maintenance run failed:', error instanceof Error ? error.message : String(error));
       process.exitCode = 1;
@@ -3344,6 +3355,24 @@ projectCmd
     } catch {
       console.error('Project identity scan failed');
       process.exit(1);
+    }
+  });
+
+projectCmd
+  .command('scope-audit')
+  .description('Read-only aggregate audit for recent cross-store session routing')
+  .option('--days <days>', 'Recent time window in days', '7')
+  .option('--json', 'Print a machine-readable aggregate report')
+  .action((options: { days?: string; json?: boolean }) => {
+    try {
+      const report = auditProjectScope({ days: parseProjectScopeAuditDays(options.days) });
+      console.log(options.json ? JSON.stringify(report, null, 2) : formatProjectScopeAudit(report));
+    } catch (error) {
+      const message = error instanceof Error && error.message.startsWith('--')
+        ? error.message
+        : 'Project scope audit failed';
+      console.error(message);
+      process.exitCode = 1;
     }
   });
 

--- a/src/apps/cli/maintenance-runner.ts
+++ b/src/apps/cli/maintenance-runner.ts
@@ -9,6 +9,8 @@ import { loadSessionRegistry } from '../../core/registry/session-registry.js';
 import { getProjectStoragePath } from '../../core/registry/project-path.js';
 import { DISABLED_SHARED_STORE_CONFIG, MemoryService } from '../../services/memory-service.js';
 
+export const DEFAULT_MAINTENANCE_MIN_FREE_BYTES = 5 * 1024 * 1024 * 1024;
+
 export interface MaintenanceTarget {
   key: string;
   storagePath: string;
@@ -19,7 +21,7 @@ export interface MaintenanceTarget {
 
 export interface MaintenanceTargetResult {
   key: string;
-  status: 'healthy' | 'processed' | 'busy' | 'needs-attention' | 'error';
+  status: 'healthy' | 'processed' | 'busy' | 'blocked' | 'needs-attention' | 'error';
   processed: number;
   recovered: number;
   pendingBefore: number;
@@ -30,6 +32,13 @@ export interface MaintenanceTargetResult {
   error?: string;
 }
 
+export interface MaintenanceDiskStatus {
+  availableBytes: number;
+  totalBytes: number;
+  minRequiredBytes: number;
+  healthy: boolean;
+}
+
 export interface MaintenanceRunReport {
   startedAt: string;
   finishedAt: string;
@@ -37,31 +46,69 @@ export interface MaintenanceRunReport {
   processed: number;
   recovered: number;
   busy: number;
+  blocked: number;
   errors: number;
   pendingRemaining: number;
   retryableRemaining: number;
   quarantined: number;
+  disk: MaintenanceDiskStatus;
   results: MaintenanceTargetResult[];
 }
 
-export type MaintenanceLastRunStatus = Omit<MaintenanceRunReport, 'results'> & { version: 1 };
+export type MaintenanceLastRunStatus = Omit<MaintenanceRunReport, 'results' | 'disk'> & {
+  version: 1;
+  disk: MaintenanceDiskStatus | null;
+};
 
 export interface MaintenanceRunOptions {
   homeDir?: string;
   projectPath?: string;
   maxProjects?: number;
   maxBatches?: number;
+  minFreeBytes?: number;
 }
 
 export interface MaintenanceRunnerDeps {
   discoverTargets?: (options: MaintenanceRunOptions) => MaintenanceTarget[];
-  inspectTarget?: (target: MaintenanceTarget) => Promise<OutboxStats>;
+  inspectTarget?: (
+    target: MaintenanceTarget,
+    options: { allowMigration: boolean }
+  ) => Promise<OutboxStats>;
   processTarget?: (target: MaintenanceTarget) => Promise<{
     processed: number;
     recovery: OutboxRecoveryResult;
     stats: OutboxStats;
   }>;
+  getDiskStatus?: (options: MaintenanceRunOptions) => MaintenanceDiskStatus;
   now?: () => Date;
+}
+
+export function parseMaintenanceMinFreeBytes(value: string | number | undefined): number {
+  if (value === undefined) return DEFAULT_MAINTENANCE_MIN_FREE_BYTES;
+  if (typeof value === 'string' && value.trim() === '') {
+    throw new Error('--min-free-gb must be a number between 0 and 1024');
+  }
+  const gigabytes = typeof value === 'number' ? value : Number(value.trim());
+  if (!Number.isFinite(gigabytes) || gigabytes < 0 || gigabytes > 1024) {
+    throw new Error('--min-free-gb must be a number between 0 and 1024');
+  }
+  return Math.floor(gigabytes * 1024 * 1024 * 1024);
+}
+
+export function getMaintenanceDiskStatus(options: MaintenanceRunOptions = {}): MaintenanceDiskStatus {
+  const homeDir = options.homeDir ?? os.homedir();
+  const memoryRoot = path.join(homeDir, '.claude-code', 'memory');
+  const probePath = findExistingAncestor(memoryRoot);
+  const stats = fs.statfsSync(probePath);
+  const availableBytes = Number(stats.bavail) * Number(stats.bsize);
+  const totalBytes = Number(stats.blocks) * Number(stats.bsize);
+  const minRequiredBytes = normalizeMinFreeBytes(options.minFreeBytes);
+  return {
+    availableBytes,
+    totalBytes,
+    minRequiredBytes,
+    healthy: availableBytes >= minRequiredBytes
+  };
 }
 
 export function discoverMaintenanceTargets(options: MaintenanceRunOptions = {}): MaintenanceTarget[] {
@@ -132,15 +179,21 @@ export async function runMaintenanceCycle(
   const targets = (deps.discoverTargets ?? discoverMaintenanceTargets)(options);
   const inspect = deps.inspectTarget ?? inspectMaintenanceTarget;
   const maxBatches = normalizeMaxBatches(options.maxBatches);
+  const readDiskStatus = deps.getDiskStatus ?? getMaintenanceDiskStatus;
+  let disk: MaintenanceDiskStatus | undefined;
   const processTarget = deps.processTarget ?? ((target) => processMaintenanceTarget(target, maxBatches));
   const results: MaintenanceTargetResult[] = [];
 
   for (const target of targets) {
+    // A cycle can process many stores and consume meaningful disk space. Check
+    // again before every target so a run that crosses the threshold stops
+    // before the next schema migration/vector write.
+    disk = readDiskStatus(options);
     let pendingBefore = 0;
     let retryableBefore = 0;
     let quarantined = 0;
     try {
-      const stats = await inspect(target);
+      const stats = await inspect(target, { allowMigration: disk.healthy });
       pendingBefore = pendingCount(stats);
       retryableBefore = retryableCount(stats);
       quarantined = quarantinedCount(stats);
@@ -149,6 +202,21 @@ export async function runMaintenanceCycle(
         results.push({
           key: target.key,
           status: quarantined > 0 ? 'needs-attention' : 'healthy',
+          processed: 0,
+          recovered: 0,
+          pendingBefore,
+          retryableBefore,
+          pendingAfter: pendingBefore,
+          retryableAfter: retryableBefore,
+          quarantined
+        });
+        continue;
+      }
+
+      if (!disk.healthy) {
+        results.push({
+          key: target.key,
+          status: 'blocked',
           processed: 0,
           recovered: 0,
           pendingBefore,
@@ -178,7 +246,19 @@ export async function runMaintenanceCycle(
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      if (message.startsWith('worker busy:')) {
+      if (error instanceof MaintenanceInspectionNeedsWriteError) {
+        results.push({
+          key: target.key,
+          status: 'blocked',
+          processed: 0,
+          recovered: 0,
+          pendingBefore,
+          retryableBefore,
+          pendingAfter: pendingBefore,
+          retryableAfter: retryableBefore,
+          quarantined
+        });
+      } else if (message.startsWith('worker busy:')) {
         results.push({
           key: target.key,
           status: 'busy',
@@ -207,6 +287,9 @@ export async function runMaintenanceCycle(
     }
   }
 
+  // Record the post-cycle value, including cycles that discovered no stores.
+  disk = readDiskStatus(options);
+
   return {
     startedAt,
     finishedAt: now().toISOString(),
@@ -214,10 +297,12 @@ export async function runMaintenanceCycle(
     processed: results.reduce((sum, item) => sum + item.processed, 0),
     recovered: results.reduce((sum, item) => sum + item.recovered, 0),
     busy: results.filter((item) => item.status === 'busy').length,
+    blocked: results.filter((item) => item.status === 'blocked').length,
     errors: results.filter((item) => item.status === 'error').length,
     pendingRemaining: results.reduce((sum, item) => sum + item.pendingAfter, 0),
     retryableRemaining: results.reduce((sum, item) => sum + item.retryableAfter, 0),
     quarantined: results.reduce((sum, item) => sum + item.quarantined, 0),
+    disk,
     results
   };
 }
@@ -230,12 +315,18 @@ export function formatMaintenanceRunReport(report: MaintenanceRunReport): string
     `Processed embeddings: ${report.processed}`,
     `Recovered outbox jobs: ${report.recovered}`,
     `Busy stores skipped: ${report.busy}`,
+    `Disk-pressure stores blocked: ${report.blocked}`,
+    `Disk available: ${formatBytes(report.disk.availableBytes)} (minimum ${formatBytes(report.disk.minRequiredBytes)})`,
     `Pending jobs remaining: ${report.pendingRemaining}`,
     `Retryable failures remaining: ${report.retryableRemaining}`,
     `Stores needing attention: ${attention}`,
     `Quarantined jobs: ${report.quarantined}`,
     `Errors: ${report.errors}`
   ].join('\n');
+}
+
+export function maintenanceRunRequiresAttention(report: MaintenanceRunReport): boolean {
+  return report.errors > 0 || report.blocked > 0 || !report.disk.healthy;
 }
 
 export function writeMaintenanceLastRunStatus(
@@ -251,10 +342,12 @@ export function writeMaintenanceLastRunStatus(
     processed: report.processed,
     recovered: report.recovered,
     busy: report.busy,
+    blocked: report.blocked,
     errors: report.errors,
     pendingRemaining: report.pendingRemaining,
     retryableRemaining: report.retryableRemaining,
-    quarantined: report.quarantined
+    quarantined: report.quarantined,
+    disk: report.disk
   };
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   const tempPath = `${filePath}.tmp-${process.pid}`;
@@ -274,12 +367,19 @@ export function readMaintenanceLastRunStatus(
       'processed',
       'recovered',
       'busy',
+      'blocked',
       'errors',
       'pendingRemaining',
       'retryableRemaining',
       'quarantined'
     ] as const;
-    if (numericKeys.some((key) => !Number.isFinite(value[key]))) return null;
+    // Version 1 status files written by 2.2.9 predate disk-pressure fields.
+    // Preserve their useful aggregate state and supply neutral defaults.
+    if (numericKeys.some((key) => key !== 'blocked' && !Number.isFinite(value[key]))) return null;
+    if (value.blocked !== undefined && !Number.isFinite(value.blocked)) return null;
+    if (value.disk !== undefined && value.disk !== null && !isMaintenanceDiskStatus(value.disk)) return null;
+    value.blocked ??= 0;
+    value.disk ??= null;
     return value as MaintenanceLastRunStatus;
   } catch {
     return null;
@@ -288,18 +388,27 @@ export function readMaintenanceLastRunStatus(
 
 export function formatMaintenanceLastRunStatus(status: MaintenanceLastRunStatus | null): string {
   if (!status) return 'Last maintenance run: none';
-  return [
+  const lines = [
     `Last maintenance run: ${status.finishedAt}`,
     `  scanned=${status.scanned} processed=${status.processed} recovered=${status.recovered}`,
-    `  busy=${status.busy} errors=${status.errors} pending=${status.pendingRemaining} retryable=${status.retryableRemaining} quarantined=${status.quarantined}`
-  ].join('\n');
+    `  busy=${status.busy} blocked=${status.blocked} errors=${status.errors} pending=${status.pendingRemaining} retryable=${status.retryableRemaining} quarantined=${status.quarantined}`
+  ];
+  lines.push(status.disk
+    ? `  disk=${formatBytes(status.disk.availableBytes)} free minimum=${formatBytes(status.disk.minRequiredBytes)} healthy=${status.disk.healthy ? 'yes' : 'no'}`
+    : '  disk=not recorded (run maintenance once with the current version)');
+  return lines.join('\n');
 }
 
 function getMaintenanceLastRunStatusPath(homeDir: string): string {
   return path.join(homeDir, '.claude-code', 'memory', 'maintenance-status.json');
 }
 
-async function inspectMaintenanceTarget(target: MaintenanceTarget): Promise<OutboxStats> {
+class MaintenanceInspectionNeedsWriteError extends Error {}
+
+async function inspectMaintenanceTarget(
+  target: MaintenanceTarget,
+  options: { allowMigration: boolean }
+): Promise<OutboxStats> {
   const store = new SQLiteEventStore(path.join(target.storagePath, 'events.sqlite'), { readonly: true });
   try {
     await store.initialize();
@@ -312,7 +421,9 @@ async function inspectMaintenanceTarget(target: MaintenanceTarget): Promise<Outb
 
   // A pre-outbox store cannot be inspected read-only until current tables are
   // present. Maintenance is already an explicit writable operation, so run the
-  // normal idempotent schema initializer once and then continue.
+  // normal idempotent schema initializer once and then continue. Under disk
+  // pressure, report the store as blocked instead of performing that migration.
+  if (!options.allowMigration) throw new MaintenanceInspectionNeedsWriteError();
   const migratingStore = new SQLiteEventStore(path.join(target.storagePath, 'events.sqlite'));
   try {
     await migratingStore.initialize();
@@ -388,6 +499,39 @@ function normalizeMaxBatches(value: number | undefined): number {
     throw new Error('--max-batches must be an integer between 1 and 100');
   }
   return value;
+}
+
+function normalizeMinFreeBytes(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_MAINTENANCE_MIN_FREE_BYTES;
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error('minimum free bytes must be a non-negative safe integer');
+  }
+  return value;
+}
+
+function findExistingAncestor(input: string): string {
+  let current = path.resolve(input);
+  while (!fs.existsSync(current)) {
+    const parent = path.dirname(current);
+    if (parent === current) return parent;
+    current = parent;
+  }
+  return current;
+}
+
+function isMaintenanceDiskStatus(value: unknown): value is MaintenanceDiskStatus {
+  if (!value || typeof value !== 'object') return false;
+  const disk = value as Partial<MaintenanceDiskStatus>;
+  return Number.isFinite(disk.availableBytes)
+    && Number.isFinite(disk.totalBytes)
+    && Number.isFinite(disk.minRequiredBytes)
+    && typeof disk.healthy === 'boolean';
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes <= 0) return '0 B';
+  const gibibytes = bytes / (1024 * 1024 * 1024);
+  return `${gibibytes.toFixed(gibibytes >= 10 ? 1 : 2)} GiB`;
 }
 
 function getStoreModifiedAtMs(storagePath: string): number {

--- a/src/apps/cli/project-scope-audit.ts
+++ b/src/apps/cli/project-scope-audit.ts
@@ -1,0 +1,213 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { createSQLiteDatabase, sqliteAll, sqliteClose } from '../../core/sqlite-wrapper.js';
+import { hashProjectPath } from '../../core/registry/project-path.js';
+import { loadSessionRegistry, type SessionRegistry } from '../../core/registry/session-registry.js';
+
+export interface ProjectScopeStoreSession {
+  storeHash: string;
+  sessionId: string;
+  eventCount: number;
+}
+
+export interface ProjectScopeAuditOptions {
+  homeDir?: string;
+  days?: number;
+}
+
+export interface ProjectScopeAuditReport {
+  schemaVersion: 'project-scope-audit-v1';
+  mode: 'read-only';
+  days: number;
+  scannedStoreCount: number;
+  unreadableStoreCount: number;
+  recentSessionCount: number;
+  correctlyScopedSessionCount: number;
+  staleRegistrySessionCount: number;
+  unregisteredSessionCount: number;
+  mismatchedSessionCount: number;
+  duplicateSessionCount: number;
+  mismatchedEventCount: number;
+}
+
+export interface ProjectScopeAuditDeps {
+  discoverStoreSessions?: (options: Required<ProjectScopeAuditOptions>) => {
+    rows: ProjectScopeStoreSession[];
+    scannedStoreCount: number;
+    unreadableStoreCount: number;
+  };
+  loadRegistry?: (homeDir: string) => SessionRegistry;
+  canonicalHash?: (projectPath: string) => string;
+}
+
+export function parseProjectScopeAuditDays(value: string | number | undefined): number {
+  if (value === undefined) return 7;
+  const parsed = typeof value === 'number' ? value : Number(value.trim());
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > 365) {
+    throw new Error('--days must be an integer between 1 and 365');
+  }
+  return parsed;
+}
+
+export function auditProjectScope(
+  options: ProjectScopeAuditOptions = {},
+  deps: ProjectScopeAuditDeps = {}
+): ProjectScopeAuditReport {
+  const resolved = {
+    homeDir: options.homeDir ?? os.homedir(),
+    days: parseProjectScopeAuditDays(options.days)
+  };
+  const discovered = (deps.discoverStoreSessions ?? discoverProjectStoreSessions)(resolved);
+  const registry = (deps.loadRegistry ?? ((homeDir) => loadSessionRegistry({ homeDir })))(resolved.homeDir);
+  const canonicalHash = deps.canonicalHash ?? hashProjectPath;
+  const bySession = new Map<string, ProjectScopeStoreSession[]>();
+  for (const row of discovered.rows) {
+    const existing = bySession.get(row.sessionId) ?? [];
+    existing.push(row);
+    bySession.set(row.sessionId, existing);
+  }
+
+  const canonicalByPath = new Map<string, string>();
+  let correctlyScopedSessionCount = 0;
+  let staleRegistrySessionCount = 0;
+  let unregisteredSessionCount = 0;
+  let mismatchedSessionCount = 0;
+  let duplicateSessionCount = 0;
+  let mismatchedEventCount = 0;
+
+  for (const [sessionId, rows] of bySession) {
+    const entry = registry.sessions[sessionId];
+    if (rows.length > 1) duplicateSessionCount += 1;
+    if (!entry) {
+      unregisteredSessionCount += 1;
+      continue;
+    }
+
+    let canonical = canonicalByPath.get(entry.projectPath);
+    if (!canonical) {
+      canonical = canonicalHash(entry.projectPath);
+      canonicalByPath.set(entry.projectPath, canonical);
+    }
+    const staleRegistry = canonical !== entry.projectHash;
+    if (staleRegistry) staleRegistrySessionCount += 1;
+
+    const mismatchedRows = rows.filter((row) => row.storeHash !== canonical);
+    if (mismatchedRows.length > 0) {
+      mismatchedSessionCount += 1;
+      mismatchedEventCount += mismatchedRows.reduce((sum, row) => sum + row.eventCount, 0);
+    }
+    if (!staleRegistry && rows.length === 1 && mismatchedRows.length === 0) {
+      correctlyScopedSessionCount += 1;
+    }
+  }
+
+  return {
+    schemaVersion: 'project-scope-audit-v1',
+    mode: 'read-only',
+    days: resolved.days,
+    scannedStoreCount: discovered.scannedStoreCount,
+    unreadableStoreCount: discovered.unreadableStoreCount,
+    recentSessionCount: bySession.size,
+    correctlyScopedSessionCount,
+    staleRegistrySessionCount,
+    unregisteredSessionCount,
+    mismatchedSessionCount,
+    duplicateSessionCount,
+    mismatchedEventCount
+  };
+}
+
+export function formatProjectScopeAudit(report: ProjectScopeAuditReport): string {
+  return [
+    `Project scope audit (${report.days} days, read-only)`,
+    `Stores scanned: ${report.scannedStoreCount}`,
+    `Unreadable stores: ${report.unreadableStoreCount}`,
+    `Recent sessions: ${report.recentSessionCount}`,
+    `Correctly scoped sessions: ${report.correctlyScopedSessionCount}`,
+    `Stale registry sessions: ${report.staleRegistrySessionCount}`,
+    `Unregistered sessions: ${report.unregisteredSessionCount}`,
+    `Mismatched sessions: ${report.mismatchedSessionCount}`,
+    `Duplicate sessions: ${report.duplicateSessionCount}`,
+    `Events in non-canonical stores: ${report.mismatchedEventCount}`,
+    'No project stores or registry entries were changed.'
+  ].join('\n');
+}
+
+function discoverProjectStoreSessions(options: Required<ProjectScopeAuditOptions>): {
+  rows: ProjectScopeStoreSession[];
+  scannedStoreCount: number;
+  unreadableStoreCount: number;
+} {
+  const memoryRoot = path.join(options.homeDir, '.claude-code', 'memory');
+  const projectsRoot = path.join(memoryRoot, 'projects');
+  const rows: ProjectScopeStoreSession[] = [];
+  const stores: Array<{ storeHash: string; dbPath: string }> = [];
+  let scannedStoreCount = 0;
+  let unreadableStoreCount = 0;
+
+  const globalDbPath = path.join(memoryRoot, 'events.sqlite');
+  if (isLocalFile(globalDbPath)) {
+    stores.push({ storeHash: '__global__', dbPath: globalDbPath });
+  }
+
+  let entries: fs.Dirent[] = [];
+  try {
+    entries = fs.readdirSync(projectsRoot, { withFileTypes: true });
+  } catch {
+    entries = [];
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.isSymbolicLink() || !/^[a-f0-9]{8}$/.test(entry.name)) continue;
+    const dbPath = path.join(projectsRoot, entry.name, 'events.sqlite');
+    if (!isLocalFile(dbPath)) continue;
+    stores.push({ storeHash: entry.name, dbPath });
+  }
+
+  for (const store of stores) {
+    scannedStoreCount += 1;
+    let db;
+    let unreadable = false;
+    const storeRows: ProjectScopeStoreSession[] = [];
+    try {
+      db = createSQLiteDatabase(store.dbPath, { readonly: true });
+      const recent = sqliteAll<{ sessionId: string; eventCount: number }>(
+        db,
+        `SELECT session_id AS sessionId, COUNT(*) AS eventCount
+         FROM events
+         WHERE datetime(timestamp) >= datetime('now', ?)
+         GROUP BY session_id`,
+        [`-${options.days} days`]
+      );
+      for (const row of recent) {
+        storeRows.push({ storeHash: store.storeHash, sessionId: row.sessionId, eventCount: Number(row.eventCount) });
+      }
+    } catch {
+      unreadable = true;
+    } finally {
+      if (db) {
+        try {
+          sqliteClose(db);
+        } catch {
+          unreadable = true;
+        }
+      }
+    }
+    if (unreadable) {
+      unreadableStoreCount += 1;
+    } else {
+      rows.push(...storeRows);
+    }
+  }
+  return { rows, scannedStoreCount, unreadableStoreCount };
+}
+
+function isLocalFile(file: string): boolean {
+  try {
+    return fs.lstatSync(file).isFile();
+  } catch {
+    return false;
+  }
+}

--- a/src/extensions/mcp/handlers.ts
+++ b/src/extensions/mcp/handlers.ts
@@ -9,6 +9,7 @@ import * as path from 'node:path';
 import {
   getDefaultMemoryService,
   getMemoryServiceForProject,
+  shutdownMemoryServices,
   type MemoryService
 } from '../../services/memory-service.js';
 import { SQLiteEventStore } from '../../core/sqlite-event-store.js';
@@ -100,6 +101,9 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 type ToolResult = CallToolResult;
 
 type MemoryToolArgs = Record<string, unknown>;
+
+/** Release process-scoped services owned by MCP handlers. */
+export const shutdownMcpMemoryServices = shutdownMemoryServices;
 
 /**
  * Cached because the MCP server's cwd is fixed for the life of the process —

--- a/src/extensions/mcp/idle-resources.ts
+++ b/src/extensions/mcp/idle-resources.ts
@@ -1,0 +1,88 @@
+export const DEFAULT_MCP_IDLE_RELEASE_MS = 10 * 60 * 1000;
+
+export interface McpIdleResourceControllerOptions {
+  release: () => Promise<void>;
+  idleMs?: number;
+  now?: () => number;
+}
+
+export interface McpIdleResourceController {
+  run<T>(operation: () => Promise<T>): Promise<T>;
+  releaseIfIdle(): Promise<boolean>;
+  stopAccepting(): void;
+  waitForIdle(): Promise<void>;
+  waitForRelease(): Promise<void>;
+}
+
+export function parseMcpIdleReleaseMs(value: string | undefined): number {
+  if (value === undefined || value.trim() === '') return DEFAULT_MCP_IDLE_RELEASE_MS;
+  const parsed = Number(value.trim());
+  if (!Number.isSafeInteger(parsed) || parsed < 60_000 || parsed > 24 * 60 * 60 * 1000) {
+    return DEFAULT_MCP_IDLE_RELEASE_MS;
+  }
+  return parsed;
+}
+
+/** Release model/native resources after inactivity while keeping the MCP stdio process available. */
+export function createMcpIdleResourceController(
+  options: McpIdleResourceControllerOptions
+): McpIdleResourceController {
+  const now = options.now ?? Date.now;
+  const idleMs = options.idleMs ?? DEFAULT_MCP_IDLE_RELEASE_MS;
+  let activeCalls = 0;
+  let lastActivityAt = now();
+  let releasePromise: Promise<void> | null = null;
+  let accepting = true;
+  const idleWaiters = new Set<() => void>();
+
+  const waitForIdle = (): Promise<void> => {
+    if (activeCalls === 0) return Promise.resolve();
+    return new Promise<void>((resolve) => idleWaiters.add(resolve));
+  };
+
+  const waitForRelease = async (): Promise<void> => {
+    await releasePromise;
+  };
+
+  const run = async <T>(operation: () => Promise<T>): Promise<T> => {
+    if (!accepting) throw new Error('MCP server is shutting down');
+    // Reserve the call synchronously when there is no release in progress;
+    // an unconditional await here would create a microtask-sized window where
+    // the idle timer could start disposing resources for a call already handed
+    // to this controller.
+    if (releasePromise) await releasePromise;
+    if (!accepting) throw new Error('MCP server is shutting down');
+    activeCalls += 1;
+    lastActivityAt = now();
+    try {
+      return await operation();
+    } finally {
+      activeCalls -= 1;
+      lastActivityAt = now();
+      if (activeCalls === 0) {
+        for (const resolve of idleWaiters) resolve();
+        idleWaiters.clear();
+      }
+    }
+  };
+
+  const releaseIfIdle = async (): Promise<boolean> => {
+    if (activeCalls > 0 || releasePromise || now() - lastActivityAt < idleMs) return false;
+    releasePromise = options.release();
+    try {
+      await releasePromise;
+      return true;
+    } finally {
+      lastActivityAt = now();
+      releasePromise = null;
+    }
+  };
+
+  return {
+    run,
+    releaseIfIdle,
+    stopAccepting: () => { accepting = false; },
+    waitForIdle,
+    waitForRelease
+  };
+}

--- a/src/extensions/mcp/index.ts
+++ b/src/extensions/mcp/index.ts
@@ -13,7 +13,9 @@ import {
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
 import { tools } from './tools.js';
-import { handleToolCall } from './handlers.js';
+import { handleToolCall, shutdownMcpMemoryServices } from './handlers.js';
+import { createMcpIdleResourceController, parseMcpIdleReleaseMs } from './idle-resources.js';
+import { createMcpProcessLifecycle } from './process-lifecycle.js';
 
 const server = new Server(
   {
@@ -27,6 +29,11 @@ const server = new Server(
   }
 );
 
+const idleResources = createMcpIdleResourceController({
+  release: shutdownMcpMemoryServices,
+  idleMs: parseMcpIdleReleaseMs(process.env.CLAUDE_MEMORY_MCP_IDLE_RELEASE_MS)
+});
+
 // Tool listing handler
 server.setRequestHandler(ListToolsRequestSchema, async () => {
   return { tools };
@@ -35,14 +42,52 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 // Tool call handler
 server.setRequestHandler(CallToolRequestSchema, async (request): Promise<CallToolResult> => {
   const { name, arguments: args } = request.params;
-  return handleToolCall(name, args || {});
+  return idleResources.run(() => handleToolCall(name, args || {}));
 });
 
 // Start server
 async function main() {
   const transport = new StdioServerTransport();
+  let lifecycleCheck: NodeJS.Timeout | null = null;
+  const lifecycle = createMcpProcessLifecycle({
+    shutdown: async () => {
+      if (lifecycleCheck) clearInterval(lifecycleCheck);
+      idleResources.stopAccepting();
+      await idleResources.waitForIdle();
+      await idleResources.waitForRelease();
+      await Promise.allSettled([
+        server.close(),
+        shutdownMcpMemoryServices()
+      ]);
+    },
+    exit: (code) => process.exit(code),
+    getParentPid: () => process.ppid
+  });
+
+  const shutdownNormally = () => { void lifecycle.requestShutdown(0); };
+  const shutdownForFailure = () => { void lifecycle.requestShutdown(1); };
+  process.stdin.once('end', shutdownNormally);
+  process.stdin.once('close', shutdownNormally);
+  process.once('SIGINT', shutdownNormally);
+  process.once('SIGTERM', shutdownNormally);
+  process.once('SIGHUP', shutdownNormally);
+  process.once('uncaughtException', shutdownForFailure);
+  process.once('unhandledRejection', shutdownForFailure);
+  lifecycleCheck = setInterval(() => {
+    lifecycle.checkParent();
+    void idleResources.releaseIfIdle().catch(() => {
+      console.error('claude-memory-layer MCP idle resource release failed');
+    });
+  }, 30_000);
+  lifecycleCheck.unref();
+
   await server.connect(transport);
   console.error('claude-memory-layer MCP server started');
 }
 
-main().catch(console.error);
+main().catch((error) => {
+  console.error('claude-memory-layer MCP server failed:', error instanceof Error ? error.message : 'unknown error');
+  // stdin listeners are already attached at this point. Merely assigning
+  // exitCode would keep a failed stdio server alive until its client closes.
+  process.exit(1);
+});

--- a/src/extensions/mcp/process-lifecycle.ts
+++ b/src/extensions/mcp/process-lifecycle.ts
@@ -1,0 +1,47 @@
+export interface McpProcessLifecycleOptions {
+  shutdown: () => Promise<void>;
+  exit: (code: number) => void;
+  getParentPid: () => number;
+  initialParentPid?: number;
+}
+
+export interface McpProcessLifecycle {
+  requestShutdown(code?: number): Promise<void>;
+  checkParent(): void;
+  isShuttingDown(): boolean;
+}
+
+/**
+ * Coordinate one idempotent MCP shutdown path for stdio close, signals, and
+ * parent-process loss. StdioServerTransport does not subscribe to stdin
+ * end/close itself, so relying on the SDK alone can leave model-heavy servers
+ * orphaned after their client disappears.
+ */
+export function createMcpProcessLifecycle(options: McpProcessLifecycleOptions): McpProcessLifecycle {
+  const initialParentPid = options.initialParentPid ?? options.getParentPid();
+  let shutdownPromise: Promise<void> | null = null;
+
+  const requestShutdown = (code = 0): Promise<void> => {
+    if (shutdownPromise) return shutdownPromise;
+    shutdownPromise = (async () => {
+      try {
+        await options.shutdown();
+      } finally {
+        options.exit(code);
+      }
+    })();
+    return shutdownPromise;
+  };
+
+  const checkParent = (): void => {
+    if (initialParentPid > 1 && options.getParentPid() === 1) {
+      void requestShutdown(0);
+    }
+  };
+
+  return {
+    requestShutdown,
+    checkParent,
+    isShuttingDown: () => shutdownPromise !== null
+  };
+}

--- a/src/extensions/vector/embedder.ts
+++ b/src/extensions/vector/embedder.ts
@@ -24,7 +24,9 @@ export const DEFAULT_EMBEDDING_FALLBACK_MODEL = 'intfloat/multilingual-e5-small'
 const MANAGED_EMBEDDING_BACKEND_DIR = '.claude-memory-layer-embedding-backend';
 
 export class Embedder {
-  private pipeline: ((input: string, options?: Record<string, unknown>) => Promise<{ data: Float32Array }>) | null = null;
+  private pipeline: (((input: string, options?: Record<string, unknown>) => Promise<{ data: Float32Array }>) & {
+    dispose?: () => void | Promise<void>;
+  }) | null = null;
   private readonly modelName: string;
   private activeModelName: string;
   private initialized = false;
@@ -193,6 +195,15 @@ export class Embedder {
   getModelName(): string {
     return this.activeModelName;
   }
+
+  /** Release the native ONNX model so a long-lived but idle MCP process does not retain it. */
+  async dispose(): Promise<void> {
+    const pipeline = this.pipeline;
+    this.pipeline = null;
+    this.initialized = false;
+    this.activeModelName = this.modelName;
+    await pipeline?.dispose?.();
+  }
 }
 
 // Singleton instance for reuse
@@ -204,6 +215,12 @@ export function getDefaultEmbedder(): Embedder {
     defaultEmbedder = new Embedder(envModel || undefined);
   }
   return defaultEmbedder;
+}
+
+export async function disposeDefaultEmbedder(): Promise<void> {
+  const embedder = defaultEmbedder;
+  defaultEmbedder = null;
+  await embedder?.dispose();
 }
 
 let transformersWarningSuppressionDepth = 0;

--- a/src/services/memory-service-registry.ts
+++ b/src/services/memory-service-registry.ts
@@ -19,6 +19,7 @@ export type MemoryServiceRegistryConfig = MemoryServiceConfig & {
 
 export interface MemoryServiceRegistryDeps<TService> {
   createService: (config: MemoryServiceRegistryConfig) => TService;
+  disposeService?: (service: TService) => void | Promise<void>;
   hashProjectPath: (projectPath: string) => string;
   getProjectStoragePath: (projectPath: string) => string;
   getSessionProject: (sessionId: string) => { projectHash: string; projectPath: string } | null;
@@ -35,6 +36,7 @@ export interface MemoryServiceRegistry<TService> {
   getLightweightMemoryService(sessionId: string): TService;
   getLightweightMemoryServiceForProject(projectPath: string): TService;
   createMemoryService(config: MemoryServiceConfig): TService;
+  shutdownAll(): Promise<void>;
 }
 
 const GLOBAL_KEY = '__global__';
@@ -43,10 +45,16 @@ export function createMemoryServiceRegistry<TService>(
   deps: MemoryServiceRegistryDeps<TService>
 ): MemoryServiceRegistry<TService> {
   const serviceCache = deps.serviceCache ?? new Map<string, TService>();
+  const ownedServices = new Set<TService>();
+  const createOwnedService = (config: MemoryServiceRegistryConfig): TService => {
+    const service = deps.createService(config);
+    ownedServices.add(service);
+    return service;
+  };
 
   const getDefaultMemoryService = (): TService => {
     if (!serviceCache.has(GLOBAL_KEY)) {
-      serviceCache.set(GLOBAL_KEY, deps.createService({
+      serviceCache.set(GLOBAL_KEY, createOwnedService({
         storagePath: '~/.claude-code/memory',
         analyticsEnabled: false,
         sharedStoreConfig: deps.disabledSharedStoreConfig
@@ -55,6 +63,9 @@ export function createMemoryServiceRegistry<TService>(
     return serviceCache.get(GLOBAL_KEY)!;
   };
 
+  // Read-only and explicit factory services are intentionally uncached. Their
+  // callers own their lifetime; retaining every dashboard/API request here
+  // would turn shutdown bookkeeping into a process-lifetime memory leak.
   const getReadOnlyMemoryService = (): TService => deps.createService({
     storagePath: '~/.claude-code/memory',
     readOnly: true,
@@ -69,7 +80,7 @@ export function createMemoryServiceRegistry<TService>(
     const hash = deps.hashProjectPath(projectPath);
 
     if (!serviceCache.has(hash)) {
-      serviceCache.set(hash, deps.createService({
+      serviceCache.set(hash, createOwnedService({
         storagePath: deps.getProjectStoragePath(projectPath),
         projectHash: hash,
         projectPath,
@@ -101,7 +112,7 @@ export function createMemoryServiceRegistry<TService>(
   ): TService => {
     const key = `lightweight_${projectHash}`;
     if (!serviceCache.has(key)) {
-      serviceCache.set(key, deps.createService({
+      serviceCache.set(key, createOwnedService({
         storagePath: deps.getProjectStoragePath(projectPath),
         projectHash,
         projectPath,
@@ -122,7 +133,7 @@ export function createMemoryServiceRegistry<TService>(
 
     const key = 'lightweight_global';
     if (!serviceCache.has(key)) {
-      serviceCache.set(key, deps.createService({
+      serviceCache.set(key, createOwnedService({
         storagePath: path.join(deps.homedir(), '.claude-code', 'memory'),
         lightweightMode: true,
         analyticsEnabled: false,
@@ -138,6 +149,23 @@ export function createMemoryServiceRegistry<TService>(
     return getOrCreateLightweightProjectService(projectHash, projectPath);
   };
 
+  const shutdownAll = async (): Promise<void> => {
+    const services = Array.from(ownedServices);
+    // Clear first so repeated close signals cannot dispose the same native or
+    // vector resources twice.
+    ownedServices.clear();
+    serviceCache.clear();
+    if (!deps.disposeService || services.length === 0) return;
+
+    const settled = await Promise.allSettled(services.map((service) => deps.disposeService!(service)));
+    const failures = settled
+      .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+      .map((result) => result.reason);
+    if (failures.length > 0) {
+      throw new AggregateError(failures, `Failed to shut down ${failures.length} memory service(s)`);
+    }
+  };
+
   return {
     getDefaultMemoryService,
     getReadOnlyMemoryService,
@@ -145,6 +173,7 @@ export function createMemoryServiceRegistry<TService>(
     getMemoryServiceForSession,
     getLightweightMemoryService,
     getLightweightMemoryServiceForProject,
-    createMemoryService: (config: MemoryServiceConfig): TService => deps.createService(config)
+    createMemoryService: (config: MemoryServiceConfig): TService => deps.createService(config),
+    shutdownAll
   };
 }

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -6,6 +6,7 @@
 import * as os from 'os';
 
 import type { RetrievalResult, UnifiedRetrievalResult } from '../core/retriever.js';
+import { disposeDefaultEmbedder } from '../core/embedder.js';
 import type { PromotionResult } from '../core/shared-promoter.js';
 import type { SharedMemoryServices } from '../extensions/shared-memory/index.js';
 import type {
@@ -802,6 +803,7 @@ const defaultRegistry = createMemoryServiceRegistry<MemoryService>({
   // caller passes them explicitly; without this, no production surface (hooks,
   // MCP server, daemon) could ever enable codifyLite/graphExpansion/etc.
   createService: (config) => new MemoryService({ operations: loadMemoryOperationsConfig(), ...config }),
+  disposeService: (service) => service.shutdown(),
   hashProjectPath: defaultHashProjectPath,
   getProjectStoragePath: defaultGetProjectStoragePath,
   getSessionProject: defaultGetSessionProject,
@@ -816,3 +818,21 @@ export const getMemoryServiceForSession = defaultRegistry.getMemoryServiceForSes
 export const getLightweightMemoryService = defaultRegistry.getLightweightMemoryService;
 export const getLightweightMemoryServiceForProject = defaultRegistry.getLightweightMemoryServiceForProject;
 export const createMemoryService = defaultRegistry.createMemoryService;
+export async function shutdownMemoryServices(): Promise<void> {
+  const failures: unknown[] = [];
+  // Services own background workers that can still be executing the shared
+  // embedder. Stop and drain those workers before disposing the native model.
+  try {
+    await defaultRegistry.shutdownAll();
+  } catch (error) {
+    failures.push(error);
+  }
+  try {
+    await disposeDefaultEmbedder();
+  } catch (error) {
+    failures.push(error);
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, 'Failed to release memory runtime resources');
+  }
+}

--- a/tests/apps/dashboard-cli-options.test.ts
+++ b/tests/apps/dashboard-cli-options.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveDashboardCommandOptions } from '../../src/apps/cli/dashboard-command.js';
+import { formatDashboardStatus, resolveDashboardCommandOptions } from '../../src/apps/cli/dashboard-command.js';
 
 describe('dashboard CLI option resolution', () => {
+  it('scopes status output to the checked port instead of claiming every dashboard is stopped', () => {
+    expect(formatDashboardStatus(true)).toContain('port 37777');
+    expect(formatDashboardStatus(false)).toContain('custom-port instances are not checked');
+    expect(formatDashboardStatus(false)).not.toContain('Dashboard: ⏹️  Not running');
+  });
+
   it('defaults to localhost bind without a dashboard password', () => {
     expect(resolveDashboardCommandOptions({ port: '37777' })).toEqual({
       port: 37777,

--- a/tests/apps/maintenance-runner.test.ts
+++ b/tests/apps/maintenance-runner.test.ts
@@ -7,6 +7,8 @@ import {
   discoverMaintenanceTargets,
   formatMaintenanceLastRunStatus,
   formatMaintenanceRunReport,
+  maintenanceRunRequiresAttention,
+  parseMaintenanceMinFreeBytes,
   readMaintenanceLastRunStatus,
   runMaintenanceCycle,
   writeMaintenanceLastRunStatus,
@@ -75,6 +77,7 @@ describe('maintenance runner', () => {
           stats: stats({})
         };
       },
+      getDiskStatus: () => healthyDisk(),
       now: () => new Date('2026-08-11T00:00:00Z')
     });
 
@@ -83,6 +86,7 @@ describe('maintenance runner', () => {
       processed: 5,
       recovered: 1,
       busy: 1,
+      blocked: 0,
       errors: 1,
       pendingRemaining: 2,
       retryableRemaining: 0,
@@ -108,6 +112,107 @@ describe('maintenance runner', () => {
     expect(() => discoverMaintenanceTargets({ homeDir: '/tmp', maxProjects: 0 })).toThrow('--max-projects');
     await expect(runMaintenanceCycle({ maxBatches: 0 }, { discoverTargets: () => [] }))
       .rejects.toThrow('--max-batches');
+  });
+
+  it('validates the configurable free-space threshold', () => {
+    expect(parseMaintenanceMinFreeBytes(undefined)).toBe(5 * 1024 * 1024 * 1024);
+    expect(parseMaintenanceMinFreeBytes('0')).toBe(0);
+    expect(parseMaintenanceMinFreeBytes('1.5')).toBe(Math.floor(1.5 * 1024 * 1024 * 1024));
+    expect(() => parseMaintenanceMinFreeBytes('   ')).toThrow('--min-free-gb');
+    expect(() => parseMaintenanceMinFreeBytes('-1')).toThrow('--min-free-gb');
+    expect(() => parseMaintenanceMinFreeBytes('invalid')).toThrow('--min-free-gb');
+  });
+
+  it('reports actionable queues but blocks writes under disk pressure', async () => {
+    let processCalls = 0;
+    const report = await runMaintenanceCycle({}, {
+      discoverTargets: () => [{ key: 'pending', storagePath: '/private/pending', modifiedAtMs: 1 }],
+      inspectTarget: async (_target, options) => {
+        expect(options.allowMigration).toBe(false);
+        return stats({ embeddingPending: 7 });
+      },
+      processTarget: async () => {
+        processCalls += 1;
+        throw new Error('must not run');
+      },
+      getDiskStatus: () => ({
+        availableBytes: 1024,
+        totalBytes: 10_000,
+        minRequiredBytes: 2048,
+        healthy: false
+      }),
+      now: () => new Date('2026-08-11T00:00:00Z')
+    });
+
+    expect(processCalls).toBe(0);
+    expect(report).toMatchObject({
+      blocked: 1,
+      errors: 0,
+      pendingRemaining: 7,
+      disk: { healthy: false }
+    });
+    expect(report.results[0]).toMatchObject({ status: 'blocked', pendingAfter: 7 });
+    expect(formatMaintenanceRunReport(report)).toContain('Disk-pressure stores blocked: 1');
+  });
+
+  it('rechecks free space between stores and stops new writes mid-cycle', async () => {
+    const processed: string[] = [];
+    let diskChecks = 0;
+    const report = await runMaintenanceCycle({}, {
+      discoverTargets: () => ['first', 'second'].map((key) => ({
+        key,
+        storagePath: `/private/${key}`,
+        modifiedAtMs: 1
+      })),
+      inspectTarget: async () => stats({ embeddingPending: 1 }),
+      processTarget: async (target) => {
+        processed.push(target.key);
+        return {
+          processed: 1,
+          recovery: {
+            embedding: { recoveredProcessing: 0, retriedFailed: 0 },
+            vector: { recoveredProcessing: 0, retriedFailed: 0 }
+          },
+          stats: stats({})
+        };
+      },
+      getDiskStatus: () => {
+        diskChecks += 1;
+        const healthy = diskChecks === 1;
+        return {
+          availableBytes: healthy ? 10_000 : 1_000,
+          totalBytes: 20_000,
+          minRequiredBytes: 5_000,
+          healthy
+        };
+      },
+      now: () => new Date('2026-08-11T00:00:00Z')
+    });
+
+    expect(processed).toEqual(['first']);
+    expect(report).toMatchObject({ processed: 1, blocked: 1, disk: { healthy: false } });
+    expect(maintenanceRunRequiresAttention(report)).toBe(true);
+    expect(diskChecks).toBe(3);
+  });
+
+  it('requires attention when the final disk check crosses the threshold', async () => {
+    let diskChecks = 0;
+    const report = await runMaintenanceCycle({}, {
+      discoverTargets: () => [],
+      getDiskStatus: () => {
+        diskChecks += 1;
+        return {
+          availableBytes: 1_000,
+          totalBytes: 20_000,
+          minRequiredBytes: 5_000,
+          healthy: false
+        };
+      }
+    });
+
+    expect(report).toMatchObject({ scanned: 0, blocked: 0, disk: { healthy: false } });
+    expect(maintenanceRunRequiresAttention(report)).toBe(true);
+    expect(diskChecks).toBe(1);
   });
 
   it('uses WAL activity when limiting scans to the most recently written stores', () => {
@@ -141,10 +246,12 @@ describe('maintenance runner', () => {
       processed: 5,
       recovered: 1,
       busy: 0,
+      blocked: 0,
       errors: 0,
       pendingRemaining: 2,
       retryableRemaining: 1,
       quarantined: 3,
+      disk: healthyDisk(),
       results: [{
         key: 'PRIVATE_PROJECT_HASH',
         status: 'needs-attention' as const,
@@ -166,6 +273,30 @@ describe('maintenance runner', () => {
     const raw = requireStatusFile(statusPath);
     expect(raw).not.toContain('PRIVATE_PROJECT_HASH');
     expect(raw).not.toContain('PRIVATE_PAYLOAD');
+  });
+
+  it('reads pre-disk-pressure version 1 status without inventing free-space data', () => {
+    const homeDir = mkdtempSync(path.join(tmpdir(), 'cml-maintenance-legacy-status-'));
+    tempDirs.push(homeDir);
+    const statusPath = path.join(homeDir, '.claude-code', 'memory', 'maintenance-status.json');
+    mkdirSync(path.dirname(statusPath), { recursive: true });
+    writeFileSync(statusPath, JSON.stringify({
+      version: 1,
+      startedAt: '2026-08-11T00:00:00.000Z',
+      finishedAt: '2026-08-11T00:01:00.000Z',
+      scanned: 2,
+      processed: 0,
+      recovered: 0,
+      busy: 0,
+      errors: 0,
+      pendingRemaining: 0,
+      retryableRemaining: 0,
+      quarantined: 3
+    }));
+
+    const status = readMaintenanceLastRunStatus(homeDir);
+    expect(status).toMatchObject({ blocked: 0, disk: null });
+    expect(formatMaintenanceLastRunStatus(status)).toContain('disk=not recorded');
   });
 });
 
@@ -201,4 +332,13 @@ function stats(input: {
 
 function requireStatusFile(filePath: string): string {
   return readFileSync(filePath, 'utf8');
+}
+
+function healthyDisk() {
+  return {
+    availableBytes: 10 * 1024 * 1024 * 1024,
+    totalBytes: 100 * 1024 * 1024 * 1024,
+    minRequiredBytes: 5 * 1024 * 1024 * 1024,
+    healthy: true
+  };
 }

--- a/tests/apps/project-scope-audit.test.ts
+++ b/tests/apps/project-scope-audit.test.ts
@@ -1,0 +1,118 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  auditProjectScope,
+  formatProjectScopeAudit,
+  parseProjectScopeAuditDays
+} from '../../src/apps/cli/project-scope-audit.js';
+import type { SessionRegistry } from '../../src/core/registry/session-registry.js';
+import { hashProjectPath } from '../../src/core/registry/project-path.js';
+import { createSQLiteDatabase, sqliteClose, sqliteExec } from '../../src/core/sqlite-wrapper.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('project scope audit', () => {
+  it('validates bounded audit windows', () => {
+    expect(parseProjectScopeAuditDays(undefined)).toBe(7);
+    expect(parseProjectScopeAuditDays('30')).toBe(30);
+    expect(() => parseProjectScopeAuditDays('0')).toThrow('--days');
+    expect(() => parseProjectScopeAuditDays('1.5')).toThrow('--days');
+    expect(() => parseProjectScopeAuditDays('invalid')).toThrow('--days');
+  });
+
+  it('reports only aggregate stale, missing, mismatched, and duplicate scope state', () => {
+    const registry: SessionRegistry = {
+      version: 1,
+      sessions: {
+        good: { projectPath: '/repo/good', projectHash: 'aaaaaaaa', registeredAt: '2026-08-12T00:00:00Z' },
+        stale: { projectPath: '/repo/stale', projectHash: 'legacy00', registeredAt: '2026-08-12T00:00:00Z' },
+        duplicate: { projectPath: '/repo/duplicate', projectHash: 'cccccccc', registeredAt: '2026-08-12T00:00:00Z' }
+      }
+    };
+    const report = auditProjectScope({ homeDir: '/private/home', days: 7 }, {
+      discoverStoreSessions: () => ({
+        scannedStoreCount: 4,
+        unreadableStoreCount: 1,
+        rows: [
+          { storeHash: 'aaaaaaaa', sessionId: 'good', eventCount: 10 },
+          { storeHash: 'bbbbbbbb', sessionId: 'stale', eventCount: 3 },
+          { storeHash: 'dddddddd', sessionId: 'missing', eventCount: 2 },
+          { storeHash: 'cccccccc', sessionId: 'duplicate', eventCount: 5 },
+          { storeHash: 'eeeeeeee', sessionId: 'duplicate', eventCount: 4 }
+        ]
+      }),
+      loadRegistry: () => registry,
+      canonicalHash: (projectPath) => ({
+        '/repo/good': 'aaaaaaaa',
+        '/repo/stale': 'bbbbbbbb',
+        '/repo/duplicate': 'cccccccc'
+      })[projectPath] ?? 'ffffffff'
+    });
+
+    expect(report).toEqual({
+      schemaVersion: 'project-scope-audit-v1',
+      mode: 'read-only',
+      days: 7,
+      scannedStoreCount: 4,
+      unreadableStoreCount: 1,
+      recentSessionCount: 4,
+      correctlyScopedSessionCount: 1,
+      staleRegistrySessionCount: 1,
+      unregisteredSessionCount: 1,
+      mismatchedSessionCount: 1,
+      duplicateSessionCount: 1,
+      mismatchedEventCount: 4
+    });
+    const output = formatProjectScopeAudit(report);
+    expect(output).toContain('No project stores or registry entries were changed.');
+    expect(output).not.toContain('/private/home');
+    expect(output).not.toContain('good');
+  });
+
+  it('includes sessions incorrectly routed to the global store', () => {
+    const homeDir = mkdtempSync(path.join(tmpdir(), 'cml-scope-audit-global-'));
+    tempDirs.push(homeDir);
+    const memoryRoot = path.join(homeDir, '.claude-code', 'memory');
+    mkdirSync(memoryRoot, { recursive: true });
+    const db = createSQLiteDatabase(path.join(memoryRoot, 'events.sqlite'));
+    sqliteExec(db, `
+      CREATE TABLE events (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        timestamp TEXT NOT NULL
+      );
+      INSERT INTO events (id, session_id, timestamp)
+      VALUES ('event-1', 'global-session', datetime('now'));
+    `);
+    sqliteClose(db);
+
+    const projectPath = path.join(homeDir, 'repo');
+    writeFileSync(path.join(memoryRoot, 'session-registry.json'), JSON.stringify({
+      version: 1,
+      sessions: {
+        'global-session': {
+          projectPath,
+          projectHash: hashProjectPath(projectPath),
+          registeredAt: '2026-08-12T00:00:00Z'
+        }
+      }
+    }));
+
+    expect(auditProjectScope({ homeDir, days: 7 })).toMatchObject({
+      scannedStoreCount: 1,
+      recentSessionCount: 1,
+      mismatchedSessionCount: 1,
+      mismatchedEventCount: 1
+    });
+  });
+});

--- a/tests/core/memory-service-registry.test.ts
+++ b/tests/core/memory-service-registry.test.ts
@@ -6,6 +6,7 @@ import type { SharedStoreConfig } from '../../src/core/types.js';
 
 interface FakeService {
   config: Record<string, unknown>;
+  disposed?: boolean;
 }
 
 const disabledSharedStoreConfig: SharedStoreConfig = {
@@ -18,10 +19,15 @@ const disabledSharedStoreConfig: SharedStoreConfig = {
 
 function createRegistry(sessionProject?: { projectHash: string; projectPath: string }) {
   const createdConfigs: Array<Record<string, unknown>> = [];
+  const disposedServices: FakeService[] = [];
   const registry = createMemoryServiceRegistry<FakeService>({
     createService: (config) => {
       createdConfigs.push(config as unknown as Record<string, unknown>);
       return { config: config as unknown as Record<string, unknown> };
+    },
+    disposeService: async (service) => {
+      service.disposed = true;
+      disposedServices.push(service);
     },
     hashProjectPath: (projectPath) => `hash:${projectPath}`,
     getProjectStoragePath: (projectPath) => `/storage/${projectPath}`,
@@ -30,7 +36,7 @@ function createRegistry(sessionProject?: { projectHash: string; projectPath: str
     disabledSharedStoreConfig
   });
 
-  return { registry, createdConfigs };
+  return { registry, createdConfigs, disposedServices };
 }
 
 describe('createMemoryServiceRegistry', () => {
@@ -214,5 +220,23 @@ describe('createMemoryServiceRegistry', () => {
 
     expect(first).not.toBe(second);
     expect(first.config).toMatchObject({ storagePath: '/tmp/a' });
+  });
+
+  it('shuts down cached services once without retaining caller-owned one-shot services', async () => {
+    const { registry, createdConfigs, disposedServices } = createRegistry();
+    const cached = registry.getMemoryServiceForProject('/workspace/app');
+    const lightweight = registry.getLightweightMemoryServiceForProject('/workspace/app');
+    const uncached = registry.createMemoryService({ storagePath: '/tmp/one-shot' });
+
+    await registry.shutdownAll();
+    await registry.shutdownAll();
+
+    expect(disposedServices).toHaveLength(2);
+    expect(new Set(disposedServices)).toEqual(new Set([cached, lightweight]));
+    expect(disposedServices).not.toContain(uncached);
+    expect(disposedServices.every((service) => service.disposed)).toBe(true);
+
+    expect(registry.getMemoryServiceForProject('/workspace/app')).not.toBe(cached);
+    expect(createdConfigs).toHaveLength(4);
   });
 });

--- a/tests/extensions/embedder-dispose.test.ts
+++ b/tests/extensions/embedder-dispose.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { DEFAULT_EMBEDDING_MODEL, Embedder } from '../../src/extensions/vector/embedder.js';
+
+describe('Embedder disposal', () => {
+  it('disposes the native pipeline and returns to an uninitialized state', async () => {
+    const dispose = vi.fn(async () => undefined);
+    const pipeline = Object.assign(
+      async () => ({ data: new Float32Array([1]) }),
+      { dispose }
+    );
+    const embedder = new Embedder();
+    const state = embedder as unknown as {
+      pipeline: typeof pipeline | null;
+      initialized: boolean;
+      activeModelName: string;
+    };
+    state.pipeline = pipeline;
+    state.initialized = true;
+    state.activeModelName = 'fallback/model';
+
+    await embedder.dispose();
+
+    expect(dispose).toHaveBeenCalledOnce();
+    expect(embedder.isReady()).toBe(false);
+    expect(embedder.getModelName()).toBe(DEFAULT_EMBEDDING_MODEL);
+  });
+});

--- a/tests/extensions/mcp-auto-project-path.test.ts
+++ b/tests/extensions/mcp-auto-project-path.test.ts
@@ -43,7 +43,8 @@ const mocks = vi.hoisted(() => {
 
 vi.mock('../../src/services/memory-service.js', () => ({
   getDefaultMemoryService: mocks.getDefaultMemoryService,
-  getMemoryServiceForProject: mocks.getMemoryServiceForProject
+  getMemoryServiceForProject: mocks.getMemoryServiceForProject,
+  shutdownMemoryServices: vi.fn(async () => undefined)
 }));
 
 vi.mock('../../src/core/registry/project-path.js', () => ({

--- a/tests/extensions/mcp-context-tools.test.ts
+++ b/tests/extensions/mcp-context-tools.test.ts
@@ -42,7 +42,8 @@ const mocks = vi.hoisted(() => {
 
 vi.mock('../../src/services/memory-service.js', () => ({
   getDefaultMemoryService: mocks.getDefaultMemoryService,
-  getMemoryServiceForProject: mocks.getMemoryServiceForProject
+  getMemoryServiceForProject: mocks.getMemoryServiceForProject,
+  shutdownMemoryServices: vi.fn(async () => undefined)
 }));
 
 vi.mock('../../src/services/session-history-importer.js', () => ({

--- a/tests/extensions/mcp-idle-resources.test.ts
+++ b/tests/extensions/mcp-idle-resources.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_MCP_IDLE_RELEASE_MS,
+  createMcpIdleResourceController,
+  parseMcpIdleReleaseMs
+} from '../../src/extensions/mcp/idle-resources.js';
+
+describe('MCP idle resource controller', () => {
+  it('uses bounded configuration and falls back for unsafe values', () => {
+    expect(parseMcpIdleReleaseMs(undefined)).toBe(DEFAULT_MCP_IDLE_RELEASE_MS);
+    expect(parseMcpIdleReleaseMs('60000')).toBe(60_000);
+    expect(parseMcpIdleReleaseMs('1')).toBe(DEFAULT_MCP_IDLE_RELEASE_MS);
+    expect(parseMcpIdleReleaseMs('invalid')).toBe(DEFAULT_MCP_IDLE_RELEASE_MS);
+  });
+
+  it('releases resources only after the idle window', async () => {
+    let now = 1_000;
+    const release = vi.fn(async () => undefined);
+    const controller = createMcpIdleResourceController({ release, idleMs: 100, now: () => now });
+
+    expect(await controller.releaseIfIdle()).toBe(false);
+    now += 100;
+    expect(await controller.releaseIfIdle()).toBe(true);
+    expect(release).toHaveBeenCalledOnce();
+    expect(await controller.releaseIfIdle()).toBe(false);
+  });
+
+  it('never releases while a tool call is active', async () => {
+    let now = 0;
+    let finish!: () => void;
+    const release = vi.fn(async () => undefined);
+    const operation = new Promise<void>((resolve) => { finish = resolve; });
+    const controller = createMcpIdleResourceController({ release, idleMs: 100, now: () => now });
+
+    const running = controller.run(() => operation);
+    now = 500;
+    expect(await controller.releaseIfIdle()).toBe(false);
+    finish();
+    await running;
+    now = 600;
+    expect(await controller.releaseIfIdle()).toBe(true);
+  });
+
+  it('lets graceful shutdown wait for active tool calls', async () => {
+    let finish!: () => void;
+    const operation = new Promise<void>((resolve) => { finish = resolve; });
+    const controller = createMcpIdleResourceController({
+      release: vi.fn(async () => undefined),
+      idleMs: 100,
+      now: () => 0
+    });
+
+    const running = controller.run(() => operation);
+    let idle = false;
+    const waiting = controller.waitForIdle().then(() => { idle = true; });
+    await Promise.resolve();
+    expect(idle).toBe(false);
+
+    finish();
+    await running;
+    await waiting;
+    expect(idle).toBe(true);
+  });
+
+  it('rejects new calls once graceful shutdown begins', async () => {
+    const controller = createMcpIdleResourceController({
+      release: vi.fn(async () => undefined),
+      idleMs: 100,
+      now: () => 0
+    });
+
+    controller.stopAccepting();
+    await expect(controller.run(async () => 'unexpected')).rejects.toThrow('shutting down');
+  });
+
+  it('makes new tool calls wait for an in-flight release', async () => {
+    let now = 0;
+    let finishRelease!: () => void;
+    const release = vi.fn(() => new Promise<void>((resolve) => { finishRelease = resolve; }));
+    const operation = vi.fn(async () => 'ok');
+    const controller = createMcpIdleResourceController({ release, idleMs: 100, now: () => now });
+
+    now = 100;
+    const releasing = controller.releaseIfIdle();
+    const running = controller.run(operation);
+    await Promise.resolve();
+    expect(operation).not.toHaveBeenCalled();
+
+    finishRelease();
+    await expect(releasing).resolves.toBe(true);
+    await expect(running).resolves.toBe('ok');
+  });
+});

--- a/tests/extensions/mcp-operation-tools.test.ts
+++ b/tests/extensions/mcp-operation-tools.test.ts
@@ -124,7 +124,8 @@ const mocks = vi.hoisted(() => {
 
 vi.mock('../../src/services/memory-service.js', () => ({
   getDefaultMemoryService: mocks.getDefaultMemoryService,
-  getMemoryServiceForProject: mocks.getMemoryServiceForProject
+  getMemoryServiceForProject: mocks.getMemoryServiceForProject,
+  shutdownMemoryServices: vi.fn(async () => undefined)
 }));
 
 vi.mock('../../src/core/registry/project-path.js', () => ({

--- a/tests/extensions/mcp-perspective-tools.test.ts
+++ b/tests/extensions/mcp-perspective-tools.test.ts
@@ -78,7 +78,8 @@ const mocks = vi.hoisted(() => {
 
 vi.mock('../../src/services/memory-service.js', () => ({
   getDefaultMemoryService: mocks.getDefaultMemoryService,
-  getMemoryServiceForProject: mocks.getMemoryServiceForProject
+  getMemoryServiceForProject: mocks.getMemoryServiceForProject,
+  shutdownMemoryServices: vi.fn(async () => undefined)
 }));
 
 vi.mock('../../src/core/registry/project-path.js', () => ({

--- a/tests/extensions/mcp-process-lifecycle.test.ts
+++ b/tests/extensions/mcp-process-lifecycle.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createMcpProcessLifecycle } from '../../src/extensions/mcp/process-lifecycle.js';
+
+describe('MCP process lifecycle', () => {
+  it('runs shutdown and exit only once across duplicate close signals', async () => {
+    const shutdown = vi.fn(async () => undefined);
+    const exit = vi.fn();
+    const lifecycle = createMcpProcessLifecycle({
+      shutdown,
+      exit,
+      getParentPid: () => 42,
+      initialParentPid: 42
+    });
+
+    await Promise.all([
+      lifecycle.requestShutdown(0),
+      lifecycle.requestShutdown(1),
+      lifecycle.requestShutdown(0)
+    ]);
+
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledOnce();
+    expect(exit).toHaveBeenCalledWith(0);
+    expect(lifecycle.isShuttingDown()).toBe(true);
+  });
+
+  it('shuts down when a previously attached parent is replaced by init', async () => {
+    let parentPid = 77;
+    const shutdown = vi.fn(async () => undefined);
+    const exit = vi.fn();
+    const lifecycle = createMcpProcessLifecycle({
+      shutdown,
+      exit,
+      getParentPid: () => parentPid,
+      initialParentPid: parentPid
+    });
+
+    lifecycle.checkParent();
+    expect(shutdown).not.toHaveBeenCalled();
+
+    parentPid = 1;
+    lifecycle.checkParent();
+    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(0));
+    expect(shutdown).toHaveBeenCalledOnce();
+  });
+
+  it('does not treat an intentionally init-owned process as newly orphaned', () => {
+    const lifecycle = createMcpProcessLifecycle({
+      shutdown: vi.fn(async () => undefined),
+      exit: vi.fn(),
+      getParentPid: () => 1,
+      initialParentPid: 1
+    });
+
+    lifecycle.checkParent();
+    expect(lifecycle.isShuttingDown()).toBe(false);
+  });
+});

--- a/tests/extensions/mcp-project-aware-tools.test.ts
+++ b/tests/extensions/mcp-project-aware-tools.test.ts
@@ -30,7 +30,8 @@ const mocks = vi.hoisted(() => {
 
 vi.mock('../../src/services/memory-service.js', () => ({
   getDefaultMemoryService: mocks.getDefaultMemoryService,
-  getMemoryServiceForProject: mocks.getMemoryServiceForProject
+  getMemoryServiceForProject: mocks.getMemoryServiceForProject,
+  shutdownMemoryServices: vi.fn(async () => undefined)
 }));
 
 const { handleToolCall } = await import('../../src/extensions/mcp/handlers.js');


### PR DESCRIPTION
## Summary

- release cached memory services and native embedding resources after MCP inactivity
- terminate MCP servers on stdio close, signals, parent loss, and startup failure
- block maintenance writes and schema migration under disk pressure, with per-store rechecks and persisted aggregate status
- add a read-only aggregate project scope audit across global and project stores
- make dashboard status explicit about the default port check and document runtime controls

## Review fixes included

- reject blank min-free-gb values instead of treating them as zero
- recheck disk space before each store and after the cycle
- surface an unhealthy final disk state to scheduled runs
- include globally misrouted sessions in scope audits and discard partial unreadable-store results
- exit immediately when MCP transport startup fails so stdin cannot keep a broken server alive
- avoid retaining caller-owned one-shot services in shutdown bookkeeping

## Validation

- npx vitest run --testTimeout=60000: 204 files, 1293 tests passed
- npm run typecheck
- npm run lint -- --quiet
- npm run check:architecture
- npm run check:public-output-privacy
- npm run build
- npm audit --omit=dev: 0 vulnerabilities
- npm pack --dry-run --json
- built MCP stdio lifecycle smoke
- built project scope-audit smoke against 64 local stores, 0 unreadable

No user hooks, scheduler definitions, running MCP processes, or memory data were mutated during validation.