### PR TITLE
docs: add memory operational quality roadmap

### DIFF
--- a/specs/memory-operational-quality-roadmap/context.md
+++ b/specs/memory-operational-quality-roadmap/context.md
@@ -1,6 +1,6 @@
 # Memory Operational Quality Roadmap Context
 
-> **Version**: 0.1.1
+> **Version**: 0.2.0
 > **Status**: Draft
 > **Created**: 2026-08-12
 > **Implementation baseline**: `origin/main` at `v2.2.10` (`3d6a47f`)
@@ -19,6 +19,17 @@ This package records enough context for a later AI agent to continue implementat
 - resource measurement from a possible shared embedding broker.
 
 The intended direction is incremental. Do not rewrite the product or add new memory subsystems while these foundations are unfinished.
+
+### 1.1 Document ownership
+
+This directory is a roadmap, not one implementation specification:
+
+- this `context.md` owns shared field evidence, architecture facts, and safety history,
+- the parent `spec.md` owns global invariants and cross-feature completion criteria,
+- the parent `plan.md` owns dependency order and workstream status,
+- each child directory owns one independently reviewable feature's context, requirements, and execution plan.
+
+When facts change, update the narrowest owning document. Do not copy the full machine-wide baseline into every child spec.
 
 ## 2. Required bootstrap for a future agent
 
@@ -261,6 +272,17 @@ At the time of this spec, `origin/main` also contains `src/extensions/mcp/idle-r
 - `specs/memory-utilization-improvements/`
 - `specs/vector-outbox-v2/`
 - `specs/memory-grounding-remediation/`
+
+### 8.1 Child feature specifications
+
+- `read-only-diagnostics/` — side-effect-free status, stats, audit, and health reads
+- `recoverable-project-gc/` — dry-run discovery, quarantine, restore, and separately gated purge
+- `derived-layer-recovery/` — derived-layer audit, verified vector rebuild, and remediation guidance
+- `retrieval-telemetry/` — presentation-aware delivery and reference-navigation measurement
+- `retrieval-benchmark-expansion/` — representative anonymized retrieval regression gates
+- `session-start-experiment/` — evidence-gated SessionStart variants
+- `mcp-tool-profiles/` — modular registry, mutation metadata, and selectable tool profiles
+- `runtime-resource-efficiency/` — model lifecycle telemetry and broker decision gate
 
 ## 9. Open questions for implementation-time validation
 

--- a/specs/memory-operational-quality-roadmap/context.md
+++ b/specs/memory-operational-quality-roadmap/context.md
@@ -1,0 +1,275 @@
+# Memory Operational Quality Roadmap Context
+
+> **Version**: 0.1.1
+> **Status**: Draft
+> **Created**: 2026-08-12
+> **Implementation baseline**: `origin/main` at `v2.2.10` (`3d6a47f`)
+> **Scope**: post-2.2.10 reliability, retrieval quality, MCP surface, and runtime efficiency
+
+## 1. Why this spec exists
+
+`claude-memory-layer` is already actively used across Claude Code, Codex, Hermes, MCP clients, the local dashboard, and many project-scoped SQLite stores. The main product problem is no longer “does memory work?” The remaining problems are operational invariants, recoverability of derived data, trustworthy usefulness measurement, benchmark depth, and the cost of a broad MCP/runtime surface.
+
+This package records enough context for a later AI agent to continue implementation without relying on the original conversation. It intentionally separates:
+
+- source-of-truth safety from cleanup,
+- audit from repair,
+- telemetry from behavior changes,
+- behavior-preserving MCP modularization from profile/default changes,
+- resource measurement from a possible shared embedding broker.
+
+The intended direction is incremental. Do not rewrite the product or add new memory subsystems while these foundations are unfinished.
+
+## 2. Required bootstrap for a future agent
+
+Before changing code:
+
+1. Read the repository `AGENTS.md`.
+2. Fetch the latest remote state and inspect `origin/main`.
+3. Start implementation from the current `origin/main`, not from the worktree revision that originally created this spec. At creation time this worktree was at `v2.2.9`, while `origin/main` and the installed package were already `v2.2.10`.
+4. If Claude Memory Layer MCP tools are available, call `mem-context-pack` with the current task and absolute project path. Do not pass the live agent session id as a CML `sessionId`.
+5. Confirm the global installed version, source version, hook paths, and maintenance scheduler path before drawing runtime conclusions.
+6. Run tests with a temporary HOME/storage root. Do not let diagnostics or tests mutate `~/.claude-code/memory`.
+7. Treat the measurements below as a dated baseline, not as permanent truth. Re-measure before implementation and after each rollout.
+
+## 3. Current product state
+
+### 3.1 What is working
+
+As of 2026-08-12:
+
+- Global CLI, Codex hooks, MCP, Claude hooks, and periodic maintenance were aligned to `2.2.10`.
+- Claude lifecycle hooks were installed for SessionStart, UserPromptSubmit, PostToolUse, Stop, and SessionEnd.
+- Codex automatic SessionStart, UserPromptSubmit, and SessionEnd hooks were installed and importing completed sessions.
+- The macOS maintenance scheduler was active at a 300-second interval.
+- The most recent maintenance runs had zero errors, zero pending work, and zero retryable failures.
+- The current repository store had 1,832 events and 1,832 vectors, with no pending, failed, stuck, or quarantined work.
+- Three legacy orphan MCP processes were terminated; later measurements showed zero orphan MCP processes.
+- npm/Yarn cache cleanup increased available disk from roughly 9.5 GiB to roughly 12 GiB. Maintenance records a 5 GiB minimum.
+- Compact memory delivery remains effective: approximately 87% character savings for SessionStart and 93% for question-time injection.
+- Project scoping, strict prompt injection gates, source references, and Codex compact reference indexes are being exercised in real sessions.
+
+### 3.2 Dated machine-wide usage baseline
+
+The most recent 24-hour aggregate used for this roadmap showed approximately:
+
+- 13 active project stores,
+- 1,630 events,
+- 78 project/session pairs,
+- 286 retrieval traces,
+- 79.4% of queries selecting at least one memory,
+- 14.7 candidates and 2.4 selected memories per query on average,
+- 1,050 helpfulness rows, 96% measured,
+- 526 SessionStart injections,
+- 522-524 question-time injections depending on the exact snapshot.
+
+These numbers demonstrate active use. They do not by themselves prove that every injection was useful.
+
+### 3.3 Store population and read-side mutation finding
+
+The machine had 67 project directories plus the global store in the maintenance scan. Project-store population was approximately:
+
+- 28 empty stores,
+- 20 stores with 1-9 events,
+- 8 stores with 10-99 events,
+- 4 stores with 100-999 events,
+- 7 stores with at least 1,000 events.
+
+A read-oriented `vector-status` invocation against an unresolved/nonexistent project argument was observed creating an empty project store. The current command path uses a lightweight writable project service rather than an existing-store read-only path. This makes “read commands do not mutate” the first invariant to fix.
+
+Do not delete the existing empty/tiny stores as part of the read-only fix. Cleanup must be a separate, dry-run-first feature with registry and lock checks. Its first mutating step should be a recoverable quarantine/move with a manifest; irreversible purge requires a separate retention policy and explicit action.
+
+### 3.4 Derived-vector damage baseline
+
+One large project store (`6ab6d837`, kept as an opaque privacy-safe identifier) had:
+
+- 26,552 canonical events,
+- 24,879 vectors,
+- 1,440 quarantined embedding jobs,
+- zero pending and zero retryable jobs.
+
+The 1,440 failures were created on 2026-08-10. Their error families referred to missing Lance deletion/data objects, not transient provider errors. Maintenance correctly avoids retrying them forever, but there is no general derived-layer audit/rebuild workflow that can reconstruct and verify a fresh vector index from canonical SQLite events.
+
+The productivity health report also recommended generic pending-work recovery for this quarantined-only state. Health remediation should distinguish retryable backlog, quarantine, corruption, and disk pressure.
+
+### 3.5 Retrieval usefulness baseline and caveat
+
+The latest 24-hour helpfulness aggregation showed:
+
+| Delivery source | Rows | Average score | Helpful | Unhelpful | Average content overlap |
+|---|---:|---:|---:|---:|---:|
+| SessionStart | 526 | 0.412 | 12.0% | 60.1% | 0.285 |
+| UserPromptSubmit | ~522 | 0.559 | 20.9% | 2.8% | 0.353 |
+
+This does not justify immediately deleting SessionStart context. The current helpfulness formula is dominated by response/content overlap and behavioral continuation. A reference index is designed to be opened only when needed, so its success signal should include source-open and citation use rather than only copied/reused text.
+
+Telemetry semantics must be corrected before selecting a new SessionStart variant.
+
+### 3.6 Benchmark depth
+
+The repository already contains replay and LongMemEval infrastructure. At the time of this spec:
+
+- the primary anonymized replay fixture had 4 queries and 7 memories,
+- the LongMemEval retrieval smoke fixture had 1 query and 2 memories,
+- replay Precision@1 was about 0.667,
+- Recall@1 was about 0.333,
+- MRR was about 0.833,
+- no-match accuracy was 1.0,
+- forbidden hits and failed queries were zero,
+- one hook-policy query did not rank the expected memory first.
+
+This is enough for a smoke test but not enough to approve risky retrieval refactors. A larger anonymized real-session corpus and category-specific qrels are required before splitting/reranking retrieval behavior.
+
+### 3.7 MCP/runtime footprint
+
+The installed MCP server exposed 44 tools. The JSON tool schema was approximately:
+
+- 47,622 bytes,
+- roughly 11,900 tokens using a simple four-characters-per-token estimate.
+
+The source had a multi-thousand-line MCP handler and a large tool definition file. Runtime snapshots showed roughly 18-20 MCP processes using about 2 GiB combined, plus a semantic daemon that could use roughly 700 MiB while active. `2.2.10` added process shutdown and ten-minute idle resource release, but process-level model-load/release telemetry is not yet sufficient to decide whether a shared embedding broker is warranted.
+
+### 3.8 Advanced-feature adoption
+
+Some benchmark-inspired features have real data:
+
+- 1,312 `source_file` entities across 11 stores,
+- 3,843 `touched_in` edges and matching temporal history across 11 stores,
+- 30 lessons across 6 stores,
+- 7 checkpoints across 3 stores.
+
+Several advanced surfaces had no rows in the inspected stores:
+
+- core memory blocks,
+- actions,
+- facets,
+- actor cards,
+- perspective observations,
+- assets and bindings,
+- superseded entities.
+
+Zero rows do not prove a feature is useless, but they do argue against expanding its default MCP surface before there is demonstrated adoption. Prefer profiles/extensions over deletion.
+
+## 4. Lessons from prior comparisons
+
+### 4.1 Already adopted
+
+From memU and `mcp-memory-service`:
+
+- fast/deep/auto retrieval,
+- scoped retrieval filters,
+- hybrid reranking,
+- strict project scope,
+- tag taxonomy,
+- health/outbox visibility.
+
+From memsearch:
+
+- progressive Search -> Expand -> Source disclosure,
+- source-ref navigation,
+- clearer core/adapter/extension direction.
+
+From SuperLocalMemory, Cognee, Letta, Mem0, and Zep/Graphiti:
+
+- raw/derived memory separation concepts,
+- code/file anchors,
+- core memory blocks,
+- entity supersession,
+- temporal graph history,
+- behavioral helpfulness signals.
+
+From MemPalace:
+
+- import-boundary guard,
+- memory-layer manifest,
+- source adapter contract,
+- one Hermes source-adapter pilot,
+- bounded source-neighbor expansion.
+
+### 4.2 Still incomplete
+
+- A reusable, typed derived-layer audit/rebuild contract.
+- Read-only commands that provably never create/migrate storage.
+- Source/presentation-aware usefulness measurement.
+- A representative real-session benchmark suite.
+- MCP handler modularization and tool profiles.
+- Zero architecture-boundary baseline exceptions.
+- Retrieval phase modules protected by large golden replay fixtures.
+- Runtime evidence for or against a shared embedding broker.
+
+## 5. Architecture and code map
+
+Future agents should inspect these areas before editing:
+
+- CLI composition: `src/apps/cli/index.ts`
+- Vector status formatting/options: `src/apps/cli/vector-command.ts`
+- Maintenance: `src/apps/cli/maintenance-runner.ts`, `src/apps/cli/maintenance-scheduler.ts`
+- Project paths/identity: `src/core/registry/project-path.ts`, `src/core/registry/repo-identity.ts`
+- Service creation/cache: `src/services/memory-service-registry.ts`
+- Compatibility facade: `src/services/memory-service.ts`
+- SQLite canonical store: `src/core/sqlite-event-store.ts`
+- Vector/outbox: `src/core/vector-worker.ts`, `src/core/vector-outbox.ts`, `src/extensions/vector/`
+- Claude SessionStart: `src/adapters/claude/hooks/session-start.ts`
+- Prompt injection policy: `src/adapters/claude/hooks/prompt-injection-policy.ts`
+- Semantic daemon: `src/adapters/claude/hooks/semantic-daemon.ts`
+- Retrieval: `src/core/retriever.ts`, `src/core/engine/retrieval-orchestrator.ts`
+- Helpfulness/analytics: `src/core/engine/retrieval-analytics-service.ts`, `src/core/sqlite-event-store.ts`
+- MCP: `src/extensions/mcp/tools.ts`, `src/extensions/mcp/handlers.ts`, `src/extensions/mcp/index.ts`
+- Architecture guard: `scripts/check-import-boundaries.mjs`
+- Replay benchmark: `scripts/replay-retrieval-benchmark.ts`, `benchmarks/replay/`
+- LongMemEval: `scripts/longmemeval-*.ts`, `benchmarks/longmemeval/`
+
+At the time of this spec, `origin/main` also contains `src/extensions/mcp/idle-resources.ts` and process-lifecycle hardening that are absent from the older local worktree HEAD. Always inspect the latest branch.
+
+## 6. Decisions that should not be reopened casually
+
+1. SQLite events and governance records are canonical.
+2. Lance/vector data is derived and must be rebuildable.
+3. Maintenance may recover bounded retryable work but must not automatically rebuild or delete a whole derived layer.
+4. Empty-store cleanup is separate from read-only correctness.
+5. Automatic prompt injection must be stricter than exploratory CLI/dashboard search.
+6. Reference indexes are navigation hints, not evidence.
+7. MCP profile rollout must preserve existing clients before changing defaults.
+8. A shared embedding broker is conditional on measured benefit; it is not an assumed destination.
+9. Advanced features with little adoption should move behind profiles/extensions, not be expanded by default.
+10. Tool mutation metadata needs three states: read-only, conditional, and mutating. `mem-context-pack` auto-refresh and preview/apply tools are conditional, not safely described by a binary flag.
+11. `src/hooks`, `src/mcp`, and `src/server` contain compatibility entrypoints. Documentation should identify their canonical implementations, not remove the shims without a separate compatibility decision.
+12. Do not add HTTP/SSE, a full code graph, a full learning platform, or a multi-agent mesh as part of this roadmap.
+
+## 7. Safety boundaries
+
+- Never run plugin `install`/`uninstall` in tests against the user's real settings.
+- Never delete or reset `~/.claude-code/memory` as part of development.
+- Never automatically clear quarantine.
+- Never rebuild vectors in place; build separately, verify, then atomically swap.
+- All cleanup/rebuild commands must default to dry-run and require explicit `--apply`.
+- Project GC apply must stage candidates into a recoverable quarantine/trash location and write a restore manifest. Permanent purge is a separate, explicitly requested operation after a retention interval.
+- Use a project lock and reject busy stores.
+- Disk preflight must account for the existing layer, temporary rebuild, backup/rollback reserve, and the global minimum-free threshold.
+- Public output must contain aggregate counts and opaque ids, not raw transcripts, secrets, or private filesystem paths.
+- Production canaries require explicit user approval after code has shipped and fresh installation smoke has passed.
+
+## 8. Related documents
+
+- `docs/architecture/memory-layer-manifest.md`
+- `docs/architecture/source-adapter-contract.md`
+- `docs/architecture/mempalace-targeted-improvement-plan.md`
+- `docs/ARCHITECTURE_COMPARISON_AND_RECOMMENDATIONS.md`
+- `docs/MCP_MEMORY_SERVICE_COMPARATIVE_REVIEW.md`
+- `docs/MEMORY_USEFULNESS_AUDIT.md`
+- `specs/thin-core-refactor/`
+- `specs/memory-utilization-improvements/`
+- `specs/vector-outbox-v2/`
+- `specs/memory-grounding-remediation/`
+
+## 9. Open questions for implementation-time validation
+
+- Should CLI commands accept both a filesystem project path and an opaque eight-character hash consistently, or should hash input use a separate option?
+- Which tables/rows count as evidence that a tiny store is not disposable?
+- What quarantine retention interval and restore/purge UX should project GC use on each supported platform?
+- Should vector rebuild preserve current embedding version only, or support an explicit target version?
+- How should a source-ref open be attributed when multiple previous injections reference the same event?
+- Can MCP profiles be negotiated per client, or is environment/config selection sufficient for the first release?
+- Does idle resource release materially reduce resident memory in real clients after ten minutes, or are most large processes continuously active?
+
+Resolve these with tests and current code evidence; do not infer them solely from this document.

--- a/specs/memory-operational-quality-roadmap/derived-layer-recovery/context.md
+++ b/specs/memory-operational-quality-roadmap/derived-layer-recovery/context.md
@@ -1,0 +1,24 @@
+# Derived-layer Recovery Context
+
+> **Status**: Ready after read-only diagnostics
+> **Parent**: [`../spec.md`](../spec.md)
+
+## Problem
+
+One large opaque project store (`6ab6d837`) had 26,552 canonical events, 24,879 vectors, and 1,440 quarantined embedding jobs. The failures referred to missing Lance data/deletion objects rather than transient provider errors. Pending and retryable queues were empty, so generic retry guidance was incorrect.
+
+SQLite events and governed records are canonical. Vector/Lance data is derived and must be auditable and reconstructable without changing canonical inputs. Maintenance may handle bounded retryable work, but must not silently rebuild an entire layer.
+
+## Relevant code
+
+- `src/core/vector-worker.ts`
+- `src/core/vector-outbox.ts`
+- `src/core/vector-store.ts`
+- `src/extensions/vector/`
+- `src/apps/cli/vector-command.ts`
+- `src/apps/cli/maintenance-runner.ts`
+- health report types/builders
+
+## Operational boundary
+
+The opaque store is a future production canary only. Audit/dry-run and especially apply require a shipped version, fresh-install smoke, disk preflight, and explicit user approval. Capture aggregate results only.

--- a/specs/memory-operational-quality-roadmap/derived-layer-recovery/plan.md
+++ b/specs/memory-operational-quality-roadmap/derived-layer-recovery/plan.md
@@ -1,0 +1,46 @@
+# Derived-layer Recovery Plan
+
+> **State**: Ready after read-only diagnostics
+> **Suggested release**: Minor
+
+## Packet 1 — Descriptor and audit
+
+1. Define audit states, descriptor, report, and privacy-safe presenters.
+2. Register vector layer first; avoid speculative abstractions for unused layers.
+3. Add human/JSON read-only audit and invariance tests.
+
+## Packet 2 — Rebuild engine
+
+1. Add deterministic dry-run planning.
+2. Reuse lock and disk helpers from maintenance.
+3. Build into a unique sibling, verify, preserve rollback, and atomically activate.
+4. Add success, verification failure, interruption, disk, lock, version, and exclusion tests.
+
+## Packet 3 — Quarantine and health
+
+1. Reconcile quarantine only after verified coverage.
+2. Add state-specific health remediation.
+3. Preserve legacy report fields or version output explicitly.
+
+## Likely files
+
+- create `src/core/layers/derived-layer.ts`, registry, and vector adapter,
+- create `src/apps/cli/layer-command.ts`,
+- modify vector/outbox/health components and focused tests.
+
+## Rollout
+
+1. Merge and release.
+2. Run fresh-install smoke.
+3. With explicit approval, audit/dry-run opaque canary `6ab6d837`.
+4. Approve apply separately; record aggregate before/after and rollback result.
+
+## Suggested commits
+
+- `feat(layers): add derived layer audit contract`
+- `feat(vectors): add verified derived index rebuild`
+- `fix(health): distinguish quarantine and rebuild guidance`
+
+## Progress
+
+No implementation started.

--- a/specs/memory-operational-quality-roadmap/derived-layer-recovery/spec.md
+++ b/specs/memory-operational-quality-roadmap/derived-layer-recovery/spec.md
@@ -1,0 +1,45 @@
+# Derived-layer Recovery Specification
+
+> **Status**: Ready after read-only diagnostics
+
+## Requirements
+
+### DLR-001 — Descriptor contract
+
+A typed derived-layer descriptor declares name/version, canonical inputs, derived outputs, audit, rebuild, and verification. Exact API is implementation-owned; these concepts are mandatory.
+
+### DLR-002 — Read-only audit
+
+`layer audit` or equivalent reports healthy, missing, stale, corrupt, version-mismatched, quarantined, and unreadable states without creating/migrating storage. Output includes aggregate expected/indexed counts, embedding version, and outbox categories.
+
+### DLR-003 — Rebuild plan
+
+Dry-run reports deterministic inputs/exclusions, target version, estimated work/space, locks, and rollback reserve. It must not initialize a replacement layer.
+
+### DLR-004 — Verified rebuild
+
+Apply acquires a project lock, performs conservative disk preflight, builds into a unique sibling location, verifies counts and deterministic sample queries, preserves rollback state, then atomically activates.
+
+### DLR-005 — Quarantine reconciliation
+
+Quarantine rows are reconciled only after the verified replacement contains their canonical inputs or an audited exclusion policy intentionally omits them.
+
+### DLR-006 — State-specific health
+
+Health distinguishes pending/retryable, stuck, quarantined-only, corruption, version mismatch, disk block, and healthy states, with the correct next safe command for each.
+
+## Acceptance
+
+- Audit is filesystem invariant.
+- Verification failure leaves the active layer untouched.
+- Interrupted rebuild retains canonical data and a recoverable active/rollback layer.
+- Version mismatch, exclusions, disk pressure, and lock contention are tested.
+- Quarantine is not cleared before verification.
+- Canary audit/rebuild/rollback is documented separately from code completion.
+
+## Non-goals
+
+- automatic whole-layer rebuild during maintenance,
+- canonical event repair,
+- perpetual retry of quarantined jobs,
+- generalized storage plugin framework beyond proven derived layers.

--- a/specs/memory-operational-quality-roadmap/mcp-tool-profiles/context.md
+++ b/specs/memory-operational-quality-roadmap/mcp-tool-profiles/context.md
@@ -1,0 +1,25 @@
+# MCP Tool Profiles Context
+
+> **Status**: Incubating
+> **Parent**: [`../spec.md`](../spec.md)
+
+## Problem
+
+The inspected MCP server exposed 44 tools with roughly 47,622 bytes of serialized schema—about 11,900 tokens by a coarse four-characters-per-token estimate. Tool definitions and handling are concentrated in large source files, increasing client context cost and making mutation safety harder to audit.
+
+Several advanced surfaces had little or no observed data, while context/search/source navigation are routinely used. This supports selectable profiles, not immediate tool removal.
+
+## Compatibility constraints
+
+- `all` initially exposes the existing tool list/schema behavior.
+- `src/mcp` remains a compatibility entrypoint while canonical implementation lives under `src/extensions/mcp`.
+- Registry refactoring must be behavior-preserving before profile selection changes visibility.
+- Mutation is not binary: `mem-context-pack` may auto-refresh, and preview/apply tools mutate only for specific inputs. Metadata needs `read_only`, `conditional`, and `mutating`.
+
+## Relevant code
+
+- `src/extensions/mcp/tools.ts`
+- `src/extensions/mcp/handlers.ts`
+- `src/extensions/mcp/index.ts`
+- `src/mcp/` compatibility shims
+- MCP tool/operation/privacy test suites

--- a/specs/memory-operational-quality-roadmap/mcp-tool-profiles/plan.md
+++ b/specs/memory-operational-quality-roadmap/mcp-tool-profiles/plan.md
@@ -1,0 +1,37 @@
+# MCP Tool Profiles Plan
+
+> **State**: Incubating
+> **Suggested release**: Minor
+
+## Entry gate
+
+Capture the exact current tool list, serialized schema bytes/hash, handler parity, and mutation behavior on latest `origin/main`.
+
+## Packet 1 — Registry without behavior change
+
+1. Define registry types and mutation predicates.
+2. Generate/list tools and dispatch from the registry.
+3. Add duplicate/missing/parity tests.
+4. Preserve `all` output exactly.
+
+## Packet 2 — Handler extraction
+
+1. Extract one bounded domain per commit.
+2. Preserve presenters, errors, privacy, and service lifecycle.
+3. Run focused parity/golden tests after every extraction.
+
+## Packet 3 — Opt-in profiles
+
+1. Assign profile metadata and define `core` contents.
+2. Add environment/config selection with `all` default.
+3. Add schema budget and conditional-mutation tests.
+4. Document migration and troubleshooting.
+
+## Suggested commits
+
+- `refactor(mcp): route tools through bounded registry modules`
+- `feat(mcp): add backward-compatible tool profiles`
+
+## Progress
+
+No implementation started; baseline capture is the next action.

--- a/specs/memory-operational-quality-roadmap/mcp-tool-profiles/spec.md
+++ b/specs/memory-operational-quality-roadmap/mcp-tool-profiles/spec.md
@@ -1,0 +1,43 @@
+# MCP Tool Profiles Specification
+
+> **Status**: Incubating
+
+## Requirements
+
+### MCP-001 — Registry parity
+
+A single registry/generated mapping owns tool name, description, schema, handler, profiles, and mutation classification. Tests fail for duplicate, missing, or unhandled entries.
+
+### MCP-002 — Mutation predicates
+
+Classification supports `read_only`, `conditional`, and `mutating`. Conditional entries expose machine-readable write predicates/defaults for auto-refresh and preview/apply behavior.
+
+### MCP-003 — Bounded handlers
+
+Extract handlers by domain—context/search, source/import, operations, graph/lessons, governance/assets, perspective/shared—while preserving the compatibility `handleToolCall` path and public output.
+
+### MCP-004 — Profiles
+
+Support `core`, `operations`, `governance`, `experimental`, and `all`. Environment/config selection is sufficient initially; per-client negotiation is optional.
+
+### MCP-005 — Core budget
+
+`core` contains at most 10 tools and at most 20 KB serialized schema. It includes context/search/source navigation and project timeline/stats, excludes always-mutating explicit import, and identifies context-pack auto-refresh as conditional with a read-only opt-out.
+
+### MCP-006 — Compatibility
+
+`all` remains the default for the compatibility period and retains the prior list/schema/behavior. Profile changes do not remove canonical functionality.
+
+## Acceptance
+
+- Exact pre/post `all` registry names, schema hashes/bytes, and critical behavior match.
+- Every conditional tool has tested true/false mutation predicates.
+- `core` meets count/schema budgets.
+- Unknown profile fails clearly; missing configuration selects `all`.
+- Context pack, import latest, source ref, frontier, graph, and governance smoke tests pass.
+
+## Non-goals
+
+- removing tools in the first profile release,
+- changing tool response semantics during handler extraction,
+- adding remote transport or per-client negotiation as a prerequisite.

--- a/specs/memory-operational-quality-roadmap/plan.md
+++ b/specs/memory-operational-quality-roadmap/plan.md
@@ -1,391 +1,69 @@
-# Memory Operational Quality Roadmap Implementation Plan
+# Memory Operational Quality Roadmap Plan
 
-> **Version**: 0.1.1
-> **Status**: Draft
+> **Version**: 0.2.0
+> **Status**: Draft roadmap
 > **Created**: 2026-08-12
-> **For future AI agents**: execute as small, reviewable work packets; do not skip the safety and benchmark gates.
 
-**Goal:** Improve operational safety, derived-data recovery, retrieval measurement, benchmark coverage, MCP ergonomics, and runtime efficiency after `v2.2.10`.
+## 1. How to use this plan
 
-**Strategy:** Establish invariants and measurements first. Add explicit audit/rebuild primitives next. Change retrieval behavior only after source-aware telemetry and a representative replay suite exist. Modularize MCP without changing behavior, then add opt-in profiles. Instrument resource use before considering a shared broker.
+This file tracks ordering and status only. Execute work from the selected child `context.md`, `spec.md`, and `plan.md`. Do not implement a whole phase directly from this parent document.
 
-## 0. Agent handoff checklist
+Before every work packet:
 
-At the beginning of every work packet:
+- read repository `AGENTS.md` and the parent context/spec,
+- recover recent CML project context when available,
+- fetch and inspect `origin/main`,
+- confirm the branch is based on current `origin/main`,
+- record baseline tests and use temporary HOME/storage,
+- preserve unrelated changes and update the child progress section after work.
 
-- [ ] Read repository `AGENTS.md` and this package's `context.md`/`spec.md`.
-- [ ] Recover recent project context with CML MCP tools when available.
-- [ ] `git fetch` and inspect `origin/main`.
-- [ ] Confirm the current branch/worktree is based on current `origin/main`; create or rebase an isolated branch only when needed.
-- [ ] Confirm self-dependency is absent: `npm list claude-memory-layer` should be empty for the repo install.
-- [ ] Record current test/build baseline before edits.
-- [ ] Use temporary HOME/storage for tests.
-- [ ] Preserve unrelated dirty-worktree changes.
-- [ ] Update this plan's progress notes or add a dated progress document after merge.
+## 2. Dependency graph
 
-At creation time, do not implement from the local `v2.2.9` HEAD. The required baseline is `v2.2.10` or newer because runtime lifecycle/disk hardening landed there.
+```text
+read-only-diagnostics ──┬──> recoverable-project-gc
+                       └──> derived-layer-recovery
 
-## Phase 0 — Baseline and test harness
+retrieval-telemetry ───────────────┐
+retrieval-benchmark-expansion ─────┴──> session-start-experiment
 
-### Task 0.1 — Refresh dated field evidence
+mcp-tool-profiles
 
-**Objective:** Verify which baseline findings still reproduce.
+runtime-resource-efficiency ──> broker ADR/spec only if evidence gate passes
 
-**Read-only checks:**
+architecture closure: cross-cutting; retrieval extraction waits for benchmark gate
+```
 
-- installed/source versions,
-- hook and maintenance paths,
-- store population histogram,
-- vector/outbox health,
-- MCP process/resource totals,
-- helpfulness split by delivery source,
-- current replay/LongMemEval metrics.
+The two root lanes—storage operations and retrieval measurement—may proceed independently. SessionStart behavior cannot precede both of its gates.
 
-**Output:** Add a privacy-safe dated baseline under this spec directory only if values materially changed. Never include transcript content or private absolute project paths.
+## 3. Workstream status
 
-### Task 0.2 — Add filesystem invariance test utility
+| Order | Workstream | State | Next action |
+|---:|---|---|---|
+| 1 | [`read-only-diagnostics`](read-only-diagnostics/plan.md) | Ready | refresh reproduction and implement filesystem invariance harness |
+| 2 | [`recoverable-project-gc`](recoverable-project-gc/plan.md) | Ready after 1 | settle quarantine retention/restore UX |
+| 2 | [`derived-layer-recovery`](derived-layer-recovery/plan.md) | Ready after 1 | implement read-only descriptor/audit before rebuild |
+| 1 | [`retrieval-telemetry`](retrieval-telemetry/plan.md) | Ready | finalize attribution window and migration shape |
+| 1 | [`retrieval-benchmark-expansion`](retrieval-benchmark-expansion/plan.md) | Ready | curate and privacy-scan 50+ labeled queries |
+| 3 | [`session-start-experiment`](session-start-experiment/plan.md) | Blocked by evidence gates | begin only after telemetry + benchmark acceptance |
+| 2 | [`mcp-tool-profiles`](mcp-tool-profiles/plan.md) | Incubating | capture exact tool/schema parity baseline |
+| 2 | [`runtime-resource-efficiency`](runtime-resource-efficiency/plan.md) | Incubating | collect process/model lifecycle measurements |
 
-**Likely files:**
+## 4. Suggested release sequence
 
-- Create: `tests/helpers/memory-root-snapshot.ts`
-- Modify: relevant CLI/API tests
+1. Patch: read-only diagnostics.
+2. Separate patch/minor: recoverable project GC without automatic purge.
+3. Minor: derived-layer audit/rebuild and state-specific health guidance.
+4. Patch/minor: retrieval telemetry and expanded benchmark gate.
+5. Patch after evidence: winning SessionStart behavior.
+6. Minor: MCP registry/profiles with `all` as compatibility default.
+7. Patch: resource telemetry and fast-path improvements.
+8. Later minor only if an ADR approves: shared embedding broker.
 
-**Behavior:** Snapshot directory entries, sizes, mtimes or hashes as appropriate before/after a read operation. Use a temporary home directory.
+Do not combine storage repair, retrieval ranking, and MCP default changes in one release.
 
-**Verification:** Prove that the helper itself detects a deliberately created file in its unit test.
+## 5. Cross-cutting verification
 
-## Phase 1 — Read-only invariant and project GC
-
-### Work packet 1A — Existing-store read composition
-
-**Objective:** Stop status/audit commands from creating stores.
-
-**Likely files:**
-
-- `src/core/registry/project-path.ts`
-- `src/services/memory-service-registry.ts`
-- `src/services/memory-service.ts`
-- `src/apps/cli/index.ts`
-- `src/apps/cli/vector-command.ts`
-- dashboard/health read-service helpers
-- CLI and registry tests
-
-**Steps:**
-
-1. Inventory every read-oriented command/API and the service factory it uses.
-2. Define path/hash argument semantics once.
-3. Add an existing-store resolver that does not call mkdir or initialize migrations.
-4. Add an uncached read-only service/store path.
-5. Return a structured no-store result instead of constructing an empty service.
-6. Migrate `vector-status`, `stats`, `health`, scope audit, and dashboard reads.
-7. Add before/after filesystem invariance tests for each migrated surface.
-
-**Acceptance:**
-
-- nonexistent project read creates no directory,
-- hash and path behavior is documented and tested,
-- existing store output remains compatible,
-- no worker/embedder starts for pure stats/status.
-
-**Suggested commit:** `fix(storage): make read diagnostics side-effect free`
-
-### Work packet 1B — Empty/tiny store GC
-
-**Objective:** Provide recoverable, explicit cleanup without coupling it to the read fix.
-
-**Likely files:**
-
-- Create: `src/apps/cli/project-gc.ts`
-- Modify: `src/apps/cli/index.ts`
-- Create tests under `tests/apps/`
-- Update README/operations docs
-
-**Steps:**
-
-1. Define empty versus tiny store classification.
-2. Inspect registry references, locks, canonical rows, outbox rows, and governance tables.
-3. Implement dry-run report with candidate reason and reclaimable bytes.
-4. Require `--apply` to move candidates into a dedicated quarantine/trash area on the same filesystem.
-5. Reject symlinks and paths outside the exact project-store root.
-6. Write a durable manifest with original location, quarantined location, identity, timestamp, and integrity metadata.
-7. Add an idempotent restore path and test interrupted-move recovery.
-8. Keep permanent purge separate, retention-gated, and explicitly requested; it may be deferred from the first release.
-9. Teach maintenance discovery to report/skip skeleton stores without migration.
-
-**Tests:**
-
-- empty unreferenced store candidate,
-- empty referenced store retained,
-- one-event/tiny store retained by default,
-- governance-only store retained,
-- lock-busy store retained,
-- symlink rejected,
-- apply quarantines only exact candidates inside temp HOME,
-- restore returns the exact candidate and preserves its identity,
-- interrupted quarantine can be recovered without selecting unrelated stores,
-- purge cannot run before its retention/confirmation gate.
-
-**Suggested commit:** `feat(project): add dry-run-first empty store gc`
-
-**Release gate:** Ship Work Packet 1A independently before any production cleanup. Review and release Work Packet 1B separately, then re-run diagnostics after fresh install. Do not automatically run `--apply` or purge on the user's machine.
-
-## Phase 2 — Derived-layer audit and rebuild
-
-### Work packet 2A — Layer descriptor and audit
-
-**Objective:** Establish a common model before implementing repair.
-
-**Likely files:**
-
-- Create: `src/core/layers/derived-layer.ts`
-- Create: `src/core/layers/derived-layer-registry.ts`
-- Create: `src/core/layers/vector-layer.ts`
-- Create: `src/apps/cli/layer-command.ts`
-- Modify: `src/apps/cli/index.ts`
-- Tests under `tests/core/` and `tests/apps/`
-
-**Steps:**
-
-1. Define descriptor, audit states, verification result, and privacy-safe output types.
-2. Register a read-only vector-layer auditor first.
-3. Report canonical input count, expected/indexed count, embedding version, outbox state, and corruption/quarantine category.
-4. Ensure audit opens existing stores only and performs no migration.
-5. Add JSON and human-readable output.
-
-**Suggested commit:** `feat(layers): add derived layer audit contract`
-
-### Work packet 2B — Vector rebuild engine
-
-**Objective:** Reconstruct vectors safely from canonical SQLite events.
-
-**Likely files:**
-
-- `src/core/layers/vector-layer.ts`
-- `src/extensions/vector/`
-- `src/core/vector-worker.ts`
-- lock/disk helpers reused from maintenance
-- CLI tests with small temporary Lance fixtures
-
-**Steps:**
-
-1. Add dry-run plan: inputs, exclusions, target version, estimated work/space.
-2. Acquire a project-specific rebuild lock and reject active conflicting workers.
-3. Calculate required disk reserve conservatively.
-4. Build into a unique temporary sibling directory.
-5. Verify counts and deterministic sample queries.
-6. Preserve the active index as rollback state.
-7. Atomically activate the verified index.
-8. Only then reconcile corresponding quarantine rows.
-9. On any failure, retain canonical SQLite and the previous active index.
-
-**Tests:**
-
-- success and atomic activation,
-- verification failure leaves old index active,
-- disk-pressure block,
-- lock contention,
-- interrupted rebuild cleanup/recovery,
-- embedding version mismatch,
-- excluded event types remain intentionally absent,
-- quarantine reconciliation only after verification.
-
-**Suggested commit:** `feat(vectors): add verified derived index rebuild`
-
-### Work packet 2C — State-specific health guidance
-
-**Objective:** Make operational recommendations actionable.
-
-**Likely files:**
-
-- health report builder/API
-- `src/apps/cli/vector-command.ts`
-- maintenance report types
-- health/vector tests
-
-**Cases:** pending, stuck, retryable failed, quarantined-only, corruption, disk block, healthy.
-
-**Suggested commit:** `fix(health): distinguish quarantine and rebuild guidance`
-
-**Production canary:** After release and fresh-install smoke, run audit/dry-run on opaque store `6ab6d837`. Actual apply is a separate explicitly approved operation. Capture only aggregate before/after results.
-
-## Phase 3 — Telemetry semantics and benchmark gate
-
-### Work packet 3A — Presentation-aware retrieval telemetry
-
-**Objective:** Stop treating reference navigation like directly injected evidence.
-
-**Likely files:**
-
-- `src/core/sqlite-event-store.ts`
-- `src/core/engine/retrieval-analytics-service.ts`
-- `src/core/engine/retrieval-orchestrator.ts`
-- `src/extensions/mcp/handlers.ts` or later source handler
-- source/details/expand paths
-- dashboard stats/usefulness API and UI
-
-**Steps:**
-
-1. Add forward-compatible columns/metadata for delivery/presentation mode.
-2. Record source-ref/expand/details opens without storing new raw content.
-3. Attribute opens to an injection trace only when deterministic.
-4. Split evidence-grounding and reference-navigation reporting.
-5. Preserve legacy rows and label their mode unknown/legacy.
-6. Add privacy scan tests.
-
-**Suggested commit:** `feat(telemetry): measure reference navigation separately`
-
-### Work packet 3B — Expand anonymized replay corpus
-
-**Objective:** Create the behavior gate required for later retrieval changes.
-
-**Likely files:**
-
-- `benchmarks/replay/`
-- `scripts/generate-session-qrels.ts`
-- `scripts/replay-retrieval-benchmark.ts`
-- benchmark docs and tests
-
-**Steps:**
-
-1. Select 50-100 anonymized query/memory cases across required categories.
-2. Add positive ids, forbidden ids, and explicit no-match cases.
-3. Run credential/path/privacy validation before committing fixtures.
-4. Record accepted baseline metrics by category.
-5. Add CI tiers: smoke, retrieval-change gate, scheduled larger eval.
-6. Keep promotion/review workflow human-reviewable.
-
-**Acceptance:** no-match 100%, forbidden hits 0, failed queries 0, no accepted-baseline MRR/Hit@3 regression.
-
-**Suggested commit:** `test(retrieval): expand anonymized real-session replay gate`
-
-## Phase 4 — SessionStart experiment
-
-### Work packet 4A — Deterministic variants
-
-**Objective:** Reduce unnecessary startup context without guessing from a misaligned metric.
-
-**Likely files:**
-
-- `src/adapters/claude/hooks/session-start.ts`
-- Codex SessionStart wrapper
-- hook configuration/options
-- helpfulness/retrieval trace schema
-- tests for deterministic assignment and formatting
-
-**Variants:** current three items; one summary plus one recent outcome; reference-only index.
-
-**Steps:**
-
-1. Implement deterministic session-id cohort assignment.
-2. Keep current behavior as default/control.
-3. Add env/config override and kill switch.
-4. Record variant and delivery token/character counts.
-5. Compare source opens, first-question relevance, continuation, re-ask, and prompt-lane quality.
-6. Run for enough sessions/time before selecting a winner.
-
-**Promotion rule:** user-prompt unhelpful stays at or below 5%; startup tokens fall materially; continuation metrics do not regress.
-
-**Suggested commit:** `feat(hooks): add measured session-start context variants`
-
-## Phase 5 — MCP modularization and profiles
-
-### Work packet 5A — Behavior-preserving registry split
-
-**Objective:** Split implementation before changing the visible tool list.
-
-**Likely files:**
-
-- Create: `src/extensions/mcp/registry.ts`
-- Create handler modules under `src/extensions/mcp/handlers/`
-- Create presenter/schema modules as needed
-- Modify compatibility `handlers.ts`, `tools.ts`, `index.ts`
-- Update MCP tests
-
-**Steps:**
-
-1. Build a registry mapping tool name to schema, handler, profile, and mutation kind (`read_only`, `conditional`, or `mutating`). Conditional entries must describe the input/default predicate that triggers writes.
-2. Generate/list tools from the registry.
-3. Add parity tests for duplicate/missing tools.
-4. Extract handlers by bounded domain without output changes.
-5. Smoke critical tools: context pack, import latest, source ref, frontier, graph query.
-
-**Acceptance:** `all` tool count/schema and behavior remain compatible; no handler module grows into a new monolith.
-
-**Suggested commit:** `refactor(mcp): route tools through bounded registry modules`
-
-### Work packet 5B — Opt-in profiles
-
-**Objective:** Reduce default context cost for clients that choose a smaller surface.
-
-**Steps:**
-
-1. Add `core`, `operations`, `governance`, `experimental`, `all` metadata.
-2. Add environment/config selection with `all` compatibility default.
-3. Add schema byte/token report tests.
-4. Keep always-mutating tools, including explicit import, out of `core`; expose context-pack auto-refresh as conditional and retain its explicit read-only opt-out.
-5. Test preview/apply and auto-refresh tools against their machine-readable mutation predicates.
-6. Document client migration and troubleshooting.
-
-**Acceptance:** core <=10 tools and <=20 KB schema; all retains the prior list.
-
-**Suggested commit:** `feat(mcp): add backward-compatible tool profiles`
-
-## Phase 6 — Runtime resource decision
-
-### Work packet 6A — Instrument idle/model resources
-
-**Objective:** Determine why process count/RSS remains high without prematurely adding IPC.
-
-**Likely files:**
-
-- `src/extensions/mcp/idle-resources.ts`
-- `src/extensions/mcp/index.ts`
-- `src/extensions/vector/embedder.ts`
-- semantic daemon/runtime health models
-- CLI/dashboard aggregate reporting
-
-**Steps:**
-
-1. Add model-load and release counters/timing.
-2. Add last-activity and cold/hot retrieval timing.
-3. Add aggregate privacy-safe status output.
-4. Verify RSS/model release after the configured idle period.
-5. Collect a representative multi-client sample.
-
-**Suggested commit:** `feat(runtime): expose embedding resource telemetry`
-
-### Work packet 6B — Broker ADR/spike, only if gate is met
-
-**Objective:** Compare alternatives and prototype the smallest safe shared broker.
-
-**Gate:** sustained duplicate-model RSS >=1 GiB or repeated model-load latency after idle release, with enough samples to exclude legacy clients.
-
-**Deliverable:** ADR comparing in-process idle release, shared broker, and provider backends. Do not merge a broker solely because the spike works.
-
-If approved, require local-only transport, bounded timeouts, one model instance, lazy lifecycle, fallback, and no canonical-store ownership.
-
-## Phase 7 — Architecture closure and docs
-
-### Work packet 7A — Boundary baseline zero
-
-1. Inspect current four baseline entries on latest main.
-2. Replace core-to-extension re-export/import boundaries with ports/composition roots.
-3. Remove baseline entries as violations disappear.
-4. Reject new violations in CI.
-
-### Work packet 7B — Retrieval phase extraction
-
-Start only after the expanded benchmark is an enforced gate.
-
-Extract query plan, candidate generation, ranking, expansion, and context assembly one at a time. Preserve trace/debug shapes or version them explicitly.
-
-### Work packet 7C — Documentation drift
-
-Update removed `src/ui` references. For `src/server`, `src/hooks`, and `src/mcp`, document that the remaining files are compatibility entrypoints and link their canonical `src/apps`, `src/adapters`, or `src/extensions` implementations. Link this spec from architecture indexes and progress documents.
-
-## Cross-cutting verification
-
-Run proportionate focused tests during development, then before merge:
+Run proportionate focused tests during a work packet and, before merge:
 
 ```bash
 npm run typecheck
@@ -398,30 +76,11 @@ npm run test:run
 npm run build
 ```
 
-Also verify:
+Also verify that self-dependency is absent, real user settings/stores were not changed by tests, and Node 20.19+ remains supported.
 
-- `npm list claude-memory-layer` is empty in the repo,
-- no real user settings were modified,
-- no live memory store was changed by tests,
-- generated `dist` behavior is smoke-tested when packaging changes,
-- Node 20.19+ compatibility remains intact.
+## 6. Progress handoff
 
-## Suggested release sequence
-
-1. Patch: Work Packet 1A read-only invariant.
-2. Separate patch/minor: Work Packet 1B recoverable project GC; defer purge until policy review.
-3. Minor: Phase 2 layer audit/rebuild and state-specific health guidance.
-4. Patch/minor: Phase 3 telemetry and benchmark gate.
-5. Patch after evidence: Phase 4 winning SessionStart behavior.
-6. Minor: Phase 5 MCP registry/profiles with `all` default.
-7. Patch: Phase 6 telemetry.
-8. Later minor only if ADR approves: shared embedding broker.
-
-Do not combine storage rebuild, retrieval ranking behavior, and MCP default-profile changes in one release.
-
-## Progress handoff template
-
-When stopping or handing off, append a dated progress note or update a dedicated progress file with:
+Record progress in the selected child `plan.md` using:
 
 ```markdown
 ## YYYY-MM-DD — Work packet X
@@ -430,13 +89,13 @@ When stopping or handing off, append a dated progress note or update a dedicated
 - Branch/PR:
 - Completed:
 - Files changed:
-- Tests run and exact results:
-- Runtime/disk/store mutations performed:
+- Tests and exact results:
+- Runtime/disk/store mutations:
 - Known failures or flakes:
-- Decisions made:
-- Remaining tasks:
+- Decisions:
+- Remaining:
 - Safe next command:
 - Rollback notes:
 ```
 
-Never describe a work packet as complete when required tests, rollout verification, or safety checks remain.
+Update this parent only when dependency, readiness, or overall completion state changes.

--- a/specs/memory-operational-quality-roadmap/plan.md
+++ b/specs/memory-operational-quality-roadmap/plan.md
@@ -1,0 +1,442 @@
+# Memory Operational Quality Roadmap Implementation Plan
+
+> **Version**: 0.1.1
+> **Status**: Draft
+> **Created**: 2026-08-12
+> **For future AI agents**: execute as small, reviewable work packets; do not skip the safety and benchmark gates.
+
+**Goal:** Improve operational safety, derived-data recovery, retrieval measurement, benchmark coverage, MCP ergonomics, and runtime efficiency after `v2.2.10`.
+
+**Strategy:** Establish invariants and measurements first. Add explicit audit/rebuild primitives next. Change retrieval behavior only after source-aware telemetry and a representative replay suite exist. Modularize MCP without changing behavior, then add opt-in profiles. Instrument resource use before considering a shared broker.
+
+## 0. Agent handoff checklist
+
+At the beginning of every work packet:
+
+- [ ] Read repository `AGENTS.md` and this package's `context.md`/`spec.md`.
+- [ ] Recover recent project context with CML MCP tools when available.
+- [ ] `git fetch` and inspect `origin/main`.
+- [ ] Confirm the current branch/worktree is based on current `origin/main`; create or rebase an isolated branch only when needed.
+- [ ] Confirm self-dependency is absent: `npm list claude-memory-layer` should be empty for the repo install.
+- [ ] Record current test/build baseline before edits.
+- [ ] Use temporary HOME/storage for tests.
+- [ ] Preserve unrelated dirty-worktree changes.
+- [ ] Update this plan's progress notes or add a dated progress document after merge.
+
+At creation time, do not implement from the local `v2.2.9` HEAD. The required baseline is `v2.2.10` or newer because runtime lifecycle/disk hardening landed there.
+
+## Phase 0 — Baseline and test harness
+
+### Task 0.1 — Refresh dated field evidence
+
+**Objective:** Verify which baseline findings still reproduce.
+
+**Read-only checks:**
+
+- installed/source versions,
+- hook and maintenance paths,
+- store population histogram,
+- vector/outbox health,
+- MCP process/resource totals,
+- helpfulness split by delivery source,
+- current replay/LongMemEval metrics.
+
+**Output:** Add a privacy-safe dated baseline under this spec directory only if values materially changed. Never include transcript content or private absolute project paths.
+
+### Task 0.2 — Add filesystem invariance test utility
+
+**Likely files:**
+
+- Create: `tests/helpers/memory-root-snapshot.ts`
+- Modify: relevant CLI/API tests
+
+**Behavior:** Snapshot directory entries, sizes, mtimes or hashes as appropriate before/after a read operation. Use a temporary home directory.
+
+**Verification:** Prove that the helper itself detects a deliberately created file in its unit test.
+
+## Phase 1 — Read-only invariant and project GC
+
+### Work packet 1A — Existing-store read composition
+
+**Objective:** Stop status/audit commands from creating stores.
+
+**Likely files:**
+
+- `src/core/registry/project-path.ts`
+- `src/services/memory-service-registry.ts`
+- `src/services/memory-service.ts`
+- `src/apps/cli/index.ts`
+- `src/apps/cli/vector-command.ts`
+- dashboard/health read-service helpers
+- CLI and registry tests
+
+**Steps:**
+
+1. Inventory every read-oriented command/API and the service factory it uses.
+2. Define path/hash argument semantics once.
+3. Add an existing-store resolver that does not call mkdir or initialize migrations.
+4. Add an uncached read-only service/store path.
+5. Return a structured no-store result instead of constructing an empty service.
+6. Migrate `vector-status`, `stats`, `health`, scope audit, and dashboard reads.
+7. Add before/after filesystem invariance tests for each migrated surface.
+
+**Acceptance:**
+
+- nonexistent project read creates no directory,
+- hash and path behavior is documented and tested,
+- existing store output remains compatible,
+- no worker/embedder starts for pure stats/status.
+
+**Suggested commit:** `fix(storage): make read diagnostics side-effect free`
+
+### Work packet 1B — Empty/tiny store GC
+
+**Objective:** Provide recoverable, explicit cleanup without coupling it to the read fix.
+
+**Likely files:**
+
+- Create: `src/apps/cli/project-gc.ts`
+- Modify: `src/apps/cli/index.ts`
+- Create tests under `tests/apps/`
+- Update README/operations docs
+
+**Steps:**
+
+1. Define empty versus tiny store classification.
+2. Inspect registry references, locks, canonical rows, outbox rows, and governance tables.
+3. Implement dry-run report with candidate reason and reclaimable bytes.
+4. Require `--apply` to move candidates into a dedicated quarantine/trash area on the same filesystem.
+5. Reject symlinks and paths outside the exact project-store root.
+6. Write a durable manifest with original location, quarantined location, identity, timestamp, and integrity metadata.
+7. Add an idempotent restore path and test interrupted-move recovery.
+8. Keep permanent purge separate, retention-gated, and explicitly requested; it may be deferred from the first release.
+9. Teach maintenance discovery to report/skip skeleton stores without migration.
+
+**Tests:**
+
+- empty unreferenced store candidate,
+- empty referenced store retained,
+- one-event/tiny store retained by default,
+- governance-only store retained,
+- lock-busy store retained,
+- symlink rejected,
+- apply quarantines only exact candidates inside temp HOME,
+- restore returns the exact candidate and preserves its identity,
+- interrupted quarantine can be recovered without selecting unrelated stores,
+- purge cannot run before its retention/confirmation gate.
+
+**Suggested commit:** `feat(project): add dry-run-first empty store gc`
+
+**Release gate:** Ship Work Packet 1A independently before any production cleanup. Review and release Work Packet 1B separately, then re-run diagnostics after fresh install. Do not automatically run `--apply` or purge on the user's machine.
+
+## Phase 2 — Derived-layer audit and rebuild
+
+### Work packet 2A — Layer descriptor and audit
+
+**Objective:** Establish a common model before implementing repair.
+
+**Likely files:**
+
+- Create: `src/core/layers/derived-layer.ts`
+- Create: `src/core/layers/derived-layer-registry.ts`
+- Create: `src/core/layers/vector-layer.ts`
+- Create: `src/apps/cli/layer-command.ts`
+- Modify: `src/apps/cli/index.ts`
+- Tests under `tests/core/` and `tests/apps/`
+
+**Steps:**
+
+1. Define descriptor, audit states, verification result, and privacy-safe output types.
+2. Register a read-only vector-layer auditor first.
+3. Report canonical input count, expected/indexed count, embedding version, outbox state, and corruption/quarantine category.
+4. Ensure audit opens existing stores only and performs no migration.
+5. Add JSON and human-readable output.
+
+**Suggested commit:** `feat(layers): add derived layer audit contract`
+
+### Work packet 2B — Vector rebuild engine
+
+**Objective:** Reconstruct vectors safely from canonical SQLite events.
+
+**Likely files:**
+
+- `src/core/layers/vector-layer.ts`
+- `src/extensions/vector/`
+- `src/core/vector-worker.ts`
+- lock/disk helpers reused from maintenance
+- CLI tests with small temporary Lance fixtures
+
+**Steps:**
+
+1. Add dry-run plan: inputs, exclusions, target version, estimated work/space.
+2. Acquire a project-specific rebuild lock and reject active conflicting workers.
+3. Calculate required disk reserve conservatively.
+4. Build into a unique temporary sibling directory.
+5. Verify counts and deterministic sample queries.
+6. Preserve the active index as rollback state.
+7. Atomically activate the verified index.
+8. Only then reconcile corresponding quarantine rows.
+9. On any failure, retain canonical SQLite and the previous active index.
+
+**Tests:**
+
+- success and atomic activation,
+- verification failure leaves old index active,
+- disk-pressure block,
+- lock contention,
+- interrupted rebuild cleanup/recovery,
+- embedding version mismatch,
+- excluded event types remain intentionally absent,
+- quarantine reconciliation only after verification.
+
+**Suggested commit:** `feat(vectors): add verified derived index rebuild`
+
+### Work packet 2C — State-specific health guidance
+
+**Objective:** Make operational recommendations actionable.
+
+**Likely files:**
+
+- health report builder/API
+- `src/apps/cli/vector-command.ts`
+- maintenance report types
+- health/vector tests
+
+**Cases:** pending, stuck, retryable failed, quarantined-only, corruption, disk block, healthy.
+
+**Suggested commit:** `fix(health): distinguish quarantine and rebuild guidance`
+
+**Production canary:** After release and fresh-install smoke, run audit/dry-run on opaque store `6ab6d837`. Actual apply is a separate explicitly approved operation. Capture only aggregate before/after results.
+
+## Phase 3 — Telemetry semantics and benchmark gate
+
+### Work packet 3A — Presentation-aware retrieval telemetry
+
+**Objective:** Stop treating reference navigation like directly injected evidence.
+
+**Likely files:**
+
+- `src/core/sqlite-event-store.ts`
+- `src/core/engine/retrieval-analytics-service.ts`
+- `src/core/engine/retrieval-orchestrator.ts`
+- `src/extensions/mcp/handlers.ts` or later source handler
+- source/details/expand paths
+- dashboard stats/usefulness API and UI
+
+**Steps:**
+
+1. Add forward-compatible columns/metadata for delivery/presentation mode.
+2. Record source-ref/expand/details opens without storing new raw content.
+3. Attribute opens to an injection trace only when deterministic.
+4. Split evidence-grounding and reference-navigation reporting.
+5. Preserve legacy rows and label their mode unknown/legacy.
+6. Add privacy scan tests.
+
+**Suggested commit:** `feat(telemetry): measure reference navigation separately`
+
+### Work packet 3B — Expand anonymized replay corpus
+
+**Objective:** Create the behavior gate required for later retrieval changes.
+
+**Likely files:**
+
+- `benchmarks/replay/`
+- `scripts/generate-session-qrels.ts`
+- `scripts/replay-retrieval-benchmark.ts`
+- benchmark docs and tests
+
+**Steps:**
+
+1. Select 50-100 anonymized query/memory cases across required categories.
+2. Add positive ids, forbidden ids, and explicit no-match cases.
+3. Run credential/path/privacy validation before committing fixtures.
+4. Record accepted baseline metrics by category.
+5. Add CI tiers: smoke, retrieval-change gate, scheduled larger eval.
+6. Keep promotion/review workflow human-reviewable.
+
+**Acceptance:** no-match 100%, forbidden hits 0, failed queries 0, no accepted-baseline MRR/Hit@3 regression.
+
+**Suggested commit:** `test(retrieval): expand anonymized real-session replay gate`
+
+## Phase 4 — SessionStart experiment
+
+### Work packet 4A — Deterministic variants
+
+**Objective:** Reduce unnecessary startup context without guessing from a misaligned metric.
+
+**Likely files:**
+
+- `src/adapters/claude/hooks/session-start.ts`
+- Codex SessionStart wrapper
+- hook configuration/options
+- helpfulness/retrieval trace schema
+- tests for deterministic assignment and formatting
+
+**Variants:** current three items; one summary plus one recent outcome; reference-only index.
+
+**Steps:**
+
+1. Implement deterministic session-id cohort assignment.
+2. Keep current behavior as default/control.
+3. Add env/config override and kill switch.
+4. Record variant and delivery token/character counts.
+5. Compare source opens, first-question relevance, continuation, re-ask, and prompt-lane quality.
+6. Run for enough sessions/time before selecting a winner.
+
+**Promotion rule:** user-prompt unhelpful stays at or below 5%; startup tokens fall materially; continuation metrics do not regress.
+
+**Suggested commit:** `feat(hooks): add measured session-start context variants`
+
+## Phase 5 — MCP modularization and profiles
+
+### Work packet 5A — Behavior-preserving registry split
+
+**Objective:** Split implementation before changing the visible tool list.
+
+**Likely files:**
+
+- Create: `src/extensions/mcp/registry.ts`
+- Create handler modules under `src/extensions/mcp/handlers/`
+- Create presenter/schema modules as needed
+- Modify compatibility `handlers.ts`, `tools.ts`, `index.ts`
+- Update MCP tests
+
+**Steps:**
+
+1. Build a registry mapping tool name to schema, handler, profile, and mutation kind (`read_only`, `conditional`, or `mutating`). Conditional entries must describe the input/default predicate that triggers writes.
+2. Generate/list tools from the registry.
+3. Add parity tests for duplicate/missing tools.
+4. Extract handlers by bounded domain without output changes.
+5. Smoke critical tools: context pack, import latest, source ref, frontier, graph query.
+
+**Acceptance:** `all` tool count/schema and behavior remain compatible; no handler module grows into a new monolith.
+
+**Suggested commit:** `refactor(mcp): route tools through bounded registry modules`
+
+### Work packet 5B — Opt-in profiles
+
+**Objective:** Reduce default context cost for clients that choose a smaller surface.
+
+**Steps:**
+
+1. Add `core`, `operations`, `governance`, `experimental`, `all` metadata.
+2. Add environment/config selection with `all` compatibility default.
+3. Add schema byte/token report tests.
+4. Keep always-mutating tools, including explicit import, out of `core`; expose context-pack auto-refresh as conditional and retain its explicit read-only opt-out.
+5. Test preview/apply and auto-refresh tools against their machine-readable mutation predicates.
+6. Document client migration and troubleshooting.
+
+**Acceptance:** core <=10 tools and <=20 KB schema; all retains the prior list.
+
+**Suggested commit:** `feat(mcp): add backward-compatible tool profiles`
+
+## Phase 6 — Runtime resource decision
+
+### Work packet 6A — Instrument idle/model resources
+
+**Objective:** Determine why process count/RSS remains high without prematurely adding IPC.
+
+**Likely files:**
+
+- `src/extensions/mcp/idle-resources.ts`
+- `src/extensions/mcp/index.ts`
+- `src/extensions/vector/embedder.ts`
+- semantic daemon/runtime health models
+- CLI/dashboard aggregate reporting
+
+**Steps:**
+
+1. Add model-load and release counters/timing.
+2. Add last-activity and cold/hot retrieval timing.
+3. Add aggregate privacy-safe status output.
+4. Verify RSS/model release after the configured idle period.
+5. Collect a representative multi-client sample.
+
+**Suggested commit:** `feat(runtime): expose embedding resource telemetry`
+
+### Work packet 6B — Broker ADR/spike, only if gate is met
+
+**Objective:** Compare alternatives and prototype the smallest safe shared broker.
+
+**Gate:** sustained duplicate-model RSS >=1 GiB or repeated model-load latency after idle release, with enough samples to exclude legacy clients.
+
+**Deliverable:** ADR comparing in-process idle release, shared broker, and provider backends. Do not merge a broker solely because the spike works.
+
+If approved, require local-only transport, bounded timeouts, one model instance, lazy lifecycle, fallback, and no canonical-store ownership.
+
+## Phase 7 — Architecture closure and docs
+
+### Work packet 7A — Boundary baseline zero
+
+1. Inspect current four baseline entries on latest main.
+2. Replace core-to-extension re-export/import boundaries with ports/composition roots.
+3. Remove baseline entries as violations disappear.
+4. Reject new violations in CI.
+
+### Work packet 7B — Retrieval phase extraction
+
+Start only after the expanded benchmark is an enforced gate.
+
+Extract query plan, candidate generation, ranking, expansion, and context assembly one at a time. Preserve trace/debug shapes or version them explicitly.
+
+### Work packet 7C — Documentation drift
+
+Update removed `src/ui` references. For `src/server`, `src/hooks`, and `src/mcp`, document that the remaining files are compatibility entrypoints and link their canonical `src/apps`, `src/adapters`, or `src/extensions` implementations. Link this spec from architecture indexes and progress documents.
+
+## Cross-cutting verification
+
+Run proportionate focused tests during development, then before merge:
+
+```bash
+npm run typecheck
+npm run lint
+npm run check:architecture
+npm run check:public-output-privacy
+npm run benchmark:replay
+npm run eval:longmemeval:retrieval-smoke
+npm run test:run
+npm run build
+```
+
+Also verify:
+
+- `npm list claude-memory-layer` is empty in the repo,
+- no real user settings were modified,
+- no live memory store was changed by tests,
+- generated `dist` behavior is smoke-tested when packaging changes,
+- Node 20.19+ compatibility remains intact.
+
+## Suggested release sequence
+
+1. Patch: Work Packet 1A read-only invariant.
+2. Separate patch/minor: Work Packet 1B recoverable project GC; defer purge until policy review.
+3. Minor: Phase 2 layer audit/rebuild and state-specific health guidance.
+4. Patch/minor: Phase 3 telemetry and benchmark gate.
+5. Patch after evidence: Phase 4 winning SessionStart behavior.
+6. Minor: Phase 5 MCP registry/profiles with `all` default.
+7. Patch: Phase 6 telemetry.
+8. Later minor only if ADR approves: shared embedding broker.
+
+Do not combine storage rebuild, retrieval ranking behavior, and MCP default-profile changes in one release.
+
+## Progress handoff template
+
+When stopping or handing off, append a dated progress note or update a dedicated progress file with:
+
+```markdown
+## YYYY-MM-DD — Work packet X
+
+- Baseline commit:
+- Branch/PR:
+- Completed:
+- Files changed:
+- Tests run and exact results:
+- Runtime/disk/store mutations performed:
+- Known failures or flakes:
+- Decisions made:
+- Remaining tasks:
+- Safe next command:
+- Rollback notes:
+```
+
+Never describe a work packet as complete when required tests, rollout verification, or safety checks remain.

--- a/specs/memory-operational-quality-roadmap/read-only-diagnostics/context.md
+++ b/specs/memory-operational-quality-roadmap/read-only-diagnostics/context.md
@@ -1,0 +1,27 @@
+# Read-only Diagnostics Context
+
+> **Status**: Ready
+> **Parent**: [`../spec.md`](../spec.md)
+
+## Problem
+
+A read-oriented `vector-status` invocation against an unresolved/nonexistent project argument was observed creating an empty project store. The current composition can resolve a writable lightweight project service, which may create directories, initialize SQLite, migrate schema, cache services, or own workers even though the caller only requested status.
+
+The dated machine scan found 67 project directories plus the global store, including 28 empty stores and 20 with only 1-9 events. This feature prevents additional diagnostic side effects; it does not decide which existing stores may be removed.
+
+## Relevant code
+
+- `src/apps/cli/index.ts`
+- `src/apps/cli/vector-command.ts`
+- `src/apps/cli/project-scope-audit.ts`
+- `src/core/registry/project-path.ts`
+- `src/core/registry/repo-identity.ts`
+- `src/services/memory-service-registry.ts`
+- `src/services/memory-service.ts`
+- dashboard/health read routes under `src/apps/server/`
+
+## Boundaries
+
+- Project GC belongs to [`../recoverable-project-gc/`](../recoverable-project-gc/).
+- Derived-layer integrity belongs to [`../derived-layer-recovery/`](../derived-layer-recovery/).
+- Re-measure on current `origin/main`; the original reproduction was against the `2.2.10` operating environment.

--- a/specs/memory-operational-quality-roadmap/read-only-diagnostics/plan.md
+++ b/specs/memory-operational-quality-roadmap/read-only-diagnostics/plan.md
@@ -1,0 +1,38 @@
+# Read-only Diagnostics Plan
+
+> **State**: Ready
+> **Suggested release**: Patch
+
+## Packet 1 — Reproduce and inventory
+
+1. Reproduce `vector-status` against missing path/hash in temporary HOME.
+2. Inventory every read command/API and its service factory.
+3. Record current output/exit behavior and filesystem diff.
+
+## Packet 2 — Invariance harness
+
+1. Add `tests/helpers/memory-root-snapshot.ts` or equivalent.
+2. Unit-test that the helper detects a deliberate mutation.
+3. Include SQLite WAL/SHM and vector artifacts in comparison.
+
+## Packet 3 — Resolver and composition
+
+1. Add non-creating existing-store resolution.
+2. Add uncached read-only composition.
+3. Migrate `vector-status`, stats, health, scope audit, and dashboard reads.
+4. Preserve public response shapes and avoid model initialization.
+
+## Verification
+
+- focused resolver, registry, CLI, server, and MCP tests,
+- filesystem invariance tests for every migrated surface,
+- parent cross-cutting verification.
+
+## Suggested commits
+
+- `test(storage): add read filesystem invariance harness`
+- `fix(storage): make diagnostics side-effect free`
+
+## Progress
+
+No implementation started.

--- a/specs/memory-operational-quality-roadmap/read-only-diagnostics/spec.md
+++ b/specs/memory-operational-quality-roadmap/read-only-diagnostics/spec.md
@@ -1,0 +1,39 @@
+# Read-only Diagnostics Specification
+
+> **Status**: Ready
+
+## Requirements
+
+### ROD-001 — Existing-store resolver
+
+Resolve filesystem paths and explicitly supported opaque hashes into `existing`, `missing`, `invalid`, or `unreadable/corrupt` without creating directories or opening a migrating store. Path/hash semantics must be documented once and shared by CLI/server/MCP callers.
+
+### ROD-002 — Read-only composition
+
+Stats, health, vector status, scope audit, dashboard reads, and other diagnostic surfaces must use uncached read-only composition that owns no worker or embedder. A missing store returns a structured empty/no-store result.
+
+### ROD-003 — Filesystem invariance
+
+Provide a reusable test helper that snapshots a temporary memory root before and after a read. It must detect added/removed files, relevant metadata/content changes, SQLite sidecars, and Lance artifacts.
+
+### ROD-004 — Compatibility
+
+Existing-store human and JSON output remains compatible. Missing/invalid inputs have explicit exit/error semantics. Pure lexical/status paths must not initialize semantic models.
+
+### ROD-005 — Maintenance discovery
+
+Maintenance discovery may count empty skeletons but must not migrate or initialize them while inspecting.
+
+## Acceptance
+
+- Nonexistent project reads create zero files/directories and perform zero migrations.
+- Existing stores are not changed by status/stats/health/audit reads.
+- No worker, embedder, or service-cache entry is created for a pure read.
+- Resolver tests cover path, hash, missing, invalid, unreadable, and symlink cases.
+- Focused CLI/server/MCP tests and parent cross-cutting checks pass.
+
+## Non-goals
+
+- deleting existing stores,
+- rebuilding vectors,
+- suppressing explicitly documented retrieval/access telemetry.

--- a/specs/memory-operational-quality-roadmap/recoverable-project-gc/context.md
+++ b/specs/memory-operational-quality-roadmap/recoverable-project-gc/context.md
@@ -1,0 +1,26 @@
+# Recoverable Project GC Context
+
+> **Status**: Ready after read-only diagnostics
+> **Parent**: [`../spec.md`](../spec.md)
+
+## Problem
+
+The dated scan found 28 empty project stores and 20 stores with 1-9 events. Some may be diagnostic artifacts, but low row count does not prove disposability: registry references, locks, governance rows, outbox work, lessons, checkpoints, or other canonical data may still make a store meaningful.
+
+Cleanup has higher risk than preventing new empty stores. It therefore ships separately from [`../read-only-diagnostics/`](../read-only-diagnostics/) and must be recoverable before any permanent purge is considered.
+
+## Safety model
+
+- Dry-run is the default.
+- `--apply` means move an exact candidate into quarantine on the same filesystem, not delete.
+- A durable manifest supports idempotent restore and interrupted-operation recovery.
+- Purge is a separate retention-gated action and may be omitted from the first release.
+- No command may traverse symlinks or operate outside the exact managed project-store root.
+
+## Open decisions
+
+- minimum candidate age,
+- tables/rows that make a tiny store non-disposable,
+- quarantine location and retention interval per supported platform,
+- registry tombstone/audit representation,
+- interaction with active maintenance and MCP processes.

--- a/specs/memory-operational-quality-roadmap/recoverable-project-gc/plan.md
+++ b/specs/memory-operational-quality-roadmap/recoverable-project-gc/plan.md
@@ -1,0 +1,44 @@
+# Recoverable Project GC Plan
+
+> **State**: Ready after read-only diagnostics
+> **Suggested release**: Separate patch/minor
+
+## Entry gate
+
+- Read-only diagnostics is merged and empty-store growth from reads is stopped.
+- Candidate rules and quarantine retention are approved.
+
+## Packet 1 — Classification and dry-run
+
+1. Define typed classifications and fail-closed eligibility rules.
+2. Reuse the non-creating existing-store resolver.
+3. Implement privacy-safe dry-run report and JSON shape.
+4. Test every retention reason.
+
+## Packet 2 — Quarantine and restore
+
+1. Define versioned manifest and lifecycle states.
+2. Implement exact-target same-filesystem move with lock checks.
+3. Implement idempotent restore and conflict handling.
+4. Add fault-injection tests around move/manifest ordering.
+
+## Packet 3 — Optional purge
+
+Proceed only after policy review. Add retention eligibility, explicit confirmation, exact-target deletion, and audit records. Do not couple purge to maintenance.
+
+## Likely files
+
+- create `src/apps/cli/project-gc.ts`,
+- modify `src/apps/cli/index.ts`,
+- reuse registry/path/lock helpers,
+- add tests under `tests/apps/` and focused operations docs.
+
+## Suggested commits
+
+- `feat(project): add project gc dry-run classification`
+- `feat(project): add recoverable store quarantine and restore`
+- optional later: `feat(project): add retention-gated quarantine purge`
+
+## Progress
+
+No implementation started.

--- a/specs/memory-operational-quality-roadmap/recoverable-project-gc/spec.md
+++ b/specs/memory-operational-quality-roadmap/recoverable-project-gc/spec.md
@@ -1,0 +1,45 @@
+# Recoverable Project GC Specification
+
+> **Status**: Ready after read-only diagnostics
+
+## Requirements
+
+### PGC-001 — Classification
+
+Classify stores as skeleton, empty, tiny, meaningful, busy, unreadable, or ineligible. Empty and tiny are distinct; tiny is retained by default.
+
+### PGC-002 — Candidate proof
+
+A candidate must pass exact-root, symlink, minimum-age, registry, lock/process, canonical rows, governance rows, and outbox checks. Unknown or failed checks retain the store.
+
+### PGC-003 — Dry-run report
+
+Report opaque identity, classification/reason, age bucket, aggregate row counts, and reclaimable bytes without transcript or private path disclosure. Dry-run performs zero mutations.
+
+### PGC-004 — Recoverable apply
+
+Explicit apply atomically moves the exact candidate to a dedicated same-filesystem quarantine and writes a durable manifest containing original/quarantine identity, timestamp, integrity metadata, and state.
+
+### PGC-005 — Restore and recovery
+
+Restore is idempotent, rejects occupied/conflicting destinations, and validates the manifest. Interrupted move/manifest sequences must be detectable and recoverable.
+
+### PGC-006 — Purge separation
+
+Permanent purge requires a retention interval, explicit target/confirmation, audit output, and a separate command or mode. It cannot be automatic maintenance behavior.
+
+## Acceptance
+
+- Governance-only, referenced, busy, symlinked, unreadable, and tiny stores are retained.
+- Apply moves only exact eligible candidates inside temporary HOME.
+- Restore reproduces identity/content and unrelated stores remain unchanged.
+- Interrupted quarantine is recoverable.
+- Purge cannot run before its policy/confirmation gate.
+- Public-output privacy and filesystem-boundary tests pass.
+
+## Non-goals
+
+- deduplicating or merging stores,
+- deleting canonical events,
+- automatic scheduled cleanup,
+- deciding project identity semantics beyond the shared resolver.

--- a/specs/memory-operational-quality-roadmap/retrieval-benchmark-expansion/context.md
+++ b/specs/memory-operational-quality-roadmap/retrieval-benchmark-expansion/context.md
@@ -1,0 +1,24 @@
+# Retrieval Benchmark Expansion Context
+
+> **Status**: Ready
+> **Parent**: [`../spec.md`](../spec.md)
+
+## Problem
+
+The existing anonymized replay fixture has 4 queries and 7 memories. LongMemEval retrieval smoke has 1 query and 2 memories. Current replay metrics—Precision@1 about 0.667, Recall@1 about 0.333, MRR about 0.833, no-match accuracy 1.0, forbidden hits 0—are useful smoke signals but too small to approve ranking or retrieval-phase refactors.
+
+One hook-policy case misses the expected top result. More importantly, the fixture lacks enough categories and negatives to reveal whether aggregate gains hide regressions.
+
+## Existing infrastructure
+
+- `scripts/replay-retrieval-benchmark.ts`
+- `scripts/generate-session-qrels.ts`
+- `scripts/promote-retrieval-review-queue.ts`
+- `scripts/validate-replay-promotion-candidates.ts`
+- `benchmarks/replay/`
+- `scripts/longmemeval-*.ts`
+- `benchmarks/longmemeval/`
+
+## Data boundary
+
+Only reviewed anonymized fixtures are committed. Generation input may use local sessions, but committed data and reports must not contain secrets, personal identity, private absolute paths, or raw transcripts not explicitly approved for the fixture.

--- a/specs/memory-operational-quality-roadmap/retrieval-benchmark-expansion/plan.md
+++ b/specs/memory-operational-quality-roadmap/retrieval-benchmark-expansion/plan.md
@@ -1,0 +1,34 @@
+# Retrieval Benchmark Expansion Plan
+
+> **State**: Ready
+> **Suggested release**: Test/CI change before retrieval behavior work
+
+## Packet 1 — Schema and privacy
+
+1. Confirm category, qrel, forbidden, no-match, and provenance schema.
+2. Strengthen promotion privacy validation with positive and negative tests.
+3. Preserve deterministic evaluator behavior.
+
+## Packet 2 — Curate corpus
+
+1. Sample diverse local session shapes without committing raw source material.
+2. Generate candidates, anonymize, and manually review labels.
+3. Reach at least 50 accepted queries with category balance.
+4. Record rejected candidates/reasons outside public fixture content where necessary.
+
+## Packet 3 — Baseline and CI
+
+1. Run repeated deterministic baselines.
+2. Record category metrics and accepted thresholds.
+3. Wire smoke/full/scheduled tiers.
+4. Test that a regression fails the appropriate gate.
+
+## Suggested commits
+
+- `test(retrieval): harden replay fixture privacy gate`
+- `test(retrieval): expand anonymized session replay corpus`
+- `ci(retrieval): enforce category-aware replay gates`
+
+## Progress
+
+No implementation started.

--- a/specs/memory-operational-quality-roadmap/retrieval-benchmark-expansion/spec.md
+++ b/specs/memory-operational-quality-roadmap/retrieval-benchmark-expansion/spec.md
@@ -1,0 +1,45 @@
+# Retrieval Benchmark Expansion Specification
+
+> **Status**: Ready
+
+## Requirements
+
+### RBE-001 — Corpus breadth
+
+Create at least 50 reviewed labeled queries spanning continuation, incident diagnosis, architectural decision recall, file/symbol recall, and negative/no-match. Aim for 50-100 before approving ranking changes.
+
+### RBE-002 — Judgments
+
+Each case declares positive ids, forbidden ids, explicit no-match expectation where applicable, category, and review provenance. Multiple relevant memories and graded relevance are supported where useful.
+
+### RBE-003 — Privacy gate
+
+Fixture generation and promotion run credential/path/identity/privacy validation. Failure blocks commit/promotion. Reports default to identifiers and aggregates.
+
+### RBE-004 — Metrics
+
+Report Precision@k, Recall@k, nDCG@k, Hit@k, MRR, no-match accuracy, forbidden hits, failed queries, query yield, and category breakdown. Token/injection cost may be added without weakening quality gates.
+
+### RBE-005 — CI tiers
+
+- every PR: deterministic smoke,
+- retrieval/injection change: full anonymized replay,
+- scheduled/manual: larger LongMemEval or provider-assisted evaluation.
+
+### RBE-006 — Promotion gate
+
+Initial hard gates are no-match accuracy 100%, forbidden hits 0, failed queries 0, and no accepted-baseline MRR/Hit@3 regression. Category failures cannot be hidden by aggregate averages; baseline changes require reviewed rationale.
+
+## Acceptance
+
+- At least 50 privacy-approved labeled queries exist.
+- All required categories include positive and negative coverage where applicable.
+- A deliberately leaked credential/path fixture is rejected by tests.
+- CI selects the correct tier for retrieval-affecting changes.
+- Accepted baseline and update procedure are documented.
+
+## Non-goals
+
+- claiming broad LongMemEval quality from the smoke fixture,
+- automatically accepting generated labels,
+- optimizing rankings as part of dataset construction.

--- a/specs/memory-operational-quality-roadmap/retrieval-telemetry/context.md
+++ b/specs/memory-operational-quality-roadmap/retrieval-telemetry/context.md
@@ -1,0 +1,25 @@
+# Retrieval Telemetry Context
+
+> **Status**: Ready
+> **Parent**: [`../spec.md`](../spec.md)
+
+## Problem
+
+The dated 24-hour aggregation showed SessionStart average helpfulness around 0.412 with 60.1% classified unhelpful, versus UserPromptSubmit around 0.559 with roughly 2.8% unhelpful. This cannot directly justify reducing SessionStart because the current score favors response/content overlap and behavioral continuation.
+
+A compact reference index succeeds when it helps an agent locate and open evidence. Its text may never appear in the final response. Reference navigation therefore needs different signals from directly injected evidence.
+
+## Existing surfaces
+
+- `src/core/engine/retrieval-analytics-service.ts`
+- `src/core/engine/retrieval-orchestrator.ts`
+- `src/core/sqlite-event-store.ts`
+- MCP source-ref/details/expand handlers
+- dashboard stats/usefulness API and UI
+
+## Boundaries
+
+- This feature measures behavior; it does not change SessionStart variants.
+- Benchmark quality belongs to [`../retrieval-benchmark-expansion/`](../retrieval-benchmark-expansion/).
+- SessionStart promotion belongs to [`../session-start-experiment/`](../session-start-experiment/).
+- Existing rows remain readable and are labeled legacy/unknown rather than rewritten.

--- a/specs/memory-operational-quality-roadmap/retrieval-telemetry/plan.md
+++ b/specs/memory-operational-quality-roadmap/retrieval-telemetry/plan.md
@@ -1,0 +1,37 @@
+# Retrieval Telemetry Plan
+
+> **State**: Ready
+> **Suggested release**: Patch/minor behind compatible schema
+
+## Packet 1 — Event model and migration
+
+1. Inventory current source/helpfulness/trace columns and API consumers.
+2. Define presentation, trigger, navigation event, and attribution identifiers.
+3. Add forward-compatible migration and legacy mapping tests.
+
+## Packet 2 — Navigation instrumentation
+
+1. Instrument source-ref/details/expand paths.
+2. Implement fail-closed deterministic attribution.
+3. Add duplicate/repeat/ambiguous/session-boundary tests.
+4. Verify no new raw content is persisted.
+
+## Packet 3 — Analytics and UI
+
+1. Split evidence grounding from reference navigation.
+2. Update aggregate API and dashboard labels/denominators.
+3. Add privacy and historical-row regression tests.
+
+## Entry decisions
+
+- attribution window and trace precedence,
+- whether citation use is directly observable or inferred,
+- schema columns versus versioned metadata.
+
+## Suggested commit
+
+`feat(telemetry): measure reference navigation separately`
+
+## Progress
+
+No implementation started.

--- a/specs/memory-operational-quality-roadmap/retrieval-telemetry/spec.md
+++ b/specs/memory-operational-quality-roadmap/retrieval-telemetry/spec.md
@@ -1,0 +1,40 @@
+# Retrieval Telemetry Specification
+
+> **Status**: Ready
+
+## Requirements
+
+### RTT-001 — Presentation model
+
+Retrieval/delivery records identify presentation and trigger concepts without conflating them. Minimum presentation modes are `evidence`, `reference`, and `core`; minimum triggers include `session_start` and `user_prompt`. Normalize existing fields where possible.
+
+### RTT-002 — Reference navigation
+
+When source-ref/details/expand opens a prior reference, record a privacy-safe linkage only when attribution is deterministic. Store identifiers, trace linkage, timestamps/counts, and outcome classification—not newly copied raw content.
+
+### RTT-003 — Attribution rules
+
+Define bounded time/session windows, multi-injection ambiguity behavior, repeat-open handling, and cross-client behavior. Ambiguous attribution remains unattributed rather than guessed.
+
+### RTT-004 — Source-specific evaluation
+
+Evidence delivery may use grounding/content overlap. Reference delivery cannot be marked unhelpful solely because reference text was not repeated. Reports expose separate evidence-grounding and reference-navigation measures.
+
+### RTT-005 — Migration and privacy
+
+Schema changes are additive and backward compatible. Legacy rows use unknown/legacy values. Public APIs remain aggregate and privacy scans cover new metadata.
+
+## Acceptance
+
+- Evidence, reference, and core deliveries can be reported separately.
+- Deterministic reference opens link to the originating trace; ambiguous cases do not.
+- Legacy rows and clients remain readable.
+- Raw transcript/source output is not duplicated for telemetry.
+- Dashboard/API tests demonstrate correct denominators and attribution.
+
+## Non-goals
+
+- selecting a SessionStart winner,
+- using an LLM judge as the only usefulness signal,
+- storing source contents again,
+- cross-project attribution.

--- a/specs/memory-operational-quality-roadmap/runtime-resource-efficiency/context.md
+++ b/specs/memory-operational-quality-roadmap/runtime-resource-efficiency/context.md
@@ -1,0 +1,25 @@
+# Runtime Resource Efficiency Context
+
+> **Status**: Incubating
+> **Parent**: [`../spec.md`](../spec.md)
+
+## Problem
+
+Runtime snapshots showed roughly 18-20 MCP processes using about 2 GiB combined, plus a semantic daemon that could use around 700 MiB while active. Version `2.2.10` added shutdown hardening and ten-minute idle resource release, and legacy orphan processes were removed. Current measurements are not sufficient to tell whether remaining memory is active work, model duplication, clients running old versions, or resources that fail to release.
+
+A shared embedding broker would add IPC, lifecycle, failure, and security complexity. It is a possible outcome of measurement, not the assumed architecture.
+
+## Relevant code
+
+- `src/extensions/mcp/idle-resources.ts`
+- `src/extensions/mcp/process-lifecycle.ts`
+- `src/extensions/mcp/index.ts`
+- `src/extensions/vector/embedder.ts`
+- semantic daemon/client under `src/adapters/claude/hooks/`
+- runtime health and CLI/dashboard aggregate reporting
+
+## Boundaries
+
+- Stats and lexical/fast retrieval should not initialize semantic models.
+- Telemetry output is aggregate and must not expose process command secrets or private paths.
+- Do not install a background service or broker without explicit approval.

--- a/specs/memory-operational-quality-roadmap/runtime-resource-efficiency/plan.md
+++ b/specs/memory-operational-quality-roadmap/runtime-resource-efficiency/plan.md
@@ -1,0 +1,37 @@
+# Runtime Resource Efficiency Plan
+
+> **State**: Incubating
+> **Suggested release**: Patch for telemetry/fast path; later minor only if broker approved
+
+## Packet 1 — Instrumentation
+
+1. Define privacy-safe lifecycle counters/timings.
+2. Instrument load, use, idle release, disposal, and failure paths.
+3. Add deterministic fake-clock/resource tests.
+4. Expose aggregate CLI/dashboard status where supported.
+
+## Packet 2 — Fast-path audit
+
+1. Inventory stats/status/fast retrieval compositions.
+2. Add tests that fail if an embedder loads.
+3. Remove accidental initialization without changing semantic behavior.
+
+## Packet 3 — Field measurement
+
+1. Collect representative multi-client process/RSS/model lifecycle samples.
+2. Separate current-version clients, legacy clients, daemon, and actual orphans.
+3. Quantify duplicate-model RSS and cold-load cost.
+
+## Packet 4 — Decision
+
+- If the gate is not met, record a no-broker ADR and continue idle-release tuning.
+- If met, write a separate broker ADR/spec and prototype the smallest local-only design. Do not merge the prototype solely because it runs.
+
+## Suggested commits
+
+- `feat(runtime): expose embedding resource telemetry`
+- `perf(runtime): keep non-semantic paths model-free`
+
+## Progress
+
+No implementation started; measurement schema is the next action.

--- a/specs/memory-operational-quality-roadmap/runtime-resource-efficiency/spec.md
+++ b/specs/memory-operational-quality-roadmap/runtime-resource-efficiency/spec.md
@@ -1,0 +1,40 @@
+# Runtime Resource Efficiency Specification
+
+> **Status**: Incubating
+
+## Requirements
+
+### RRE-001 — Model lifecycle telemetry
+
+Expose process-local model/backend loaded state, load count/duration, release count/time/reason, last relevant activity, and cold/hot retrieval latency. Backend identity may be opaque.
+
+### RRE-002 — Resource observation
+
+Provide supported-platform aggregate process count/RSS and model-state reporting with version/client grouping sufficient to exclude legacy clients. Unsupported metrics degrade explicitly rather than fabricating zero.
+
+### RRE-003 — Fast path
+
+Stats, status, lexical retrieval, and other non-semantic paths must not load the embedding model. Idle release must be observable and covered by deterministic lifecycle tests.
+
+### RRE-004 — Broker decision gate
+
+Create a broker ADR/spec only if representative post-`2.2.10` evidence shows sustained duplicate-model RSS of at least 1 GiB or repeated material model-load latency after idle release, with enough samples to exclude legacy clients and transient spikes.
+
+### RRE-005 — Broker constraints if approved
+
+Any later broker uses local-only transport, one lazy model instance, idle shutdown, bounded requests/timeouts, client audit where appropriate, in-process/provider fallback, and no canonical-store ownership. Target at least 50% embedding-related aggregate RSS reduction without quality regression.
+
+## Acceptance
+
+- Load/release and cold/hot events are observable without raw/private data.
+- Tests prove fast paths avoid model initialization.
+- Field sample distinguishes current and legacy clients.
+- An ADR records broker, in-process idle release, and provider alternatives.
+- If the gate is not met, a documented no-broker decision completes this feature.
+
+## Non-goals
+
+- building a broker before the gate,
+- centralizing canonical storage,
+- adding network-accessible embedding service,
+- treating RSS alone as proof of a leak.

--- a/specs/memory-operational-quality-roadmap/session-start-experiment/context.md
+++ b/specs/memory-operational-quality-roadmap/session-start-experiment/context.md
@@ -1,0 +1,21 @@
+# SessionStart Experiment Context
+
+> **Status**: Incubating
+> **Parent**: [`../spec.md`](../spec.md)
+
+## Why this is gated
+
+SessionStart currently delivers compact context with substantial character savings, but its overlap-oriented helpfulness score looks materially worse than question-time injection. That score is not aligned with reference-index behavior, so changing the default now would be guesswork.
+
+This feature begins only after:
+
+- [`../retrieval-telemetry/`](../retrieval-telemetry/) can measure reference navigation separately,
+- [`../retrieval-benchmark-expansion/`](../retrieval-benchmark-expansion/) provides the accepted regression gate.
+
+## Candidate variants
+
+- control: current three-item behavior,
+- concise: one summary plus one recent outcome,
+- reference: compact reference-only index resolved at question time.
+
+Exact formatting must be refreshed against current Claude and Codex hook implementations before coding.

--- a/specs/memory-operational-quality-roadmap/session-start-experiment/plan.md
+++ b/specs/memory-operational-quality-roadmap/session-start-experiment/plan.md
@@ -1,0 +1,38 @@
+# SessionStart Experiment Plan
+
+> **State**: Blocked by entry gates
+> **Suggested release**: Patch after evidence
+
+## Entry gates
+
+- Retrieval telemetry acceptance is complete and field-tested.
+- Expanded replay benchmark is enforced.
+- Required sample size/duration and promotion thresholds are approved.
+
+## Packet 1 — Experiment design
+
+1. Refresh current Claude/Codex SessionStart output and constraints.
+2. Freeze control and variant format/version definitions.
+3. Define deterministic cohort and analysis plan.
+
+## Packet 2 — Flagged implementation
+
+1. Add assignment, override, and kill switch.
+2. Implement variants without changing default.
+3. Record delivery/trace metadata and add formatting tests.
+
+## Packet 3 — Field evaluation
+
+1. Run for the approved duration/sample.
+2. Compare quality, navigation, cost, latency, and continuation metrics.
+3. Record promote/retain/redesign decision.
+4. Promote separately with rollback monitoring if approved.
+
+## Suggested commits
+
+- `feat(hooks): add measured session-start variants`
+- after evidence: `feat(hooks): promote measured session-start format`
+
+## Progress
+
+Blocked; do not implement variants yet.

--- a/specs/memory-operational-quality-roadmap/session-start-experiment/spec.md
+++ b/specs/memory-operational-quality-roadmap/session-start-experiment/spec.md
@@ -1,0 +1,39 @@
+# SessionStart Experiment Specification
+
+> **Status**: Incubating; implementation blocked by telemetry and benchmark gates
+
+## Requirements
+
+### SSE-001 — Deterministic assignment
+
+Eligible sessions receive a stable variant assignment. Assignment must not expose session ids and must support environment/config override for testing.
+
+### SSE-002 — Safe default and rollback
+
+Current behavior remains the default/control until promotion. A kill switch restores control without schema rollback.
+
+### SSE-003 — Comparable delivery
+
+Each variant records version, presentation mode, delivered item/character/token estimates, and trace linkage using the accepted telemetry model.
+
+### SSE-004 — Outcome measures
+
+Compare reference opens, first-question relevance, continuation, re-ask, prompt-lane usefulness, latency, and delivery cost. Do not select a winner from overlap alone.
+
+### SSE-005 — Promotion
+
+Promotion requires enough sessions/time for stable comparison, no benchmark regression, user-prompt unhelpful at or below the accepted threshold, material startup reduction, and no meaningful continuation regression.
+
+## Acceptance
+
+- Assignment is deterministic and tested across supported runtimes.
+- Control output remains byte/semantically compatible as defined at implementation time.
+- Kill switch and forced-variant paths work.
+- Reports separate variants and presentation modes.
+- Promotion decision and rollback criteria are recorded.
+
+## Non-goals
+
+- changing question-time retrieval ranking,
+- deleting SessionStart context based only on current helpfulness,
+- uncontrolled online learning of prompt format.

--- a/specs/memory-operational-quality-roadmap/spec.md
+++ b/specs/memory-operational-quality-roadmap/spec.md
@@ -1,0 +1,395 @@
+# Memory Operational Quality Roadmap Specification
+
+> **Version**: 0.1.1
+> **Status**: Draft
+> **Created**: 2026-08-12
+> **Baseline**: `v2.2.10`
+
+## 1. Goal
+
+Improve the shipped memory layer without expanding its product scope. The result should have:
+
+1. side-effect-free read operations,
+2. explicit, verified recovery for derived layers,
+3. presentation-aware usefulness telemetry,
+4. representative retrieval regression benchmarks,
+5. a smaller selectable MCP surface,
+6. measured and bounded model/runtime resource usage,
+7. stronger core/adapter/extension boundaries.
+
+## 2. Non-goals
+
+- Replacing SQLite as canonical storage.
+- Rewriting all retrieval code in one change.
+- Automatically deleting empty/tiny stores.
+- Automatically rebuilding corrupted vectors during maintenance.
+- Automatically retrying quarantined work forever.
+- Shipping a shared embedding broker without evidence.
+- Adding full code graph, full autonomous learning, mesh, or new remote API products.
+- Removing advanced MCP tools without a compatibility period.
+
+## 3. Global invariants
+
+### INV-001 — Canonical data safety
+
+Raw events and governed SQLite records must not be deleted, rewritten, or inferred away by GC or derived-layer repair.
+
+### INV-002 — Read means no write
+
+A command/API advertised as status, stats, audit, list, preview, health, or dry-run must not:
+
+- create a project directory,
+- create an SQLite file,
+- run a schema migration,
+- create a Lance table,
+- enqueue an outbox job,
+- change registry state,
+- update access/helpfulness telemetry unless the endpoint explicitly documents that mutation.
+
+### INV-003 — Dry-run first
+
+Cleanup and rebuild operations default to dry-run. Mutation requires explicit `--apply` or an equivalent audited API option. Project GC apply stages data into recoverable quarantine with a restore manifest; irreversible purge is a separate operation with an explicit retention policy.
+
+### INV-004 — Derived layers are replaceable
+
+Vectors and other declared projections are built from canonical inputs into a separate location, verified, and atomically activated. Failed verification leaves the current active layer untouched.
+
+### INV-005 — Privacy-safe output
+
+Operational output contains aggregate counts, opaque ids, categories, and bounded redacted previews only. It must not expose raw transcript text, credentials, or private source paths.
+
+### INV-006 — Backward compatibility
+
+Existing public CLI/MCP behavior remains compatible unless a release explicitly introduces a migration period. MCP `all` must initially preserve the shipped tool list.
+
+## 4. Workstream A — Existing-store read paths
+
+### RO-001 — Existing-store resolver
+
+Provide a resolver that accepts a project path or supported project hash and returns one of:
+
+- existing readable store,
+- missing store,
+- invalid project argument,
+- unreadable/corrupt store.
+
+The resolver must not create directories or initialize/migrate storage.
+
+### RO-002 — Read-only service composition
+
+Stats, health, vector status, project audit, dashboard reads, and other read surfaces must use a read-only service/store that does not cache or own background workers.
+
+### RO-003 — Filesystem invariance test helper
+
+Add a reusable test helper that snapshots a temporary memory root before and after a read command and asserts no filesystem or database change.
+
+### RO-004 — Empty/tiny-store GC
+
+Add a project GC workflow with:
+
+- dry-run default,
+- exact target enumeration,
+- registry-reference check,
+- active lock/process check,
+- symlink rejection,
+- minimum age,
+- canonical row/outbox/governance checks,
+- aggregate reclaimable-byte report,
+- explicit apply that moves exact candidates to quarantine,
+- durable restore manifest and restore command,
+- separately authorized purge after a retention interval.
+
+Empty and tiny stores must be separate categories. Tiny stores are not automatically disposable.
+
+### RO-005 — Maintenance discovery
+
+Maintenance should distinguish existing meaningful stores from empty skeletons and report both counts without migrating empty stores during inspection.
+
+## 5. Workstream B — Derived-layer audit and rebuild
+
+### DL-001 — Descriptor contract
+
+Introduce a typed descriptor concept with at least:
+
+```ts
+interface DerivedLayerDescriptor {
+  name: string;
+  version: string;
+  inputs: readonly string[];
+  outputs: readonly string[];
+  audit(context: LayerContext): Promise<LayerAuditReport>;
+  rebuild(context: LayerRebuildContext): Promise<LayerRebuildResult>;
+  verify(context: LayerVerificationContext): Promise<LayerVerification>;
+}
+```
+
+The exact API may change, but audit, rebuild, verification, version, and declared inputs/outputs are required concepts.
+
+### DL-002 — Layer audit CLI
+
+Provide privacy-safe commands equivalent to:
+
+```bash
+claude-memory-layer layer audit -p <project> [--json]
+```
+
+Reports should identify missing, stale, corrupt, version-mismatched, quarantined, and healthy states without mutation.
+
+### DL-003 — Vector rebuild
+
+Provide a vector rebuild command with:
+
+- project lock,
+- disk preflight,
+- explicit embedding version,
+- temporary output location,
+- deterministic input selection,
+- bounded progress reporting,
+- count and sampled-query verification,
+- atomic activation,
+- rollback preservation,
+- cleanup only after success.
+
+### DL-004 — Quarantine graduation
+
+Quarantined jobs are only retired/unquarantined when the replacement layer has been verified to contain the corresponding canonical inputs or when an explicit audited policy says those inputs are intentionally non-vectorized.
+
+### DL-005 — Health remediation
+
+Health must distinguish:
+
+- pending/retryable backlog,
+- stuck processing,
+- quarantined-only failure,
+- derived-layer corruption,
+- disk-pressure block,
+- healthy state.
+
+Each state must recommend the correct next command. A quarantined-only store must not be told to run generic pending processing.
+
+## 6. Workstream C — Presentation-aware telemetry
+
+### TEL-001 — Delivery mode
+
+Retrieval/helpfulness records must identify at least:
+
+- `evidence`,
+- `reference`,
+- `core`,
+- `session_start`,
+- `user_prompt`.
+
+Existing `source` data may be extended or normalized rather than duplicated.
+
+### TEL-002 — Reference use
+
+When a referenced memory is opened through source/expand/details, record a privacy-safe linkage when attribution is unambiguous:
+
+- source-open count/time,
+- originating injection/trace when available,
+- whether the source was later cited/used.
+
+Do not record raw output solely for this telemetry.
+
+### TEL-003 — Source-specific scoring
+
+Evidence injection may use grounding/content overlap. Reference delivery must not be classified as unhelpful solely because the summary text was not repeated in the answer.
+
+### TEL-004 — SessionStart variants
+
+Support deterministic, configurable variants:
+
+- current three-item behavior,
+- one summary plus one recent outcome,
+- reference-only index with question-time resolution.
+
+The shipped default remains unchanged until sufficient telemetry selects a winner.
+
+### TEL-005 — Rollback
+
+Variant assignment must be feature-flagged and reversible without schema rollback.
+
+## 7. Workstream D — Retrieval benchmark expansion
+
+### BENCH-001 — Corpus
+
+Create an anonymized fixture with at least 50 labeled queries spanning:
+
+- continuation,
+- bug/incident diagnosis,
+- architectural decision recall,
+- file/symbol-specific recall,
+- negative/no-match.
+
+Aim for 50-100 queries before using it to approve retrieval phase/ranking changes.
+
+### BENCH-002 — Privacy
+
+Fixture generation must redact secrets and local identities/paths. Public reports include ids and aggregate metrics, not raw text.
+
+### BENCH-003 — Metrics
+
+Report at least:
+
+- Precision@k,
+- Recall@k,
+- nDCG@k,
+- Hit@k,
+- MRR,
+- no-match accuracy,
+- forbidden hits,
+- failed queries,
+- category breakdown,
+- query yield,
+- optional token/injection cost.
+
+### BENCH-004 — CI tiers
+
+- Every PR: small deterministic smoke.
+- Retrieval/injection PR: full anonymized replay.
+- Scheduled/manual: larger LongMemEval/provider-assisted evaluation.
+
+### BENCH-005 — Initial gates
+
+- no-match accuracy: 100%,
+- forbidden hits: 0,
+- failed queries: 0,
+- MRR and Hit@3: no regression from the accepted baseline,
+- category failures cannot be hidden by aggregate averages.
+
+## 8. Workstream E — MCP registry and profiles
+
+### MCP-001 — Single tool registry
+
+Tool name, description, schema, handler, profile, and mutation classification should be declared through a registry or generated mapping. Mutation classification must support `read_only`, `conditional`, and `mutating`; conditional tools declare the arguments/default behavior that trigger writes. Tests must fail for missing or duplicate handlers.
+
+### MCP-002 — Handler modules
+
+Split the monolithic handler into bounded modules such as:
+
+- context/search,
+- source/import,
+- operations,
+- graph/lessons,
+- governance/assets,
+- perspective/shared.
+
+Keep a compatibility `handleToolCall` entry point if needed.
+
+### MCP-003 — Profiles
+
+Support:
+
+- `core`,
+- `operations`,
+- `governance`,
+- `experimental`,
+- `all`.
+
+`all` must initially be the compatibility default. Profile selection may use environment/config first; per-client negotiation is optional.
+
+### MCP-004 — Core budget
+
+Target core profile:
+
+- at most 10 tools,
+- at most 20 KB serialized tool schema,
+- includes context pack, search, source navigation, and project timeline/stats,
+- excludes always-mutating tools; explicit import belongs in `operations`,
+- identifies context-pack auto-refresh as conditional mutation and preserves an explicit read-only opt-out.
+
+### MCP-005 — Mutation disclosure
+
+Registry metadata must identify read-only, conditional, and mutating tools so clients and tests can enforce safer defaults. Preview/apply tools and context-pack auto-refresh are conditional; their write-triggering inputs and default behavior must be machine-readable.
+
+## 9. Workstream F — Runtime resource efficiency
+
+### RES-001 — Resource telemetry
+
+Expose privacy-safe process-local signals:
+
+- model loaded state/name or opaque backend id,
+- model load count/time,
+- last MCP activity,
+- idle resource release count/time,
+- cold/hot retrieval latency,
+- process memory totals where supported.
+
+### RES-002 — Fast path
+
+Stats and lexical/fast retrieval must not initialize the embedding model unless a semantic/vector lane is actually required.
+
+### RES-003 — Broker decision gate
+
+A shared local embedding broker is implemented only if post-telemetry evidence shows sustained duplicate model memory or repeated load cost. The decision record must compare:
+
+- in-process plus idle release,
+- shared broker,
+- external/provider embedding options,
+- failure and security boundaries.
+
+### RES-004 — Broker requirements, if approved
+
+- local-only transport,
+- one model instance,
+- lazy start and idle shutdown,
+- bounded requests and timeouts,
+- client identity/audit as appropriate,
+- in-process fallback,
+- no canonical storage ownership.
+
+Target at least 50% aggregate embedding-related RSS reduction without retrieval-quality regression.
+
+## 10. Workstream G — Architecture closure
+
+### ARCH-001 — Boundary baseline to zero
+
+Remove the remaining architecture-guard baseline violations. No new baseline entries are allowed.
+
+### ARCH-002 — Retrieval phases
+
+Only after BENCH-001 through BENCH-005 exist, split retrieval into independently testable phases:
+
+- query plan,
+- candidate generation,
+- ranking,
+- expansion,
+- context assembly.
+
+Public output and trace semantics must remain compatible.
+
+### ARCH-003 — Documentation drift
+
+Update stale references to removed `src/ui` paths. Where `src/server`, `src/hooks`, or `src/mcp` compatibility entrypoints still exist, documentation must distinguish those shims from canonical implementations under `src/apps`, `src/adapters`, and `src/extensions`.
+
+### ARCH-004 — Advanced surface policy
+
+Features with low/no adoption remain available through explicit profiles/extensions. Do not expand default tool/context surfaces solely because the underlying tables exist.
+
+## 11. Acceptance metrics
+
+The roadmap is complete when:
+
+1. Read-only commands create zero files/directories and perform zero migrations in invariant tests.
+2. Empty-store count no longer grows from diagnostics.
+3. GC identifies candidates safely, never selects a store containing canonical/governance data, and can restore every applied quarantine before purge.
+4. The quarantined vector canary can be audited, rebuilt, verified, and rolled back without modifying canonical events.
+5. Health gives state-specific remediation.
+6. Reference opens are attributable and reference delivery is evaluated separately from evidence delivery.
+7. The accepted replay corpus has at least 50 queries and blocks no-match/privacy regressions.
+8. MCP `core` meets the tool/schema budget while `all` preserves compatibility.
+9. Resource telemetry supports an evidence-based broker decision.
+10. Architecture guard baseline violations reach zero and retrieval phase extraction is benchmark-protected.
+
+## 12. Release compatibility
+
+Suggested release grouping:
+
+- Patch: read-only invariant.
+- Separate patch/minor: recoverable project GC with quarantine/restore; defer purge until policy review.
+- Minor: layer audit/rebuild commands and state-specific health remediation.
+- Patch/minor: telemetry schema and SessionStart experiment behind flags.
+- Minor: MCP registry/profiles with `all` default.
+- Later minor only if approved: shared embedding broker.
+
+No release should combine a storage repair primitive, a retrieval ranking change, and an MCP default change in the same rollout.

--- a/specs/memory-operational-quality-roadmap/spec.md
+++ b/specs/memory-operational-quality-roadmap/spec.md
@@ -1,34 +1,31 @@
 # Memory Operational Quality Roadmap Specification
 
-> **Version**: 0.1.1
-> **Status**: Draft
+> **Version**: 0.2.0
+> **Status**: Draft roadmap
 > **Created**: 2026-08-12
 > **Baseline**: `v2.2.10`
 
-## 1. Goal
+## 1. Purpose
 
-Improve the shipped memory layer without expanding its product scope. The result should have:
+This is the parent contract for post-`2.2.10` operational quality work. It defines rules shared by every child feature spec and tracks the product-level outcome. Feature behavior and implementation details belong in child directories.
+
+## 2. Product outcome
+
+The completed roadmap provides:
 
 1. side-effect-free read operations,
-2. explicit, verified recovery for derived layers,
-3. presentation-aware usefulness telemetry,
-4. representative retrieval regression benchmarks,
-5. a smaller selectable MCP surface,
-6. measured and bounded model/runtime resource usage,
-7. stronger core/adapter/extension boundaries.
-
-## 2. Non-goals
-
-- Replacing SQLite as canonical storage.
-- Rewriting all retrieval code in one change.
-- Automatically deleting empty/tiny stores.
-- Automatically rebuilding corrupted vectors during maintenance.
-- Automatically retrying quarantined work forever.
-- Shipping a shared embedding broker without evidence.
-- Adding full code graph, full autonomous learning, mesh, or new remote API products.
-- Removing advanced MCP tools without a compatibility period.
+2. recoverable project-store cleanup,
+3. explicit recovery for derived layers,
+4. presentation-aware usefulness telemetry,
+5. representative retrieval regression gates,
+6. evidence-based SessionStart behavior,
+7. a smaller selectable MCP surface,
+8. measured and bounded model/runtime resource use,
+9. stronger core/adapter/extension boundaries.
 
 ## 3. Global invariants
+
+Every child specification inherits these requirements.
 
 ### INV-001 — Canonical data safety
 
@@ -36,360 +33,85 @@ Raw events and governed SQLite records must not be deleted, rewritten, or inferr
 
 ### INV-002 — Read means no write
 
-A command/API advertised as status, stats, audit, list, preview, health, or dry-run must not:
+A surface advertised as status, stats, audit, list, preview, health, or dry-run must not create storage, migrate schemas, enqueue work, change registry state, or start background workers. Telemetry writes are permitted only when explicitly documented by that surface.
 
-- create a project directory,
-- create an SQLite file,
-- run a schema migration,
-- create a Lance table,
-- enqueue an outbox job,
-- change registry state,
-- update access/helpfulness telemetry unless the endpoint explicitly documents that mutation.
+### INV-003 — Dry-run and recovery first
 
-### INV-003 — Dry-run first
-
-Cleanup and rebuild operations default to dry-run. Mutation requires explicit `--apply` or an equivalent audited API option. Project GC apply stages data into recoverable quarantine with a restore manifest; irreversible purge is a separate operation with an explicit retention policy.
+Cleanup and rebuild operations default to dry-run. Mutation requires explicit authorization. Destructive cleanup must first use recoverable quarantine with a restore manifest; permanent purge is a separate retention-gated action.
 
 ### INV-004 — Derived layers are replaceable
 
-Vectors and other declared projections are built from canonical inputs into a separate location, verified, and atomically activated. Failed verification leaves the current active layer untouched.
+Vectors and other declared projections are built from canonical inputs into a separate location, verified, and atomically activated. Failed verification leaves the active layer untouched.
 
 ### INV-005 — Privacy-safe output
 
-Operational output contains aggregate counts, opaque ids, categories, and bounded redacted previews only. It must not expose raw transcript text, credentials, or private source paths.
+Operational output contains aggregate counts, opaque identifiers, categories, and bounded redacted previews only. It must not expose raw transcripts, credentials, or private source paths.
 
 ### INV-006 — Backward compatibility
 
-Existing public CLI/MCP behavior remains compatible unless a release explicitly introduces a migration period. MCP `all` must initially preserve the shipped tool list.
+Existing public CLI, MCP, hook, and compatibility-entrypoint behavior remains compatible unless a release explicitly documents a migration period and rollback.
 
-## 4. Workstream A — Existing-store read paths
+### INV-007 — Evidence before behavior
 
-### RO-001 — Existing-store resolver
+Telemetry and benchmark gates must exist before retrieval ranking, SessionStart defaults, MCP defaults, or resource architecture changes are promoted.
 
-Provide a resolver that accepts a project path or supported project hash and returns one of:
+### INV-008 — Explicit mutation classification
 
-- existing readable store,
-- missing store,
-- invalid project argument,
-- unreadable/corrupt store.
+MCP and CLI operations must distinguish `read_only`, `conditional`, and `mutating`. Conditional operations declare the inputs and defaults that trigger writes.
 
-The resolver must not create directories or initialize/migrate storage.
+## 4. Feature specifications
 
-### RO-002 — Read-only service composition
+| Feature | Status | Depends on | Specification |
+|---|---|---|---|
+| Read-only diagnostics | Ready | none | [`read-only-diagnostics/spec.md`](read-only-diagnostics/spec.md) |
+| Recoverable project GC | Ready | read-only diagnostics | [`recoverable-project-gc/spec.md`](recoverable-project-gc/spec.md) |
+| Derived-layer recovery | Ready | read-only diagnostics | [`derived-layer-recovery/spec.md`](derived-layer-recovery/spec.md) |
+| Retrieval telemetry | Ready | none | [`retrieval-telemetry/spec.md`](retrieval-telemetry/spec.md) |
+| Retrieval benchmark expansion | Ready | none; required before behavior changes | [`retrieval-benchmark-expansion/spec.md`](retrieval-benchmark-expansion/spec.md) |
+| SessionStart experiment | Incubating | telemetry + benchmark | [`session-start-experiment/spec.md`](session-start-experiment/spec.md) |
+| MCP tool profiles | Incubating | registry parity baseline | [`mcp-tool-profiles/spec.md`](mcp-tool-profiles/spec.md) |
+| Runtime resource efficiency | Incubating | post-2.2.10 measurements | [`runtime-resource-efficiency/spec.md`](runtime-resource-efficiency/spec.md) |
 
-Stats, health, vector status, project audit, dashboard reads, and other read surfaces must use a read-only service/store that does not cache or own background workers.
+`Ready` means the feature is sufficiently bounded to begin implementation after refreshing its dated evidence. `Incubating` means implementation must not start until its listed entry gate is met.
 
-### RO-003 — Filesystem invariance test helper
+## 5. Architecture closure
 
-Add a reusable test helper that snapshots a temporary memory root before and after a read command and asserts no filesystem or database change.
+Architecture closure remains cross-cutting rather than a standalone feature:
 
-### RO-004 — Empty/tiny-store GC
+- remove the four current architecture-guard baseline violations without adding replacements,
+- split retrieval phases only after the expanded benchmark is enforced,
+- distinguish compatibility shims under `src/hooks`, `src/mcp`, and `src/server` from canonical implementations,
+- keep low-adoption advanced features behind explicit profiles/extensions rather than expanding defaults.
 
-Add a project GC workflow with:
+Each child PR must avoid new boundary violations. Larger boundary cleanup should be a dedicated, behavior-preserving PR tied to the relevant child spec.
 
-- dry-run default,
-- exact target enumeration,
-- registry-reference check,
-- active lock/process check,
-- symlink rejection,
-- minimum age,
-- canonical row/outbox/governance checks,
-- aggregate reclaimable-byte report,
-- explicit apply that moves exact candidates to quarantine,
-- durable restore manifest and restore command,
-- separately authorized purge after a retention interval.
+## 6. Roadmap completion criteria
 
-Empty and tiny stores must be separate categories. Tiny stores are not automatically disposable.
+The roadmap is complete only when:
 
-### RO-005 — Maintenance discovery
+1. all eight child specs meet their acceptance criteria,
+2. read diagnostics create zero filesystem/database changes,
+3. applied GC can be restored before retention-gated purge,
+4. a damaged derived vector layer can be audited, rebuilt, verified, activated, and rolled back without canonical mutation,
+5. reference navigation and evidence delivery are evaluated separately,
+6. the accepted replay corpus contains at least 50 labeled queries and blocks privacy/no-match regressions,
+7. SessionStart promotion is supported by telemetry and benchmark evidence,
+8. MCP `core` meets its schema budget while `all` remains compatible,
+9. resource telemetry supports a recorded broker/no-broker decision,
+10. architecture-guard baseline violations reach zero.
 
-Maintenance should distinguish existing meaningful stores from empty skeletons and report both counts without migrating empty stores during inspection.
+## 7. Non-goals
 
-## 5. Workstream B — Derived-layer audit and rebuild
+- replacing SQLite as canonical storage,
+- rewriting retrieval in one change,
+- automatically deleting stores or rebuilding corrupted vectors during maintenance,
+- retrying quarantined work forever,
+- shipping a shared embedding broker without its evidence gate,
+- adding HTTP/SSE, a full code graph, autonomous learning platform, or multi-agent mesh,
+- removing compatibility entrypoints or advanced tools without a migration period.
 
-### DL-001 — Descriptor contract
+## 8. Change control
 
-Introduce a typed descriptor concept with at least:
-
-```ts
-interface DerivedLayerDescriptor {
-  name: string;
-  version: string;
-  inputs: readonly string[];
-  outputs: readonly string[];
-  audit(context: LayerContext): Promise<LayerAuditReport>;
-  rebuild(context: LayerRebuildContext): Promise<LayerRebuildResult>;
-  verify(context: LayerVerificationContext): Promise<LayerVerification>;
-}
-```
-
-The exact API may change, but audit, rebuild, verification, version, and declared inputs/outputs are required concepts.
-
-### DL-002 — Layer audit CLI
-
-Provide privacy-safe commands equivalent to:
-
-```bash
-claude-memory-layer layer audit -p <project> [--json]
-```
-
-Reports should identify missing, stale, corrupt, version-mismatched, quarantined, and healthy states without mutation.
-
-### DL-003 — Vector rebuild
-
-Provide a vector rebuild command with:
-
-- project lock,
-- disk preflight,
-- explicit embedding version,
-- temporary output location,
-- deterministic input selection,
-- bounded progress reporting,
-- count and sampled-query verification,
-- atomic activation,
-- rollback preservation,
-- cleanup only after success.
-
-### DL-004 — Quarantine graduation
-
-Quarantined jobs are only retired/unquarantined when the replacement layer has been verified to contain the corresponding canonical inputs or when an explicit audited policy says those inputs are intentionally non-vectorized.
-
-### DL-005 — Health remediation
-
-Health must distinguish:
-
-- pending/retryable backlog,
-- stuck processing,
-- quarantined-only failure,
-- derived-layer corruption,
-- disk-pressure block,
-- healthy state.
-
-Each state must recommend the correct next command. A quarantined-only store must not be told to run generic pending processing.
-
-## 6. Workstream C — Presentation-aware telemetry
-
-### TEL-001 — Delivery mode
-
-Retrieval/helpfulness records must identify at least:
-
-- `evidence`,
-- `reference`,
-- `core`,
-- `session_start`,
-- `user_prompt`.
-
-Existing `source` data may be extended or normalized rather than duplicated.
-
-### TEL-002 — Reference use
-
-When a referenced memory is opened through source/expand/details, record a privacy-safe linkage when attribution is unambiguous:
-
-- source-open count/time,
-- originating injection/trace when available,
-- whether the source was later cited/used.
-
-Do not record raw output solely for this telemetry.
-
-### TEL-003 — Source-specific scoring
-
-Evidence injection may use grounding/content overlap. Reference delivery must not be classified as unhelpful solely because the summary text was not repeated in the answer.
-
-### TEL-004 — SessionStart variants
-
-Support deterministic, configurable variants:
-
-- current three-item behavior,
-- one summary plus one recent outcome,
-- reference-only index with question-time resolution.
-
-The shipped default remains unchanged until sufficient telemetry selects a winner.
-
-### TEL-005 — Rollback
-
-Variant assignment must be feature-flagged and reversible without schema rollback.
-
-## 7. Workstream D — Retrieval benchmark expansion
-
-### BENCH-001 — Corpus
-
-Create an anonymized fixture with at least 50 labeled queries spanning:
-
-- continuation,
-- bug/incident diagnosis,
-- architectural decision recall,
-- file/symbol-specific recall,
-- negative/no-match.
-
-Aim for 50-100 queries before using it to approve retrieval phase/ranking changes.
-
-### BENCH-002 — Privacy
-
-Fixture generation must redact secrets and local identities/paths. Public reports include ids and aggregate metrics, not raw text.
-
-### BENCH-003 — Metrics
-
-Report at least:
-
-- Precision@k,
-- Recall@k,
-- nDCG@k,
-- Hit@k,
-- MRR,
-- no-match accuracy,
-- forbidden hits,
-- failed queries,
-- category breakdown,
-- query yield,
-- optional token/injection cost.
-
-### BENCH-004 — CI tiers
-
-- Every PR: small deterministic smoke.
-- Retrieval/injection PR: full anonymized replay.
-- Scheduled/manual: larger LongMemEval/provider-assisted evaluation.
-
-### BENCH-005 — Initial gates
-
-- no-match accuracy: 100%,
-- forbidden hits: 0,
-- failed queries: 0,
-- MRR and Hit@3: no regression from the accepted baseline,
-- category failures cannot be hidden by aggregate averages.
-
-## 8. Workstream E — MCP registry and profiles
-
-### MCP-001 — Single tool registry
-
-Tool name, description, schema, handler, profile, and mutation classification should be declared through a registry or generated mapping. Mutation classification must support `read_only`, `conditional`, and `mutating`; conditional tools declare the arguments/default behavior that trigger writes. Tests must fail for missing or duplicate handlers.
-
-### MCP-002 — Handler modules
-
-Split the monolithic handler into bounded modules such as:
-
-- context/search,
-- source/import,
-- operations,
-- graph/lessons,
-- governance/assets,
-- perspective/shared.
-
-Keep a compatibility `handleToolCall` entry point if needed.
-
-### MCP-003 — Profiles
-
-Support:
-
-- `core`,
-- `operations`,
-- `governance`,
-- `experimental`,
-- `all`.
-
-`all` must initially be the compatibility default. Profile selection may use environment/config first; per-client negotiation is optional.
-
-### MCP-004 — Core budget
-
-Target core profile:
-
-- at most 10 tools,
-- at most 20 KB serialized tool schema,
-- includes context pack, search, source navigation, and project timeline/stats,
-- excludes always-mutating tools; explicit import belongs in `operations`,
-- identifies context-pack auto-refresh as conditional mutation and preserves an explicit read-only opt-out.
-
-### MCP-005 — Mutation disclosure
-
-Registry metadata must identify read-only, conditional, and mutating tools so clients and tests can enforce safer defaults. Preview/apply tools and context-pack auto-refresh are conditional; their write-triggering inputs and default behavior must be machine-readable.
-
-## 9. Workstream F — Runtime resource efficiency
-
-### RES-001 — Resource telemetry
-
-Expose privacy-safe process-local signals:
-
-- model loaded state/name or opaque backend id,
-- model load count/time,
-- last MCP activity,
-- idle resource release count/time,
-- cold/hot retrieval latency,
-- process memory totals where supported.
-
-### RES-002 — Fast path
-
-Stats and lexical/fast retrieval must not initialize the embedding model unless a semantic/vector lane is actually required.
-
-### RES-003 — Broker decision gate
-
-A shared local embedding broker is implemented only if post-telemetry evidence shows sustained duplicate model memory or repeated load cost. The decision record must compare:
-
-- in-process plus idle release,
-- shared broker,
-- external/provider embedding options,
-- failure and security boundaries.
-
-### RES-004 — Broker requirements, if approved
-
-- local-only transport,
-- one model instance,
-- lazy start and idle shutdown,
-- bounded requests and timeouts,
-- client identity/audit as appropriate,
-- in-process fallback,
-- no canonical storage ownership.
-
-Target at least 50% aggregate embedding-related RSS reduction without retrieval-quality regression.
-
-## 10. Workstream G — Architecture closure
-
-### ARCH-001 — Boundary baseline to zero
-
-Remove the remaining architecture-guard baseline violations. No new baseline entries are allowed.
-
-### ARCH-002 — Retrieval phases
-
-Only after BENCH-001 through BENCH-005 exist, split retrieval into independently testable phases:
-
-- query plan,
-- candidate generation,
-- ranking,
-- expansion,
-- context assembly.
-
-Public output and trace semantics must remain compatible.
-
-### ARCH-003 — Documentation drift
-
-Update stale references to removed `src/ui` paths. Where `src/server`, `src/hooks`, or `src/mcp` compatibility entrypoints still exist, documentation must distinguish those shims from canonical implementations under `src/apps`, `src/adapters`, and `src/extensions`.
-
-### ARCH-004 — Advanced surface policy
-
-Features with low/no adoption remain available through explicit profiles/extensions. Do not expand default tool/context surfaces solely because the underlying tables exist.
-
-## 11. Acceptance metrics
-
-The roadmap is complete when:
-
-1. Read-only commands create zero files/directories and perform zero migrations in invariant tests.
-2. Empty-store count no longer grows from diagnostics.
-3. GC identifies candidates safely, never selects a store containing canonical/governance data, and can restore every applied quarantine before purge.
-4. The quarantined vector canary can be audited, rebuilt, verified, and rolled back without modifying canonical events.
-5. Health gives state-specific remediation.
-6. Reference opens are attributable and reference delivery is evaluated separately from evidence delivery.
-7. The accepted replay corpus has at least 50 queries and blocks no-match/privacy regressions.
-8. MCP `core` meets the tool/schema budget while `all` preserves compatibility.
-9. Resource telemetry supports an evidence-based broker decision.
-10. Architecture guard baseline violations reach zero and retrieval phase extraction is benchmark-protected.
-
-## 12. Release compatibility
-
-Suggested release grouping:
-
-- Patch: read-only invariant.
-- Separate patch/minor: recoverable project GC with quarantine/restore; defer purge until policy review.
-- Minor: layer audit/rebuild commands and state-specific health remediation.
-- Patch/minor: telemetry schema and SessionStart experiment behind flags.
-- Minor: MCP registry/profiles with `all` default.
-- Later minor only if approved: shared embedding broker.
-
-No release should combine a storage repair primitive, a retrieval ranking change, and an MCP default change in the same rollout.
+- A child spec may tighten its own requirements but cannot weaken parent invariants.
+- If implementation reveals a cross-feature decision, update this parent before diverging child specs.
+- Do not mark a feature complete merely because code merged; required tests, rollout evidence, and rollback documentation must also be complete.

--- a/tests/apps/postinstall-embedding-backend.test.ts
+++ b/tests/apps/postinstall-embedding-backend.test.ts
@@ -242,7 +242,7 @@ describe('embedding backend postinstall repair', () => {
 
   it('does not mistake the checkout dependency for an installed managed backend', () => {
     const postinstall = loadPostinstallModule();
-    const rootDir = mkdtempSync(join(process.cwd(), 'node_modules', '.cml-healthcheck-test-'));
+    const rootDir = mkdtempSync(join(process.cwd(), '.cml-healthcheck-test-'));
 
     try {
       expect(postinstall.isEmbeddingBackendAvailable(rootDir)).toBe(false);


### PR DESCRIPTION
## Summary

- add a dated operational context handoff covering live usage, known gaps, architecture locations, and safety boundaries
- keep a compact parent roadmap for shared invariants, dependency order, release sequence, and completion criteria
- split implementation work into eight independently reviewable feature spec packets, each with context, requirements, acceptance criteria, and execution plan
- gate SessionStart behavior on telemetry and benchmark evidence, and gate any embedding broker on measured resource evidence
- require recoverable project-store quarantine before permanent purge and classify MCP operations as read-only, conditional, or mutating
- make the postinstall health-check test independent of a local node_modules directory

## Feature specs

- read-only diagnostics
- recoverable project GC
- derived-layer recovery
- retrieval telemetry
- retrieval benchmark expansion
- SessionStart experiment
- MCP tool profiles
- runtime resource efficiency

## Validation

- Markdown structure: 27/27 expected files present
- Relative Markdown links: passed
- Code fence and final newline validation: passed
- git diff --check: passed
- npm run typecheck: passed
- npm run lint: 0 errors, 44 pre-existing warnings
- npm run check:architecture: passed, 4 existing baseline entries
- npm run check:public-output-privacy: passed, 0 findings
- npm run benchmark:replay: passed
- npm run eval:longmemeval:retrieval-smoke: passed
- npm run test:run: 204 files, 1293 tests passed
- npm run build: passed