### PR TITLE
feat: add presentation-aware retrieval telemetry

### DIFF
--- a/specs/memory-operational-quality-roadmap/retrieval-telemetry/plan.md
+++ b/specs/memory-operational-quality-roadmap/retrieval-telemetry/plan.md
@@ -1,6 +1,6 @@
 # Retrieval Telemetry Plan
 
-> **State**: Ready
+> **State**: Implemented; review and rollout evidence pending
 > **Suggested release**: Patch/minor behind compatible schema
 
 ## Packet 1 — Event model and migration
@@ -24,9 +24,11 @@
 
 ## Entry decisions
 
-- attribution window and trace precedence,
-- whether citation use is directly observable or inferred,
-- schema columns versus versioned metadata.
+- Attribution uses a 15-minute lookback. An explicit delivery session, when supplied, is a hard boundary; otherwise the target must match exactly one recent reference trace. Multiple candidates remain `ambiguous`, and no candidate remains `unattributed`.
+- Client labels are diagnostic only. Cross-client opens may link to the unique trace, but the client label is never used to guess between traces.
+- Repeated opens of the same target/action/client/outcome within the window increment `open_count`; navigation-rate numerators remain distinct attributed traces.
+- Citation use is not inferred because it is not directly observable. Only source-ref, details, expand, and source opens are recorded.
+- Presentation, trigger, and client use additive typed columns. Navigation uses a separate additive table containing identifiers, timestamps, counts, and classifications only.
 
 ## Suggested commit
 
@@ -34,4 +36,8 @@
 
 ## Progress
 
-No implementation started.
+- Packet 1: implemented with additive migration and legacy `unknown` mapping.
+- Packet 2: implemented for MCP source-ref/details and public CLI/dashboard expand/source paths with fail-closed attribution.
+- Packet 3: implemented with separate evidence-grounding and reference-navigation aggregates plus dashboard/API presentation.
+- Automated tests cover migration, privacy-safe columns, deterministic/ambiguous/expired/session-bounded attribution, repeat opens, denominators, and legacy rows.
+- Remaining before roadmap-level completion: merge, release rollout evidence, and post-rollout measurement. The SessionStart default is unchanged.

--- a/src/adapters/claude/hooks/session-start.ts
+++ b/src/adapters/claude/hooks/session-start.ts
@@ -276,6 +276,22 @@ export async function main(options: SessionStartMainOptions = {}): Promise<strin
           resolveCanonicalMemoryActorId(input.actor_id)
         );
         context = formatCoreMemoryBlockContext(coreBlocks);
+        const deliveredCoreBlockIds = coreBlocks
+          .filter((item) => ('value' in item ? item.value : item).content.trim().length > 0)
+          .map((item) => `core:${('value' in item ? item.value : item).blockKey}`);
+        if (!isHookEvaluationMode() && deliveredCoreBlockIds.length > 0) {
+          await memoryService.recordQueryTrace({
+            sessionId: input.session_id,
+            queryText: '[session-start] core memory',
+            strategy: 'core-memory',
+            candidateEventIds: deliveredCoreBlockIds,
+            selectedEventIds: deliveredCoreBlockIds,
+            confidence: 'core',
+            presentationMode: 'core',
+            triggerType: 'session_start',
+            deliveryClient: 'claude-hook'
+          });
+        }
       } catch {
         // Core memory injection is supplementary; never fail session start over it.
       }
@@ -325,6 +341,23 @@ export async function main(options: SessionStartMainOptions = {}): Promise<strin
       // the evidence history cover this injection path too. One shared batch
       // id groups the injected memories into a single history entry.
       const batchTraceId = randomUUID();
+      const presentationMode = options.contextPresentation ?? 'evidence';
+      if (!isHookEvaluationMode()) {
+        try {
+          await memoryService.recordQueryTrace({
+            traceId: batchTraceId,
+            sessionId: input.session_id,
+            queryText: '[session-start] recent project context',
+            strategy: 'session-start-hook',
+            candidateEventIds: injectedEvents.map((event) => event.id),
+            selectedEventIds: injectedEvents.map((event) => event.id),
+            confidence: 'session-start',
+            presentationMode,
+            triggerType: 'session_start',
+            deliveryClient: 'claude-hook'
+          });
+        } catch { /* non-critical telemetry */ }
+      }
       for (const event of injectedEvents) {
         try {
           await memoryService.recordRetrieval(
@@ -335,6 +368,9 @@ export async function main(options: SessionStartMainOptions = {}): Promise<strin
             {
               traceId: batchTraceId,
               source: 'session_start',
+              presentationMode,
+              triggerType: 'session_start',
+              deliveryClient: 'claude-hook',
               // Grounding is measured against the exact text injected above,
               // not the full event.
               injectedContent: excerpts.get(event.id) ?? sessionStartExcerpt(event)

--- a/src/adapters/claude/hooks/user-prompt-submit.ts
+++ b/src/adapters/claude/hooks/user-prompt-submit.ts
@@ -691,6 +691,9 @@ export async function main(options: UserPromptSubmitMainOptions = {}): Promise<s
               {
                 traceId: retrievalTraceId,
                 source: 'user_prompt',
+                presentationMode: options.contextPresentation ?? 'evidence',
+                triggerType: 'user_prompt',
+                deliveryClient: 'claude-hook',
                 injectedContent: options.contextPresentation === 'reference'
                   ? memoryReferenceSummary(m.content, retrievalQuery)
                   : selectEvidencePreview(m.content, retrievalQuery)
@@ -721,7 +724,10 @@ export async function main(options: UserPromptSubmitMainOptions = {}): Promise<s
             strategy: RETRIEVAL_MODE,
             candidateEventIds: allCandidateIds,
             selectedEventIds: selectedIds,
-            confidence: summarizeHookInjectionConfidence(injectableMemories)
+            confidence: summarizeHookInjectionConfidence(injectableMemories),
+            presentationMode: options.contextPresentation ?? 'evidence',
+            triggerType: 'user_prompt',
+            deliveryClient: 'claude-hook'
           });
         } catch { /* non-critical */ }
 

--- a/src/apps/cli/index.ts
+++ b/src/apps/cli/index.ts
@@ -1087,7 +1087,7 @@ program
  */
 program
   .command('expand <resultId>')
-  .description('Expand a progressive retrieval result with surrounding context')
+  .description('Expand a progressive retrieval result with surrounding context (records navigation telemetry)')
   .option('-w, --window-size <number>', 'Number of surrounding events on each side', '3')
   .option('-p, --project <path>', 'Project path (defaults to cwd)')
   .action(async (resultId: string, options) => {
@@ -1096,7 +1096,9 @@ program
 
     try {
       const expansion = await service.expandDisclosure(resultId, {
-        windowSize: parseInt(options.windowSize)
+        windowSize: parseInt(options.windowSize),
+        recordNavigation: true,
+        navigationClient: 'cli'
       });
 
       if (!expansion) {
@@ -1119,14 +1121,17 @@ program
  */
 program
   .command('source <resultId>')
-  .description('Show raw source details for a progressive retrieval result')
+  .description('Show raw source details for a progressive retrieval result (records navigation telemetry)')
   .option('-p, --project <path>', 'Project path (defaults to cwd)')
   .action(async (resultId: string, options) => {
     const projectPath = options.project || process.cwd();
     const service = getMemoryServiceForProject(projectPath);
 
     try {
-      const source = await service.sourceDisclosure(resultId);
+      const source = await service.sourceDisclosure(resultId, {
+        recordNavigation: true,
+        navigationClient: 'cli'
+      });
 
       if (!source) {
         console.error(`Source not found: ${resultId}`);

--- a/src/apps/dashboard/assets/js/state.js
+++ b/src/apps/dashboard/assets/js/state.js
@@ -11,6 +11,7 @@ const state = {
   sharedStats: null,
   mostAccessed: null,
   helpfulness: null,
+  retrievalTelemetry: null,
   overviewRecentPrompts: [],
   overviewUsefulnessEntries: [],
   memoryUsefulness: null,

--- a/src/apps/dashboard/assets/js/usefulness.js
+++ b/src/apps/dashboard/assets/js/usefulness.js
@@ -14,9 +14,10 @@ async function loadUsefulnessView() {
   state.usefulnessHistoryOffset = 0;
   state.usefulnessHistory = [];
 
-  const [memoryUsefulness, helpfulness, retrievalTraces, retrievalReviewQueue, mostAccessed, adherenceSummary] = await Promise.all([
+  const [memoryUsefulness, helpfulness, retrievalTelemetry, retrievalTraces, retrievalReviewQueue, mostAccessed, adherenceSummary] = await Promise.all([
     fetch(apiUrl(`${API_BASE}/stats/usefulness`, { window: state.usefulnessWindow || '7d' })).then(r => r.json()).catch(() => null),
     fetch(apiUrl(`${API_BASE}/stats/helpfulness`, { limit: 5 })).then(r => r.json()).catch(() => null),
+    fetch(apiUrl(`${API_BASE}/stats/retrieval-telemetry`)).then(r => r.json()).catch(() => null),
     fetch(apiUrl(`${API_BASE}/stats/retrieval-traces`, { limit: 20 })).then(r => r.json()).catch(() => null),
     fetch(apiUrl(`${API_BASE}/stats/retrieval-review-queue`, { limit: 10 })).then(r => r.json()).catch(() => null),
     fetch(apiUrl(`${API_BASE}/stats/most-accessed`, { limit: 10 })).then(r => r.json()).catch(() => null),
@@ -25,6 +26,7 @@ async function loadUsefulnessView() {
 
   state.memoryUsefulness = memoryUsefulness;
   state.helpfulness = helpfulness;
+  state.retrievalTelemetry = retrievalTelemetry;
   state.retrievalTraces = retrievalTraces;
   state.retrievalReviewQueue = retrievalReviewQueue;
   state.mostAccessed = mostAccessed;
@@ -32,12 +34,33 @@ async function loadUsefulnessView() {
 
   updateMemoryUsefulnessUI();
   updateHelpfulnessUI();
+  updateRetrievalTelemetryUI();
   updateMostHelpfulList();
   updateTopAccessedEventsUI();
   updateAdherenceSummaryUI();
   updateRetrievalTraceUI();
 
   await loadUsefulnessHistory({ reset: true });
+}
+
+function updateRetrievalTelemetryUI() {
+  const container = document.getElementById('retrieval-telemetry-summary');
+  if (!container) return;
+  const telemetry = state.retrievalTelemetry;
+  if (!telemetry || telemetry.error) {
+    container.textContent = 'No presentation-aware telemetry yet.';
+    return;
+  }
+  const grounding = telemetry.evidenceGrounding || {};
+  const navigation = telemetry.referenceNavigation || {};
+  const presentations = new Map((telemetry.deliveries?.byPresentation || [])
+    .map(row => [row.presentationMode, row.deliveredItemCount || 0]));
+  const pct = value => `${(Number(value || 0) * 100).toFixed(1)}%`;
+  container.innerHTML = `
+    <div><strong>${formatNumber(presentations.get('evidence') || 0)}</strong> evidence items · <strong>${pct(grounding.groundingRate)}</strong> grounded (${formatNumber(grounding.groundedDeliveries || 0)}/${formatNumber(grounding.evaluatedDeliveries || 0)})</div>
+    <div style="margin-top:6px;"><strong>${formatNumber(presentations.get('reference') || 0)}</strong> reference items · <strong>${pct(navigation.navigationRate)}</strong> navigated (${formatNumber(navigation.navigatedTraces || 0)}/${formatNumber(navigation.eligibleTraces || 0)} traces)</div>
+    <div style="margin-top:6px;"><strong>${formatNumber(presentations.get('core') || 0)}</strong> core items · ${formatNumber(navigation.ambiguousOpenCount || 0)} ambiguous opens</div>
+  `;
 }
 
 async function loadUsefulnessHistory(options = {}) {
@@ -109,13 +132,17 @@ function renderUsefulnessHistory() {
     const isSessionStart = entry.kind === 'session_start';
     const icon = isSessionStart ? 'ri-restart-line' : 'ri-question-line';
     const memories = entry.memories || [];
+    const presentationMode = entry.presentationMode || 'unknown';
+    const isReference = presentationMode === 'reference';
     const measured = memories.filter(m => m.helpfulnessScore !== null && m.helpfulnessScore !== undefined);
     const grounded = memories.filter(m => (m.contentOverlapScore || 0) >= 0.3);
     const bestScore = measured.length > 0 ? Math.max(...measured.map(m => m.helpfulnessScore)) : null;
 
     const statusChips = [
       `<span class="evidence-chip">${memories.length} injected</span>`,
-      grounded.length > 0
+      isReference
+        ? '<span class="evidence-chip">reference navigation measured separately</span>'
+        : grounded.length > 0
         ? `<span class="evidence-chip chip-grounded"><i class="ri-double-quotes-l"></i> ${grounded.length} used in answer</span>`
         : (measured.length > 0 ? '<span class="evidence-chip chip-unused">not reused in answer</span>' : '<span class="evidence-chip">awaiting evaluation</span>'),
       entry.confidence ? `<span class="evidence-chip">${escapeHtml(entry.confidence)}</span>` : ''
@@ -151,8 +178,10 @@ function renderUsefulnessHistory() {
                 ${escapeHtml(m.summary || '(no summary)')}
               </span>
               <span class="evidence-memory-scores">
-                ${groundingBadge(m.contentOverlapScore)}
-                ${usefulnessScoreBadge(m.helpfulnessScore)}
+                ${m.presentationMode === 'reference' ? '' : groundingBadge(m.contentOverlapScore)}
+                ${m.presentationMode === 'reference'
+                  ? '<span class="evidence-score score-pending">reference</span>'
+                  : usefulnessScoreBadge(m.helpfulnessScore)}
               </span>
             </div>
             ${evidenceHtml}

--- a/src/apps/dashboard/index.html
+++ b/src/apps/dashboard/index.html
@@ -462,6 +462,11 @@
               </div>
 
               <div style="margin-top:20px;">
+                <div class="section-label">Delivery Quality by Presentation</div>
+                <div id="retrieval-telemetry-summary" style="padding:8px 0; font-size:13px; color:var(--text-muted);">Loading...</div>
+              </div>
+
+              <div style="margin-top:20px;">
                 <div class="section-label">Helpfulness Distribution</div>
                 <div id="helpfulness-summary" style="padding:8px 0; font-size:13px; color:var(--text-muted);">Loading...</div>
               </div>

--- a/src/apps/server/api/search.ts
+++ b/src/apps/server/api/search.ts
@@ -4,7 +4,7 @@
  */
 
 import { Hono } from 'hono';
-import { getLightweightServiceFromQuery, getServiceFromQuery, jsonError } from './utils.js';
+import { getLightweightServiceFromQuery, getServiceFromQuery, getWritableServiceFromQuery, jsonError } from './utils.js';
 
 export const searchRouter = new Hono();
 
@@ -137,14 +137,19 @@ searchRouter.post('/disclosure', async (c) => {
 
 // GET /api/search/disclosure/:resultId/expand - Expand a disclosure search result
 searchRouter.get('/disclosure/:resultId/expand', async (c) => {
-  const memoryService = getLightweightServiceFromQuery(c);
+  // Explicit disclosure navigation records privacy-safe telemetry.
+  const memoryService = getWritableServiceFromQuery(c);
   try {
     const resultId = c.req.param('resultId');
     const rawWindowSize = c.req.query('windowSize');
     const windowSize = rawWindowSize ? parseInt(rawWindowSize, 10) : undefined;
     const result = await memoryService.expandDisclosure(
       resultId,
-      Number.isFinite(windowSize) ? { windowSize } : undefined
+      {
+        ...(Number.isFinite(windowSize) ? { windowSize } : {}),
+        recordNavigation: true,
+        navigationClient: 'dashboard'
+      }
     );
 
     if (!result) {
@@ -161,10 +166,14 @@ searchRouter.get('/disclosure/:resultId/expand', async (c) => {
 
 // GET /api/search/disclosure/:resultId/source - Resolve source for a disclosure search result
 searchRouter.get('/disclosure/:resultId/source', async (c) => {
-  const memoryService = getLightweightServiceFromQuery(c);
+  // Explicit disclosure navigation records privacy-safe telemetry.
+  const memoryService = getWritableServiceFromQuery(c);
   try {
     const resultId = c.req.param('resultId');
-    const result = await memoryService.sourceDisclosure(resultId);
+    const result = await memoryService.sourceDisclosure(resultId, {
+      recordNavigation: true,
+      navigationClient: 'dashboard'
+    });
 
     if (!result) {
       return c.json({ error: 'Source not found' }, 404);

--- a/src/apps/server/api/stats.ts
+++ b/src/apps/server/api/stats.ts
@@ -1811,6 +1811,32 @@ statsRouter.get('/helpfulness', async (c) => {
     await memoryService.shutdown();
   }
 });
+
+// GET /api/stats/retrieval-telemetry - Presentation-aware aggregate metrics.
+// This is read-only: source/navigation rows are written only by explicit
+// source-ref/details/expand/source actions.
+statsRouter.get('/retrieval-telemetry', async (c) => {
+  const memoryService = getLightweightServiceFromQuery(c);
+  try {
+    await memoryService.initialize();
+    return c.json(await memoryService.getRetrievalTelemetryStats());
+  } catch {
+    return c.json({
+      deliveries: { totalTraces: 0, totalItems: 0, byPresentation: [], byTrigger: [], legacyUnknownRows: 0 },
+      evidenceGrounding: { evaluatedDeliveries: 0, groundedDeliveries: 0, groundingRate: 0, averageContentOverlap: 0 },
+      referenceNavigation: {
+        eligibleTraces: 0,
+        navigatedTraces: 0,
+        navigationRate: 0,
+        attributedOpenCount: 0,
+        ambiguousOpenCount: 0,
+        unattributedOpenCount: 0
+      }
+    });
+  } finally {
+    await memoryService.shutdown();
+  }
+});
 // GET /api/stats/usefulness - Get a dashboard-ready memory usefulness score
 statsRouter.get('/usefulness', async (c) => {
   const rawWindow = (c.req.query('window') || '7d') as KpiWindow;
@@ -1873,6 +1899,7 @@ statsRouter.get('/usefulness-history', async (c) => {
         // intentionally omitted (matches /api/stats/retrieval-traces).
         question: entry.question,
         strategy: entry.strategy,
+        presentationMode: entry.presentationMode,
         confidence: entry.confidence,
         candidateCount: entry.candidateCount,
         selectedCount: entry.selectedCount,
@@ -1911,6 +1938,9 @@ statsRouter.get('/retrieval-traces', async (c) => {
           queryRewriteKind,
           rewritten: queryRewriteKind !== 'none',
           strategy: normalizeRetrievalTraceStrategy(t.strategy ?? 'unknown'),
+          presentationMode: t.presentationMode ?? 'unknown',
+          triggerType: t.triggerType ?? 'unknown',
+          deliveryClient: t.deliveryClient ?? 'unknown',
           candidateEventIds: t.candidateEventIds,
           selectedEventIds: t.selectedEventIds,
           candidateDetails: t.candidateDetails || [],

--- a/src/core/engine/retrieval-analytics-service.ts
+++ b/src/core/engine/retrieval-analytics-service.ts
@@ -6,6 +6,13 @@
  */
 
 import type { RetrievalDebugLane } from '../retrieval-debug-lanes.js';
+import type {
+  RecordReferenceNavigationInput,
+  RecordReferenceNavigationResult,
+  RetrievalPresentationMode,
+  RetrievalTelemetryStats,
+  RetrievalTriggerType
+} from '../retrieval-telemetry.js';
 import type { MemoryEvent } from '../types.js';
 
 export interface RetrievalTraceStrategyStats {
@@ -81,6 +88,7 @@ export interface UsefulnessHistoryMemory {
   evidence: UsefulnessEvidenceMatch[];
   measuredAt: string | null;
   source: string;
+  presentationMode: RetrievalPresentationMode;
 }
 
 export interface UsefulnessHistoryEntry {
@@ -94,6 +102,7 @@ export interface UsefulnessHistoryEntry {
   candidateCount: number;
   selectedCount: number;
   createdAt: Date;
+  presentationMode: RetrievalPresentationMode;
   memories: UsefulnessHistoryMemory[];
 }
 
@@ -137,6 +146,9 @@ export interface RetrievalTrace {
   selectedCount: number;
   confidence?: string;
   fallbackTrace: string[];
+  presentationMode?: RetrievalPresentationMode;
+  triggerType?: RetrievalTriggerType;
+  deliveryClient?: string;
   createdAt: Date;
 }
 
@@ -165,6 +177,8 @@ export interface RetrievalAnalyticsStore {
   getHelpfulnessStats(since?: Date, until?: Date): Promise<HelpfulnessStats>;
   getHelpfulnessStatsByDay?(since: Date, until: Date): Promise<DailyHelpfulnessStats[]>;
   getUsefulnessHistory?(options?: UsefulnessHistoryOptions): Promise<UsefulnessHistoryEntry[]>;
+  getRetrievalTelemetryStats?(): Promise<RetrievalTelemetryStats>;
+  recordReferenceNavigation?(input: RecordReferenceNavigationInput): Promise<RecordReferenceNavigationResult>;
 }
 
 export interface RetrievalAnalyticsServiceDeps {
@@ -243,6 +257,41 @@ export class RetrievalAnalyticsService {
     await this.deps.initialize();
     if (!this.deps.retrievalStore.getUsefulnessHistory) return [];
     return this.deps.retrievalStore.getUsefulnessHistory(options);
+  }
+
+  async getRetrievalTelemetryStats(): Promise<RetrievalTelemetryStats> {
+    await this.deps.initialize();
+    return this.deps.retrievalStore.getRetrievalTelemetryStats?.() || {
+      deliveries: {
+        totalTraces: 0,
+        totalItems: 0,
+        byPresentation: [],
+        byTrigger: [],
+        legacyUnknownRows: 0
+      },
+      evidenceGrounding: {
+        evaluatedDeliveries: 0,
+        groundedDeliveries: 0,
+        groundingRate: 0,
+        averageContentOverlap: 0
+      },
+      referenceNavigation: {
+        eligibleTraces: 0,
+        navigatedTraces: 0,
+        navigationRate: 0,
+        attributedOpenCount: 0,
+        ambiguousOpenCount: 0,
+        unattributedOpenCount: 0
+      }
+    };
+  }
+
+  async recordReferenceNavigation(
+    input: RecordReferenceNavigationInput
+  ): Promise<RecordReferenceNavigationResult> {
+    await this.deps.initialize();
+    return this.deps.retrievalStore.recordReferenceNavigation?.(input)
+      || { outcome: 'unattributed', traceId: null, repeated: false };
   }
 
   /**

--- a/src/core/engine/retrieval-disclosure-service.ts
+++ b/src/core/engine/retrieval-disclosure-service.ts
@@ -12,6 +12,7 @@ import { sanitizeGovernanceAuditValue } from '../operations/governance-audit.js'
 import type { UnifiedRetrievalResult, MemoryWithContext, RetrievalDebugDetail } from '../retriever.js';
 import type { MemoryEvent, SharedTroubleshootingEntry } from '../types.js';
 import type { RetrieveMemoriesOptions } from './retrieval-orchestrator.js';
+import type { RecordReferenceNavigationInput } from '../retrieval-telemetry.js';
 
 export type RetrievalDisclosureResultType = RetrievalResultType;
 export type RetrievalDisclosureReason = RetrievalReason;
@@ -60,6 +61,15 @@ export type RetrievalDisclosureSearchOptions = RetrieveMemoriesOptions;
 
 export interface RetrievalDisclosureExpandOptions {
   windowSize?: number;
+  recordNavigation?: boolean;
+  navigationClient?: string;
+  attributionSessionId?: string;
+}
+
+export interface RetrievalDisclosureSourceOptions {
+  recordNavigation?: boolean;
+  navigationClient?: string;
+  attributionSessionId?: string;
 }
 
 export interface RetrievalDisclosureOrchestrator {
@@ -72,6 +82,7 @@ export interface RetrievalDisclosureOrchestrator {
 export interface RetrievalDisclosureEventStore {
   getEvent(id: string): Promise<MemoryEvent | null>;
   getSessionEvents(sessionId: string): Promise<MemoryEvent[]>;
+  recordReferenceNavigation?(input: RecordReferenceNavigationInput): Promise<unknown>;
 }
 
 export interface RetrievalDisclosureSharedStore {
@@ -92,7 +103,15 @@ export class RetrievalDisclosureService {
     query: string,
     options?: RetrievalDisclosureSearchOptions
   ): Promise<RetrievalDisclosureSearchResponse> {
-    const result = await this.deps.retrievalOrchestrator.retrieveMemories(query, options);
+    const result = await this.deps.retrievalOrchestrator.retrieveMemories(query, {
+      ...options,
+      telemetry: {
+        ...options?.telemetry,
+        presentationMode: 'reference',
+        triggerType: options?.telemetry?.triggerType ?? 'explicit_search',
+        deliveryClient: options?.telemetry?.deliveryClient ?? 'disclosure'
+      }
+    });
     const debugByEventId = this.buildDebugIndex(result);
     const projectResults = result.memories.map((memory) => this.memoryToEnvelope(
       memory,
@@ -142,7 +161,7 @@ export class RetrievalDisclosureService {
     const nearbyEvents = surroundingEvents.length > 0 ? surroundingEvents : [targetEvent];
     const nonTargetEvents = nearbyEvents.filter((event) => event.id !== targetEvent.id);
 
-    return {
+    const expansion = {
       target: this.eventToEnvelope(targetEvent, 1, ['continuity_link']),
       surroundingFacts: nonTargetEvents.map((event) => this.eventToEnvelope(event, 1, this.reasonsForContextEvent(event))),
       summaries: nonTargetEvents
@@ -151,9 +170,14 @@ export class RetrievalDisclosureService {
       relatedSources: nearbyEvents.map((event) => this.sourceReferenceForEvent(event)),
       expandedContext: this.formatTimelineContext(nearbyEvents)
     };
+    await this.recordNavigation(targetEvent.id, 'expand', options);
+    return expansion;
   }
 
-  async source(resultId: string): Promise<RetrievalDisclosureSource | null> {
+  async source(
+    resultId: string,
+    options?: RetrievalDisclosureSourceOptions
+  ): Promise<RetrievalDisclosureSource | null> {
     const parsedId = parseDisclosureResultRef(resultId);
     if (parsedId.kind === 'shared') {
       return this.sourceShared(parsedId.entryId);
@@ -162,11 +186,31 @@ export class RetrievalDisclosureService {
     const rawEvent = await this.deps.eventStore.getEvent(parsedId.eventId);
     if (!rawEvent) return null;
 
-    return {
+    const source = {
       ...this.sourceReferenceForEvent(rawEvent),
       rawEvents: [rawEvent],
       primaryEvent: rawEvent
     };
+    await this.recordNavigation(rawEvent.id, 'source', options);
+    return source;
+  }
+
+  private async recordNavigation(
+    targetEventId: string,
+    action: 'expand' | 'source',
+    options?: RetrievalDisclosureSourceOptions
+  ): Promise<void> {
+    if (options?.recordNavigation !== true || !this.deps.eventStore.recordReferenceNavigation) return;
+    try {
+      await this.deps.eventStore.recordReferenceNavigation({
+        targetEventId,
+        action,
+        navigationClient: options.navigationClient ?? 'disclosure',
+        attributionSessionId: options.attributionSessionId
+      });
+    } catch {
+      // Navigation telemetry must never make disclosure fail.
+    }
   }
 
   private async expandShared(entryId: string): Promise<RetrievalDisclosureExpansion | null> {

--- a/src/core/engine/retrieval-orchestrator.ts
+++ b/src/core/engine/retrieval-orchestrator.ts
@@ -16,6 +16,7 @@ import {
   type UnifiedRetrievalResult
 } from '../retriever.js';
 import type { RetrievalDebugLane } from '../retrieval-debug-lanes.js';
+import type { RetrievalTelemetryContext } from '../retrieval-telemetry.js';
 import type { MemoryOperationsConfig } from '../types.js';
 
 export interface RetrieveMemoriesOptions {
@@ -40,9 +41,11 @@ export interface RetrieveMemoriesOptions {
    * that may receive secret-bearing ad-hoc queries.
    */
   recordTrace?: boolean;
+  /** Presentation-aware telemetry. These values never affect ranking. */
+  telemetry?: RetrievalTelemetryContext;
 }
 
-export interface RecordQueryTraceInput {
+export interface RecordQueryTraceInput extends RetrievalTelemetryContext {
   /** Caller-provided trace id so helpfulness rows can link back to this trace */
   traceId?: string;
   sessionId?: string;
@@ -95,6 +98,9 @@ export interface RetrievalTraceStore {
     selectedDetails?: RetrievalTraceDetail[];
     confidence?: string;
     fallbackTrace?: string[];
+    presentationMode?: RetrievalTelemetryContext['presentationMode'];
+    triggerType?: RetrievalTelemetryContext['triggerType'];
+    deliveryClient?: string;
   }): Promise<void>;
 }
 
@@ -105,7 +111,7 @@ export interface RetrievalAccessStore {
     sessionId: string,
     score: number,
     query: string,
-    options?: { traceId?: string; source?: string; injectedContent?: string }
+    options?: { traceId?: string; source?: string; injectedContent?: string } & RetrievalTelemetryContext
   ): Promise<void>;
 }
 
@@ -131,7 +137,7 @@ export class RetrievalOrchestrator {
     query: string,
     options?: RetrieveMemoriesOptions
   ): Promise<UnifiedRetrievalResult> {
-    const { recordTrace = true, ...retrieverOptions } = options ?? {};
+    const { recordTrace = true, telemetry, ...retrieverOptions } = options ?? {};
     const lightweightFastRead = this.isLightweightFastRead(options);
     if (!lightweightFastRead) {
       await this.deps.initialize();
@@ -173,7 +179,7 @@ export class RetrievalOrchestrator {
 
     if (recordTrace) {
       try {
-        await this.recordAutomaticTrace(query, result, options, projectHash);
+        await this.recordAutomaticTrace(query, result, options, projectHash, telemetry);
       } catch {
         // Non-blocking telemetry.
       }
@@ -237,7 +243,7 @@ export class RetrievalOrchestrator {
     sessionId: string,
     score: number,
     query: string,
-    options?: { traceId?: string; source?: string; injectedContent?: string }
+    options?: { traceId?: string; source?: string; injectedContent?: string } & RetrievalTelemetryContext
   ): Promise<void> {
     await this.deps.initialize();
     await this.deps.accessStore.recordRetrieval(eventId, sessionId, score, query, options);
@@ -275,7 +281,8 @@ export class RetrievalOrchestrator {
     query: string,
     result: UnifiedRetrievalResult,
     options: RetrieveMemoriesOptions | undefined,
-    projectHash: string | null
+    projectHash: string | null,
+    telemetry: RetrievalTelemetryContext | undefined
   ): Promise<void> {
     const selectedEventIds = result.memories.map((memory) => memory.event.id);
     const selectedDetails = (result.selectedDebug || []).map((detail) => ({
@@ -310,7 +317,10 @@ export class RetrievalOrchestrator {
       candidateDetails,
       selectedDetails,
       confidence: result.matchResult.confidence,
-      fallbackTrace: result.fallbackTrace || []
+      fallbackTrace: result.fallbackTrace || [],
+      presentationMode: telemetry?.presentationMode,
+      triggerType: telemetry?.triggerType,
+      deliveryClient: telemetry?.deliveryClient
     });
   }
 

--- a/src/core/engine/retrieval-services.ts
+++ b/src/core/engine/retrieval-services.ts
@@ -175,6 +175,7 @@ export type {
   RetrievalDisclosureServiceDeps,
   RetrievalDisclosureSharedStore,
   RetrievalDisclosureSource,
+  RetrievalDisclosureSourceOptions,
   RetrievalDisclosureSourceReference,
   RetrievalDisclosureSourceType
 } from './retrieval-disclosure-service.js';

--- a/src/core/retrieval-telemetry.ts
+++ b/src/core/retrieval-telemetry.ts
@@ -1,0 +1,92 @@
+export const RETRIEVAL_PRESENTATION_MODES = ['evidence', 'reference', 'core', 'unknown'] as const;
+export type RetrievalPresentationMode = typeof RETRIEVAL_PRESENTATION_MODES[number];
+
+export const RETRIEVAL_TRIGGER_TYPES = [
+  'session_start',
+  'user_prompt',
+  'explicit_search',
+  'context_pack',
+  'unknown'
+] as const;
+export type RetrievalTriggerType = typeof RETRIEVAL_TRIGGER_TYPES[number];
+
+export const REFERENCE_NAVIGATION_ACTIONS = ['source_ref', 'details', 'expand', 'source'] as const;
+export type ReferenceNavigationAction = typeof REFERENCE_NAVIGATION_ACTIONS[number];
+
+export type ReferenceNavigationOutcome = 'attributed' | 'ambiguous' | 'unattributed';
+
+export interface RetrievalTelemetryContext {
+  presentationMode?: RetrievalPresentationMode;
+  triggerType?: RetrievalTriggerType;
+  deliveryClient?: string;
+}
+
+export interface RecordReferenceNavigationInput {
+  targetEventId: string;
+  action: ReferenceNavigationAction;
+  navigationClient: string;
+  /** Optional current delivery session. When supplied, attribution never crosses its boundary. */
+  attributionSessionId?: string;
+  openedAt?: Date;
+}
+
+export interface RecordReferenceNavigationResult {
+  outcome: ReferenceNavigationOutcome;
+  traceId: string | null;
+  repeated: boolean;
+}
+
+export interface RetrievalPresentationBreakdown {
+  presentationMode: RetrievalPresentationMode;
+  traceCount: number;
+  deliveredItemCount: number;
+}
+
+export interface RetrievalTriggerBreakdown {
+  triggerType: RetrievalTriggerType;
+  traceCount: number;
+  deliveredItemCount: number;
+}
+
+export interface RetrievalTelemetryStats {
+  deliveries: {
+    totalTraces: number;
+    totalItems: number;
+    byPresentation: RetrievalPresentationBreakdown[];
+    byTrigger: RetrievalTriggerBreakdown[];
+    legacyUnknownRows: number;
+  };
+  evidenceGrounding: {
+    evaluatedDeliveries: number;
+    groundedDeliveries: number;
+    groundingRate: number;
+    averageContentOverlap: number;
+  };
+  referenceNavigation: {
+    eligibleTraces: number;
+    navigatedTraces: number;
+    navigationRate: number;
+    attributedOpenCount: number;
+    ambiguousOpenCount: number;
+    unattributedOpenCount: number;
+  };
+}
+
+export function normalizeRetrievalPresentationMode(value: unknown): RetrievalPresentationMode {
+  return typeof value === 'string' && (RETRIEVAL_PRESENTATION_MODES as readonly string[]).includes(value)
+    ? value as RetrievalPresentationMode
+    : 'unknown';
+}
+
+export function normalizeRetrievalTriggerType(value: unknown): RetrievalTriggerType {
+  return typeof value === 'string' && (RETRIEVAL_TRIGGER_TYPES as readonly string[]).includes(value)
+    ? value as RetrievalTriggerType
+    : 'unknown';
+}
+
+export function normalizeTelemetryClient(value: unknown): string {
+  if (typeof value !== 'string') return 'unknown';
+  const normalized = value.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, '-').slice(0, 48);
+  return normalized || 'unknown';
+}
+

--- a/src/core/sqlite-event-store.ts
+++ b/src/core/sqlite-event-store.ts
@@ -39,6 +39,17 @@ import { MarkdownMirror } from './markdown-mirror.js';
 import { VectorOutbox, type OutboxConfig } from './vector-outbox.js';
 import { normalizeRetrievalDebugLanes, type RetrievalDebugLane } from './retrieval-debug-lanes.js';
 import { computeMemoryUsageEvidence, type EvidenceMatch } from './usefulness-evidence.js';
+import {
+  normalizeRetrievalPresentationMode,
+  normalizeRetrievalTriggerType,
+  normalizeTelemetryClient,
+  type RecordReferenceNavigationInput,
+  type RecordReferenceNavigationResult,
+  type RetrievalPresentationMode,
+  type RetrievalTelemetryContext,
+  type RetrievalTelemetryStats,
+  type RetrievalTriggerType
+} from './retrieval-telemetry.js';
 
 export interface SQLiteEventStoreOptions extends SQLiteOptions {
   markdownMirrorRoot?: string;
@@ -100,6 +111,7 @@ function normalizeQueryRewriteKind(value?: string | null): QueryRewriteKind {
 const REWRITTEN_QUERY_REWRITE_KIND_SQL = `LOWER(TRIM(COALESCE(query_rewrite_kind, 'none'))) IN ('follow-up-context', 'intent-rewrite')`;
 const DEFAULT_OUTBOX_STUCK_THRESHOLD_MS = 5 * 60 * 1000;
 const DEFAULT_OUTBOX_MAX_RETRIES = 3;
+export const REFERENCE_ATTRIBUTION_WINDOW_MS = 15 * 60 * 1000;
 // Bump when introducing an ordered migration that must run exactly once; gate
 // such migrations on the persisted PRAGMA user_version.
 const SQLITE_SCHEMA_VERSION = 1;
@@ -586,6 +598,9 @@ export class SQLiteEventStore {
         tool_total_count INTEGER DEFAULT 0,
         was_reasked INTEGER DEFAULT 0,
         helpfulness_score REAL DEFAULT 0.5,
+        presentation_mode TEXT NOT NULL DEFAULT 'unknown',
+        trigger_type TEXT NOT NULL DEFAULT 'unknown',
+        delivery_client TEXT NOT NULL DEFAULT 'unknown',
         created_at TEXT DEFAULT (datetime('now')),
         measured_at TEXT
       );
@@ -607,7 +622,28 @@ export class SQLiteEventStore {
         selected_count INTEGER DEFAULT 0,
         confidence TEXT,
         fallback_trace TEXT,
+        presentation_mode TEXT NOT NULL DEFAULT 'unknown',
+        trigger_type TEXT NOT NULL DEFAULT 'unknown',
+        delivery_client TEXT NOT NULL DEFAULT 'unknown',
         created_at TEXT DEFAULT (datetime('now'))
+      );
+
+      -- Privacy-safe reference navigation. Target and trace identifiers are
+      -- stored without copying source or transcript content.
+      CREATE TABLE IF NOT EXISTS retrieval_navigation_events (
+        navigation_id TEXT PRIMARY KEY,
+        target_event_id TEXT NOT NULL,
+        trace_id TEXT,
+        delivery_session_id TEXT,
+        presentation_mode TEXT NOT NULL DEFAULT 'reference',
+        trigger_type TEXT NOT NULL DEFAULT 'unknown',
+        navigation_action TEXT NOT NULL,
+        navigation_client TEXT NOT NULL DEFAULT 'unknown',
+        attribution_outcome TEXT NOT NULL,
+        attribution_reason TEXT NOT NULL,
+        open_count INTEGER NOT NULL DEFAULT 1,
+        first_opened_at TEXT NOT NULL,
+        last_opened_at TEXT NOT NULL
       );
 
       -- Sync position tracking (for SQLite -> DuckDB sync)
@@ -930,6 +966,8 @@ export class SQLiteEventStore {
       CREATE INDEX IF NOT EXISTS idx_retrieval_traces_created_at ON retrieval_traces(created_at DESC);
       CREATE INDEX IF NOT EXISTS idx_retrieval_traces_project_hash ON retrieval_traces(project_hash);
       CREATE INDEX IF NOT EXISTS idx_retrieval_traces_session_id ON retrieval_traces(session_id);
+      CREATE INDEX IF NOT EXISTS idx_retrieval_navigation_trace ON retrieval_navigation_events(trace_id);
+      CREATE INDEX IF NOT EXISTS idx_retrieval_navigation_target_time ON retrieval_navigation_events(target_event_id, last_opened_at DESC);
       CREATE INDEX IF NOT EXISTS idx_memory_facets_project_dimension_value ON memory_facets(project_hash, dimension, value);
       CREATE INDEX IF NOT EXISTS idx_memory_facets_target ON memory_facets(target_type, target_id);
       CREATE INDEX IF NOT EXISTS idx_memory_facets_dimension_value_confidence ON memory_facets(dimension, value, confidence DESC);
@@ -1049,6 +1087,9 @@ export class SQLiteEventStore {
     this.addColumnIfMissing('memory_helpfulness', 'content_overlap_score', 'REAL');
     this.addColumnIfMissing('memory_helpfulness', 'evidence_json', 'TEXT');
     this.addColumnIfMissing('memory_helpfulness', 'injected_content', 'TEXT');
+    this.addColumnIfMissing('memory_helpfulness', 'presentation_mode', `TEXT NOT NULL DEFAULT 'unknown'`);
+    this.addColumnIfMissing('memory_helpfulness', 'trigger_type', `TEXT NOT NULL DEFAULT 'unknown'`);
+    this.addColumnIfMissing('memory_helpfulness', 'delivery_client', `TEXT NOT NULL DEFAULT 'unknown'`);
     try {
       sqliteExec(this.db, `CREATE INDEX IF NOT EXISTS idx_helpfulness_trace ON memory_helpfulness(trace_id);`);
     } catch {
@@ -1060,6 +1101,9 @@ export class SQLiteEventStore {
     this.addColumnIfMissing('retrieval_traces', 'candidate_details_json', 'TEXT');
     this.addColumnIfMissing('retrieval_traces', 'raw_query_text', 'TEXT');
     this.addColumnIfMissing('retrieval_traces', 'query_rewrite_kind', 'TEXT');
+    this.addColumnIfMissing('retrieval_traces', 'presentation_mode', `TEXT NOT NULL DEFAULT 'unknown'`);
+    this.addColumnIfMissing('retrieval_traces', 'trigger_type', `TEXT NOT NULL DEFAULT 'unknown'`);
+    this.addColumnIfMissing('retrieval_traces', 'delivery_client', `TEXT NOT NULL DEFAULT 'unknown'`);
 
     // Explicit curation reuses the existing lesson artifact while preserving
     // whether the item came from a reviewed/manual capture or a derivation.
@@ -2597,7 +2641,7 @@ export class SQLiteEventStore {
     sessionId: string,
     score: number,
     query: string,
-    options?: { traceId?: string; source?: string; injectedContent?: string }
+    options?: { traceId?: string; source?: string; injectedContent?: string } & RetrievalTelemetryContext
   ): Promise<void> {
     if (this.readOnly) return;
     await this.initialize();
@@ -2608,13 +2652,18 @@ export class SQLiteEventStore {
     // timestamp in the same second) would count as "after" the retrieval.
     sqliteRun(
       this.db,
-      `INSERT INTO memory_helpfulness (id, event_id, session_id, retrieval_score, query_preview, trace_id, source, injected_content, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO memory_helpfulness (
+         id, event_id, session_id, retrieval_score, query_preview, trace_id, source,
+         injected_content, presentation_mode, trigger_type, delivery_client, created_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         id, eventId, sessionId, score, query.slice(0, 200),
         options?.traceId || null,
         options?.source || 'user_prompt',
         options?.injectedContent ? options.injectedContent.slice(0, 2000) : null,
+        normalizeRetrievalPresentationMode(options?.presentationMode),
+        normalizeRetrievalTriggerType(options?.triggerType),
+        normalizeTelemetryClient(options?.deliveryClient),
         new Date().toISOString()
       ]
     );
@@ -2741,13 +2790,25 @@ export class SQLiteEventStore {
       const memoryContent = (retrieval.injected_content as string)
         || memoryContentById.get(retrieval.event_id as string)
         || '';
+      const presentationMode = normalizeRetrievalPresentationMode(retrieval.presentation_mode);
       let contentOverlapScore: number | null = null;
       let evidenceMatches: EvidenceMatch[] = [];
-      if (responsesAfter.length > 0 && memoryContent) {
+      if (presentationMode !== 'reference' && responsesAfter.length > 0 && memoryContent) {
         const evidence = computeMemoryUsageEvidence(memoryContent, responsesAfter);
         contentOverlapScore = evidence.contentOverlapScore;
         evidenceMatches = evidence.matches;
       }
+
+      const referenceOpened = presentationMode === 'reference' && Boolean(retrieval.trace_id) && Boolean(
+        sqliteGet<{ opened: number }>(
+          this.db,
+          `SELECT 1 AS opened
+           FROM retrieval_navigation_events
+           WHERE trace_id = ? AND target_event_id = ? AND attribution_outcome = 'attributed'
+           LIMIT 1`,
+          [retrieval.trace_id, retrieval.event_id]
+        )
+      );
 
       // Calculate helpfulness score
       // Weights tuned for shopping-assistant-like corpora where sessions
@@ -2758,7 +2819,12 @@ export class SQLiteEventStore {
       // When content grounding is measurable it dominates the score; the
       // legacy behavioral-only formula remains the fallback (e.g. session
       // ended right after retrieval, so no responses followed).
-      const helpfulnessScore = contentOverlapScore !== null
+      // A reference index is navigation, not evidence. Absence of copied text
+      // must not make it unhelpful: a deterministic open is positive and an
+      // unopened reference remains neutral. Citation use is not inferred.
+      const helpfulnessScore = presentationMode === 'reference'
+        ? (referenceOpened ? 1 : 0.5)
+        : contentOverlapScore !== null
         ? (
           0.45 * contentOverlapScore +
           0.20 * Math.min(retrievalScore, 1.0) +
@@ -2985,7 +3051,9 @@ export class SQLiteEventStore {
       evidence: EvidenceMatch[];
       measuredAt: string | null;
       source: string;
+      presentationMode: RetrievalPresentationMode;
     }>;
+    presentationMode: RetrievalPresentationMode;
   }>> {
     await this.initialize();
 
@@ -2995,6 +3063,11 @@ export class SQLiteEventStore {
     // Read-only dashboards can open legacy DBs where the trace-link migration
     // (trace_id/source columns) never ran; fall back to trace-only history.
     const hasTraceLink = this.hasTableColumn('memory_helpfulness', 'trace_id');
+    const hasTraceTrigger = this.hasTableColumn('retrieval_traces', 'trigger_type');
+    const hasTracePresentation = this.hasTableColumn('retrieval_traces', 'presentation_mode');
+    const traceKindSql = hasTraceTrigger
+      ? `CASE WHEN trigger_type = 'session_start' THEN 'session_start' ELSE 'query' END`
+      : `'query'`;
 
     const sessionFilterTrace = options.sessionId ? `AND session_id = ?` : '';
     const selectionFilter = options.withSelectionsOnly ? `AND selected_count > 0` : '';
@@ -3012,13 +3085,16 @@ export class SQLiteEventStore {
                 session_id,
                 MIN(created_at) AS created_at
          FROM memory_helpfulness
-         WHERE source = 'session_start' ${sessionFilterTrace}
+         WHERE source = 'session_start'
+           AND (trace_id IS NULL OR NOT EXISTS (
+             SELECT 1 FROM retrieval_traces rt WHERE rt.trace_id = memory_helpfulness.trace_id
+           )) ${sessionFilterTrace}
          GROUP BY COALESCE(trace_id, 'ss-' || session_id), session_id`
       : '';
     const heads = sqliteAll<Record<string, unknown>>(
       this.db,
       `SELECT * FROM (
-         SELECT 'query' AS kind, trace_id AS id, session_id, created_at
+         SELECT ${traceKindSql} AS kind, trace_id AS id, session_id, created_at
          FROM retrieval_traces
          WHERE 1=1 ${sessionFilterTrace} ${selectionFilter}
          ${sessionStartBranch}
@@ -3049,7 +3125,9 @@ export class SQLiteEventStore {
         evidence: EvidenceMatch[];
         measuredAt: string | null;
         source: string;
+        presentationMode: RetrievalPresentationMode;
       }>;
+      presentationMode: RetrievalPresentationMode;
     }> = [];
 
     for (const head of heads) {
@@ -3057,13 +3135,13 @@ export class SQLiteEventStore {
       const headId = head.id as string;
 
       let trace: Record<string, unknown> | undefined;
-      if (kind === 'query') {
+      if (!headId.startsWith('ss-')) {
         trace = sqliteGet<Record<string, unknown>>(
           this.db,
           `SELECT * FROM retrieval_traces WHERE trace_id = ?`,
           [headId]
         );
-        if (!trace) continue;
+        if (!trace && kind === 'query') continue;
       }
 
       // Helpfulness rows for this head: primary link via trace_id; legacy
@@ -3075,7 +3153,7 @@ export class SQLiteEventStore {
           [headId]
         )
         : [];
-      if (kind === 'query' && helpRows.length === 0 && trace) {
+      if (helpRows.length === 0 && trace) {
         const selectedIds: string[] = (() => {
           try { return JSON.parse((trace.selected_event_ids as string) || '[]'); } catch { return []; }
         })();
@@ -3092,7 +3170,7 @@ export class SQLiteEventStore {
           );
         }
       }
-      if (kind === 'session_start' && helpRows.length === 0 && headId.startsWith('ss-')) {
+      if (kind === 'session_start' && helpRows.length === 0 && !trace) {
         helpRows = sqliteAll<Record<string, unknown>>(
           this.db,
           `SELECT * FROM memory_helpfulness
@@ -3133,22 +3211,30 @@ export class SQLiteEventStore {
           contentOverlapScore: (row.content_overlap_score as number) ?? null,
           evidence,
           measuredAt: (row.measured_at as string) ?? null,
-          source: (row.source as string) || 'user_prompt'
+          source: (row.source as string) || 'user_prompt',
+          presentationMode: normalizeRetrievalPresentationMode(row.presentation_mode)
         };
       });
 
-      if (kind === 'query' && trace) {
+      if (trace) {
         entries.push({
           traceId: headId,
           kind,
           sessionId: (trace.session_id as string) ?? null,
-          question: (trace.raw_query_text as string) || (trace.query_text as string) || '',
+          question: kind === 'session_start'
+            ? (normalizeRetrievalPresentationMode(trace.presentation_mode) === 'core'
+              ? 'Session start — core memory injected'
+              : 'Session start — recent project context injected')
+            : (trace.raw_query_text as string) || (trace.query_text as string) || '',
           queryText: (trace.query_text as string) ?? null,
           strategy: (trace.strategy as string) ?? null,
           confidence: (trace.confidence as string) ?? null,
           candidateCount: (trace.candidate_count as number) ?? 0,
           selectedCount: (trace.selected_count as number) ?? 0,
           createdAt: toDateFromSQLite(trace.created_at as string),
+          presentationMode: hasTracePresentation
+            ? normalizeRetrievalPresentationMode(trace.presentation_mode)
+            : 'unknown',
           memories
         });
       } else {
@@ -3163,6 +3249,7 @@ export class SQLiteEventStore {
           candidateCount: memories.length,
           selectedCount: memories.length,
           createdAt: toDateFromSQLite(head.created_at as string),
+          presentationMode: 'unknown',
           memories
         });
       }
@@ -3418,7 +3505,11 @@ export class SQLiteEventStore {
     }>;
     confidence?: string;
     fallbackTrace?: string[];
+    presentationMode?: RetrievalPresentationMode;
+    triggerType?: RetrievalTriggerType;
+    deliveryClient?: string;
   }): Promise<void> {
+    if (this.readOnly) return;
     await this.initialize();
 
     const traceId = input.traceId || randomUUID();
@@ -3430,8 +3521,9 @@ export class SQLiteEventStore {
       `INSERT INTO retrieval_traces (
         trace_id, session_id, project_hash, query_text, raw_query_text, query_rewrite_kind, strategy,
         candidate_event_ids, selected_event_ids, candidate_details_json, selected_details_json,
-        candidate_count, selected_count, confidence, fallback_trace
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        candidate_count, selected_count, confidence, fallback_trace,
+        presentation_mode, trigger_type, delivery_client
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         traceId,
         input.sessionId || null,
@@ -3447,9 +3539,232 @@ export class SQLiteEventStore {
         (input.candidateEventIds || []).length,
         (input.selectedEventIds || []).length,
         input.confidence || null,
-        JSON.stringify(input.fallbackTrace || [])
+        JSON.stringify(input.fallbackTrace || []),
+        normalizeRetrievalPresentationMode(input.presentationMode),
+        normalizeRetrievalTriggerType(input.triggerType),
+        normalizeTelemetryClient(input.deliveryClient)
       ]
     );
+  }
+
+  /**
+   * Attribute a reference open to a recent reference delivery only when one
+   * trace is the unique candidate. The 15-minute window is deliberately
+   * bounded; an optional current session makes the boundary stricter. Client
+   * labels are recorded for diagnostics but never used to guess attribution.
+   * Repeated opens collapse into one row with an incremented count.
+   */
+  async recordReferenceNavigation(
+    input: RecordReferenceNavigationInput
+  ): Promise<RecordReferenceNavigationResult> {
+    if (this.readOnly) {
+      return { outcome: 'unattributed', traceId: null, repeated: false };
+    }
+    await this.initialize();
+
+    const openedAt = input.openedAt ?? new Date();
+    const windowStart = new Date(openedAt.getTime() - REFERENCE_ATTRIBUTION_WINDOW_MS).toISOString();
+    const openedAtIso = openedAt.toISOString();
+    const traceRows = sqliteAll<Record<string, unknown>>(
+      this.db,
+      `SELECT trace_id, session_id, trigger_type, selected_event_ids
+       FROM retrieval_traces
+       WHERE presentation_mode = 'reference'
+         AND datetime(created_at) >= datetime(?)
+         AND datetime(created_at) <= datetime(?)
+       ORDER BY created_at DESC
+       LIMIT 500`,
+      [windowStart, openedAtIso]
+    ).filter((row) => {
+      if (input.attributionSessionId && row.session_id !== input.attributionSessionId) return false;
+      try {
+        const selected = JSON.parse(String(row.selected_event_ids || '[]'));
+        return Array.isArray(selected) && selected.includes(input.targetEventId);
+      } catch {
+        return false;
+      }
+    });
+
+    const byTrace = new Map<string, Record<string, unknown>>();
+    for (const row of traceRows) {
+      const traceId = String(row.trace_id || '');
+      if (traceId) byTrace.set(traceId, row);
+    }
+    const candidates = Array.from(byTrace.values());
+    const attributed = candidates.length === 1 ? candidates[0] : undefined;
+    const traceId = attributed ? String(attributed.trace_id) : null;
+    const outcome = candidates.length === 1
+      ? 'attributed'
+      : candidates.length > 1
+        ? 'ambiguous'
+        : 'unattributed';
+    const reason = candidates.length === 1
+      ? 'unique_recent_reference_delivery'
+      : candidates.length > 1
+        ? 'multiple_recent_reference_deliveries'
+        : 'no_recent_reference_delivery';
+    const navigationClient = normalizeTelemetryClient(input.navigationClient);
+
+    const repeated = sqliteGet<{ navigation_id: string }>(
+      this.db,
+      `SELECT navigation_id
+       FROM retrieval_navigation_events
+       WHERE target_event_id = ?
+         AND trace_id IS ?
+         AND navigation_action = ?
+         AND navigation_client = ?
+         AND attribution_outcome = ?
+         AND datetime(last_opened_at) >= datetime(?)
+       ORDER BY last_opened_at DESC
+       LIMIT 1`,
+      [input.targetEventId, traceId, input.action, navigationClient, outcome, windowStart]
+    );
+
+    if (repeated) {
+      sqliteRun(
+        this.db,
+        `UPDATE retrieval_navigation_events
+         SET open_count = open_count + 1, last_opened_at = ?
+         WHERE navigation_id = ?`,
+        [openedAtIso, repeated.navigation_id]
+      );
+      return { outcome, traceId, repeated: true };
+    }
+
+    sqliteRun(
+      this.db,
+      `INSERT INTO retrieval_navigation_events (
+         navigation_id, target_event_id, trace_id, delivery_session_id,
+         presentation_mode, trigger_type, navigation_action, navigation_client,
+         attribution_outcome, attribution_reason, open_count, first_opened_at, last_opened_at
+       ) VALUES (?, ?, ?, ?, 'reference', ?, ?, ?, ?, ?, 1, ?, ?)`,
+      [
+        randomUUID(),
+        input.targetEventId,
+        traceId,
+        attributed?.session_id || input.attributionSessionId || null,
+        normalizeRetrievalTriggerType(attributed?.trigger_type),
+        input.action,
+        navigationClient,
+        outcome,
+        reason,
+        openedAtIso,
+        openedAtIso
+      ]
+    );
+    return { outcome, traceId, repeated: false };
+  }
+
+  async getRetrievalTelemetryStats(): Promise<RetrievalTelemetryStats> {
+    await this.initialize();
+
+    const hasTracePresentation = this.hasTableColumn('retrieval_traces', 'presentation_mode');
+    const hasTraceTrigger = this.hasTableColumn('retrieval_traces', 'trigger_type');
+    const hasHelpfulnessTable = Boolean(sqliteGet<{ name: string }>(
+      this.db,
+      `SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memory_helpfulness'`
+    ));
+    const hasHelpfulnessPresentation = hasHelpfulnessTable
+      && this.hasTableColumn('memory_helpfulness', 'presentation_mode');
+    const hasNavigationTable = Boolean(sqliteGet<{ name: string }>(
+      this.db,
+      `SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'retrieval_navigation_events'`
+    ));
+    const presentationSql = hasTracePresentation
+      ? "COALESCE(NULLIF(TRIM(presentation_mode), ''), 'unknown')"
+      : "'unknown'";
+    const triggerSql = hasTraceTrigger
+      ? "COALESCE(NULLIF(TRIM(trigger_type), ''), 'unknown')"
+      : "'unknown'";
+
+    const presentationRows = sqliteAll<Record<string, unknown>>(
+      this.db,
+      `SELECT ${presentationSql} AS label, COUNT(*) AS trace_count,
+              COALESCE(SUM(selected_count), 0) AS item_count
+       FROM retrieval_traces GROUP BY ${presentationSql} ORDER BY label ASC`
+    );
+    const triggerRows = sqliteAll<Record<string, unknown>>(
+      this.db,
+      `SELECT ${triggerSql} AS label, COUNT(*) AS trace_count,
+              COALESCE(SUM(selected_count), 0) AS item_count
+       FROM retrieval_traces GROUP BY ${triggerSql} ORDER BY label ASC`
+    );
+    const deliveryTotals = sqliteGet<Record<string, unknown>>(
+      this.db,
+      `SELECT COUNT(*) AS trace_count, COALESCE(SUM(selected_count), 0) AS item_count FROM retrieval_traces`
+    );
+    const legacyUnknownRows = hasHelpfulnessTable
+      ? sqliteGet<{ count: number }>(
+          this.db,
+          hasHelpfulnessPresentation
+            ? `SELECT COUNT(*) AS count FROM memory_helpfulness WHERE presentation_mode = 'unknown' OR presentation_mode IS NULL`
+            : `SELECT COUNT(*) AS count FROM memory_helpfulness`
+        )?.count ?? 0
+      : 0;
+
+    const evidence = hasHelpfulnessPresentation
+      ? sqliteGet<Record<string, unknown>>(
+          this.db,
+          `SELECT COUNT(content_overlap_score) AS evaluated,
+                  SUM(CASE WHEN content_overlap_score >= 0.3 THEN 1 ELSE 0 END) AS grounded,
+                  AVG(content_overlap_score) AS average_overlap
+           FROM memory_helpfulness
+           WHERE presentation_mode = 'evidence'`
+        )
+      : undefined;
+    const referenceEligible = hasTracePresentation
+      ? Number(sqliteGet<{ count: number }>(
+          this.db,
+          `SELECT COUNT(*) AS count FROM retrieval_traces
+           WHERE presentation_mode = 'reference' AND selected_count > 0`
+        )?.count ?? 0)
+      : 0;
+    const navigation = hasNavigationTable
+      ? sqliteGet<Record<string, unknown>>(
+          this.db,
+          `SELECT
+             COUNT(DISTINCT CASE WHEN attribution_outcome = 'attributed' THEN trace_id END) AS navigated_traces,
+             SUM(CASE WHEN attribution_outcome = 'attributed' THEN open_count ELSE 0 END) AS attributed_opens,
+             SUM(CASE WHEN attribution_outcome = 'ambiguous' THEN open_count ELSE 0 END) AS ambiguous_opens,
+             SUM(CASE WHEN attribution_outcome = 'unattributed' THEN open_count ELSE 0 END) AS unattributed_opens
+           FROM retrieval_navigation_events`
+        )
+      : undefined;
+    const evidenceEvaluated = Number(evidence?.evaluated || 0);
+    const evidenceGrounded = Number(evidence?.grounded || 0);
+    const navigatedTraces = Number(navigation?.navigated_traces || 0);
+
+    return {
+      deliveries: {
+        totalTraces: Number(deliveryTotals?.trace_count || 0),
+        totalItems: Number(deliveryTotals?.item_count || 0),
+        byPresentation: presentationRows.map((row) => ({
+          presentationMode: normalizeRetrievalPresentationMode(row.label),
+          traceCount: Number(row.trace_count || 0),
+          deliveredItemCount: Number(row.item_count || 0)
+        })),
+        byTrigger: triggerRows.map((row) => ({
+          triggerType: normalizeRetrievalTriggerType(row.label),
+          traceCount: Number(row.trace_count || 0),
+          deliveredItemCount: Number(row.item_count || 0)
+        })),
+        legacyUnknownRows: Number(legacyUnknownRows)
+      },
+      evidenceGrounding: {
+        evaluatedDeliveries: evidenceEvaluated,
+        groundedDeliveries: evidenceGrounded,
+        groundingRate: evidenceEvaluated > 0 ? evidenceGrounded / evidenceEvaluated : 0,
+        averageContentOverlap: Number(evidence?.average_overlap || 0)
+      },
+      referenceNavigation: {
+        eligibleTraces: referenceEligible,
+        navigatedTraces,
+        navigationRate: referenceEligible > 0 ? navigatedTraces / referenceEligible : 0,
+        attributedOpenCount: Number(navigation?.attributed_opens || 0),
+        ambiguousOpenCount: Number(navigation?.ambiguous_opens || 0),
+        unattributedOpenCount: Number(navigation?.unattributed_opens || 0)
+      }
+    };
   }
 
   async getRecentRetrievalTraces(limit: number = 50): Promise<Array<{
@@ -3482,14 +3797,20 @@ export class SQLiteEventStore {
     selectedCount: number;
     confidence?: string;
     fallbackTrace: string[];
+    presentationMode: RetrievalPresentationMode;
+    triggerType: RetrievalTriggerType;
+    deliveryClient: string;
     createdAt: Date;
   }>> {
     await this.initialize();
 
     try {
+      const userQueryWhere = this.hasTableColumn('retrieval_traces', 'trigger_type')
+        ? `WHERE COALESCE(trigger_type, 'unknown') != 'session_start'`
+        : '';
       const rows = sqliteAll<Record<string, unknown>>(
         this.db,
-        `SELECT * FROM retrieval_traces ORDER BY created_at DESC LIMIT ?`,
+        `SELECT * FROM retrieval_traces ${userQueryWhere} ORDER BY created_at DESC LIMIT ?`,
         [limit]
       );
 
@@ -3509,6 +3830,9 @@ export class SQLiteEventStore {
         selectedCount: Number(row.selected_count || 0),
         confidence: (row.confidence as string) || undefined,
         fallbackTrace: row.fallback_trace ? JSON.parse(row.fallback_trace as string) : [],
+        presentationMode: normalizeRetrievalPresentationMode(row.presentation_mode),
+        triggerType: normalizeRetrievalTriggerType(row.trigger_type),
+        deliveryClient: normalizeTelemetryClient(row.delivery_client),
         createdAt: toDateFromSQLite(row.created_at),
       }));
     } catch (err: any) {
@@ -3550,6 +3874,9 @@ export class SQLiteEventStore {
       const rewrittenQueryRewriteKindSql = this.hasTableColumn('retrieval_traces', 'query_rewrite_kind')
         ? REWRITTEN_QUERY_REWRITE_KIND_SQL
         : '0';
+      const userQueryWhere = this.hasTableColumn('retrieval_traces', 'trigger_type')
+        ? `WHERE COALESCE(trigger_type, 'unknown') != 'session_start'`
+        : '';
       const row = sqliteGet<Record<string, unknown>>(
         this.db,
         `SELECT
@@ -3565,7 +3892,8 @@ export class SQLiteEventStore {
             WHEN SUM(candidate_count) > 0 THEN (SUM(selected_count) * 1.0 / SUM(candidate_count))
             ELSE 0
           END as selection_rate
-         FROM retrieval_traces`,
+         FROM retrieval_traces
+         ${userQueryWhere}`,
         []
       );
 
@@ -3588,6 +3916,7 @@ export class SQLiteEventStore {
             ELSE 0
           END as selection_rate
          FROM retrieval_traces
+         ${userQueryWhere}
          GROUP BY ${strategyColumnSql}
          ORDER BY total_queries DESC, strategy ASC`,
         []

--- a/src/extensions/mcp/handlers.ts
+++ b/src/extensions/mcp/handlers.ts
@@ -2166,6 +2166,15 @@ async function handleMemDetails(memoryService: MemoryService, args: Record<strin
     lines.push('');
     lines.push('---');
     lines.push('');
+    try {
+      await memoryService.recordReferenceNavigation({
+        targetEventId: event.id,
+        action: 'details',
+        navigationClient: 'mcp'
+      });
+    } catch {
+      // Source disclosure remains available if telemetry cannot be written.
+    }
   }
 
   return {
@@ -2597,6 +2606,15 @@ async function handleMemSourceRef(memoryService: MemoryService, args: Record<str
       }
     }
     lines.push('');
+    try {
+      await memoryService.recordReferenceNavigation({
+        targetEventId: event.id,
+        action: 'source_ref',
+        navigationClient: 'mcp'
+      });
+    } catch {
+      // Source disclosure remains available if telemetry cannot be written.
+    }
   }
 
   return textResult(lines.join('\n'));

--- a/src/extensions/mcp/tools.ts
+++ b/src/extensions/mcp/tools.ts
@@ -137,7 +137,7 @@ export const tools: Tool[] = [
   },
   {
     name: 'mem-details',
-    description: 'Get full content of specific memories. Use after mem-search to get complete information.',
+    description: 'Get full content of specific memories. Use after mem-search to get complete information. Conditional mutation: each successfully resolved reference records privacy-safe navigation telemetry.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -342,7 +342,7 @@ export const tools: Tool[] = [
   },
   {
     name: 'mem-source-ref',
-    description: 'Resolve memory IDs, mem citation IDs, or event: IDs into privacy-safe source references with redacted previews and safe metadata only. Prefer this before mem-details when raw transcript exposure is unnecessary.',
+    description: 'Resolve memory IDs, mem citation IDs, or event: IDs into privacy-safe source references with redacted previews and safe metadata only. Prefer this before mem-details when raw transcript exposure is unnecessary. Conditional mutation: each successfully resolved reference records privacy-safe navigation telemetry.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -43,6 +43,12 @@ import type { IngestInterceptor } from '../core/ingest-interceptor.js';
 import type { MemoryIngestService } from '../core/engine/memory-ingest-service.js';
 import type { MemoryQueryService } from '../core/engine/memory-query-service.js';
 import type { CanonicalMemoryInjection } from '../core/operations/canonical-memory-injection-service.js';
+import type {
+  RecordReferenceNavigationInput,
+  RecordReferenceNavigationResult,
+  RetrievalTelemetryContext,
+  RetrievalTelemetryStats
+} from '../core/retrieval-telemetry.js';
 import { createMemoryServiceComposition } from '../core/engine/memory-service-composition.js';
 import {
   getProjectStoragePath as defaultGetProjectStoragePath,
@@ -70,6 +76,7 @@ import {
   type RetrievalDisclosureSearchResponse,
   type RetrievalDisclosureService,
   type RetrievalDisclosureSource,
+  type RetrievalDisclosureSourceOptions,
   type RetrievalOrchestrator,
   type RetrievalTrace,
   type RetrievalTraceStats,
@@ -319,8 +326,11 @@ export class MemoryService {
   /**
    * Layer 3 retrieval disclosure: resolve a search result to its raw source event.
    */
-  async sourceDisclosure(resultId: string): Promise<RetrievalDisclosureSource | null> {
-    return this.retrievalDisclosureService.source(resultId);
+  async sourceDisclosure(
+    resultId: string,
+    options?: RetrievalDisclosureSourceOptions
+  ): Promise<RetrievalDisclosureSource | null> {
+    return this.retrievalDisclosureService.source(resultId, options);
   }
 
   /**
@@ -607,7 +617,7 @@ export class MemoryService {
     sessionId: string,
     score: number,
     query: string,
-    options?: { traceId?: string; source?: string; injectedContent?: string }
+    options?: { traceId?: string; source?: string; injectedContent?: string } & RetrievalTelemetryContext
   ): Promise<void> {
     return this.retrievalOrchestrator.recordRetrieval(eventId, sessionId, score, query, options);
   }
@@ -661,6 +671,16 @@ export class MemoryService {
    */
   async getUsefulnessHistory(options: UsefulnessHistoryOptions = {}): Promise<UsefulnessHistoryEntry[]> {
     return this.retrievalAnalyticsService.getUsefulnessHistory(options);
+  }
+
+  async getRetrievalTelemetryStats(): Promise<RetrievalTelemetryStats> {
+    return this.retrievalAnalyticsService.getRetrievalTelemetryStats();
+  }
+
+  async recordReferenceNavigation(
+    input: RecordReferenceNavigationInput
+  ): Promise<RecordReferenceNavigationResult> {
+    return this.retrievalAnalyticsService.recordReferenceNavigation(input);
   }
 
   /**

--- a/tests/apps/dashboard-usefulness-stats.test.ts
+++ b/tests/apps/dashboard-usefulness-stats.test.ts
@@ -83,7 +83,7 @@ function loadOverviewWithElements(elements: Record<string, TestElement>, files =
   };
 
   const usefulnessHooks = files.includes('usefulness.js')
-    ? ', renderUsefulnessHistory, updateOverviewUsefulnessStrip'
+    ? ', renderUsefulnessHistory, updateOverviewUsefulnessStrip, updateRetrievalTelemetryUI'
     : '';
   vm.runInNewContext(
     `${source}\n;globalThis.__dashboardTestHooks = { state, updateMemoryUsefulnessUI, updateRetrievalTraceUI, updateKpiCardsUI, updateOverviewActivityUI${usefulnessHooks} };`,
@@ -97,6 +97,7 @@ function loadOverviewWithElements(elements: Record<string, TestElement>, files =
     updateOverviewActivityUI: () => void;
     renderUsefulnessHistory: () => void;
     updateOverviewUsefulnessStrip: () => void;
+    updateRetrievalTelemetryUI: () => void;
   }}).__dashboardTestHooks;
 }
 
@@ -832,6 +833,62 @@ describe('dashboard memory usefulness stats', () => {
     expect(html).toContain('&lt;script&gt;');
     // Selected-but-untracked traces explain themselves instead of claiming nothing was injected.
     expect(html).toContain('2 memories were selected, but per-memory tracking is unavailable');
+  });
+
+  it('renders evidence grounding and reference navigation with separate denominators', () => {
+    const elements = { 'retrieval-telemetry-summary': new TestElement() };
+    const hooks = loadOverviewWithElements(elements, ['state.js', 'views.js', 'overview.js', 'usefulness.js']);
+    hooks.state.retrievalTelemetry = {
+      deliveries: {
+        byPresentation: [
+          { presentationMode: 'evidence', deliveredItemCount: 8 },
+          { presentationMode: 'reference', deliveredItemCount: 5 },
+          { presentationMode: 'core', deliveredItemCount: 2 }
+        ]
+      },
+      evidenceGrounding: { evaluatedDeliveries: 8, groundedDeliveries: 4, groundingRate: 0.5 },
+      referenceNavigation: { eligibleTraces: 4, navigatedTraces: 3, navigationRate: 0.75, ambiguousOpenCount: 1 }
+    };
+
+    hooks.updateRetrievalTelemetryUI();
+
+    const html = elements['retrieval-telemetry-summary'].innerHTML;
+    expect(html).toContain('8</strong> evidence items');
+    expect(html).toContain('50.0%</strong> grounded (4/8)');
+    expect(html).toContain('5</strong> reference items');
+    expect(html).toContain('75.0%</strong> navigated (3/4 traces)');
+    expect(html).toContain('2</strong> core items');
+    expect(html).toContain('1 ambiguous opens');
+  });
+
+  it('does not label reference delivery unhelpful from missing content overlap', () => {
+    const elements = { 'usefulness-history-list': new TestElement() };
+    const hooks = loadOverviewWithElements(elements, ['state.js', 'views.js', 'overview.js', 'usefulness.js']);
+    hooks.state.usefulnessHistory = [{
+      traceId: 'reference-trace',
+      kind: 'session_start',
+      sessionId: 'session-reference',
+      question: 'Session start',
+      presentationMode: 'reference',
+      selectedCount: 1,
+      createdAt: '2026-05-08T10:10:00.000Z',
+      memories: [{
+        eventId: 'memory-reference',
+        summary: 'A navigation hint',
+        helpfulnessScore: 0.5,
+        contentOverlapScore: null,
+        presentationMode: 'reference',
+        evidence: []
+      }]
+    }];
+
+    hooks.renderUsefulnessHistory();
+
+    const html = elements['usefulness-history-list'].innerHTML;
+    expect(html).toContain('reference navigation measured separately');
+    expect(html).toContain('>reference</span>');
+    expect(html).not.toContain('not reused in answer');
+    expect(html).not.toContain('grounding 0%');
   });
 
   it('renders the overview usefulness strip from the usefulness payload', () => {

--- a/tests/apps/search-api-disclosure.test.ts
+++ b/tests/apps/search-api-disclosure.test.ts
@@ -23,13 +23,15 @@ const mocks = vi.hoisted(() => {
     service,
     lightweightService,
     getServiceFromQuery: vi.fn(() => service),
-    getLightweightServiceFromQuery: vi.fn(() => lightweightService)
+    getLightweightServiceFromQuery: vi.fn(() => lightweightService),
+    getWritableServiceFromQuery: vi.fn(() => service)
   };
 });
 
 vi.mock('../../src/apps/server/api/utils.js', () => ({
   getServiceFromQuery: mocks.getServiceFromQuery,
-  getLightweightServiceFromQuery: mocks.getLightweightServiceFromQuery
+  getLightweightServiceFromQuery: mocks.getLightweightServiceFromQuery,
+  getWritableServiceFromQuery: mocks.getWritableServiceFromQuery
 }));
 
 const { searchRouter } = await import('../../src/server/api/search.js');
@@ -55,6 +57,7 @@ describe('search disclosure API', () => {
     mocks.lightweightService.sourceDisclosure.mockReset();
     mocks.getServiceFromQuery.mockClear();
     mocks.getLightweightServiceFromQuery.mockClear();
+    mocks.getWritableServiceFromQuery.mockClear();
   });
 
   it('POST /api/search/disclosure delegates to MemoryService.searchDisclosure', async () => {
@@ -193,18 +196,21 @@ describe('search disclosure API', () => {
       surroundingFacts: [],
       relatedSources: [{ sourceRef: 'event:e1', sourceType: 'raw_event', eventIds: ['e1'] }]
     };
-    mocks.lightweightService.expandDisclosure.mockResolvedValue(responseBody);
+    mocks.service.expandDisclosure.mockResolvedValue(responseBody);
 
     const res = await createApp().request('/api/search/disclosure/event:e1/expand?windowSize=2');
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual(responseBody);
-    expect(mocks.getLightweightServiceFromQuery).toHaveBeenCalledTimes(1);
+    expect(mocks.getWritableServiceFromQuery).toHaveBeenCalledTimes(1);
     expect(mocks.getServiceFromQuery).not.toHaveBeenCalled();
-    expect(mocks.lightweightService.initialize).not.toHaveBeenCalled();
-    expect(mocks.lightweightService.expandDisclosure).toHaveBeenCalledWith('event:e1', { windowSize: 2 });
-    expect(mocks.lightweightService.shutdown).toHaveBeenCalledTimes(1);
-    expect(mocks.service.expandDisclosure).not.toHaveBeenCalled();
+    expect(mocks.service.initialize).not.toHaveBeenCalled();
+    expect(mocks.service.expandDisclosure).toHaveBeenCalledWith('event:e1', {
+      windowSize: 2,
+      recordNavigation: true,
+      navigationClient: 'dashboard'
+    });
+    expect(mocks.service.shutdown).toHaveBeenCalledTimes(1);
   });
 
   it('GET /api/search/disclosure/:resultId/source resolves a disclosure result source', async () => {
@@ -214,31 +220,32 @@ describe('search disclosure API', () => {
       eventIds: ['e1'],
       rawEvents: [{ id: 'e1', content: 'checkout fix' }]
     };
-    mocks.lightweightService.sourceDisclosure.mockResolvedValue(responseBody);
+    mocks.service.sourceDisclosure.mockResolvedValue(responseBody);
 
     const res = await createApp().request('/api/search/disclosure/event:e1/source');
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual(responseBody);
-    expect(mocks.getLightweightServiceFromQuery).toHaveBeenCalledTimes(1);
+    expect(mocks.getWritableServiceFromQuery).toHaveBeenCalledTimes(1);
     expect(mocks.getServiceFromQuery).not.toHaveBeenCalled();
-    expect(mocks.lightweightService.initialize).not.toHaveBeenCalled();
-    expect(mocks.lightweightService.sourceDisclosure).toHaveBeenCalledWith('event:e1');
-    expect(mocks.lightweightService.shutdown).toHaveBeenCalledTimes(1);
-    expect(mocks.service.sourceDisclosure).not.toHaveBeenCalled();
+    expect(mocks.service.initialize).not.toHaveBeenCalled();
+    expect(mocks.service.sourceDisclosure).toHaveBeenCalledWith('event:e1', {
+      recordNavigation: true,
+      navigationClient: 'dashboard'
+    });
+    expect(mocks.service.shutdown).toHaveBeenCalledTimes(1);
   });
 
   it('GET /api/search/disclosure/:resultId/source returns 404 when source is missing', async () => {
-    mocks.lightweightService.sourceDisclosure.mockResolvedValue(null);
+    mocks.service.sourceDisclosure.mockResolvedValue(null);
 
     const res = await createApp().request('/api/search/disclosure/event:missing/source');
 
     expect(res.status).toBe(404);
     expect(await res.json()).toEqual({ error: 'Source not found' });
-    expect(mocks.getLightweightServiceFromQuery).toHaveBeenCalledTimes(1);
+    expect(mocks.getWritableServiceFromQuery).toHaveBeenCalledTimes(1);
     expect(mocks.getServiceFromQuery).not.toHaveBeenCalled();
-    expect(mocks.lightweightService.initialize).not.toHaveBeenCalled();
-    expect(mocks.lightweightService.shutdown).toHaveBeenCalledTimes(1);
-    expect(mocks.service.sourceDisclosure).not.toHaveBeenCalled();
+    expect(mocks.service.initialize).not.toHaveBeenCalled();
+    expect(mocks.service.shutdown).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/apps/stats-api-lightweight.test.ts
+++ b/tests/apps/stats-api-lightweight.test.ts
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => {
     getMostAccessedMemories: vi.fn(),
     getHelpfulnessStats: vi.fn(),
     getHelpfulnessStatsByDay: vi.fn(),
+    getRetrievalTelemetryStats: vi.fn(),
     getHelpfulMemories: vi.fn(),
     getRecentRetrievalTraces: vi.fn(),
     getEndlessModeStatus: vi.fn()
@@ -77,6 +78,11 @@ describe('stats API lightweight read paths', () => {
     mocks.service.getMostAccessedMemories.mockReset().mockResolvedValue([]);
     mocks.service.getHelpfulnessStats.mockReset().mockResolvedValue({ avgScore: 0, totalEvaluated: 0, totalRetrievals: 0, helpful: 0, neutral: 0, unhelpful: 0 });
     mocks.service.getHelpfulnessStatsByDay.mockReset().mockResolvedValue([]);
+    mocks.service.getRetrievalTelemetryStats.mockReset().mockResolvedValue({
+      deliveries: { totalTraces: 0, totalItems: 0, byPresentation: [], byTrigger: [], legacyUnknownRows: 0 },
+      evidenceGrounding: { evaluatedDeliveries: 0, groundedDeliveries: 0, groundingRate: 0, averageContentOverlap: 0 },
+      referenceNavigation: { eligibleTraces: 0, navigatedTraces: 0, navigationRate: 0, attributedOpenCount: 0, ambiguousOpenCount: 0, unattributedOpenCount: 0 }
+    });
     mocks.service.getHelpfulMemories.mockReset().mockResolvedValue([]);
     mocks.service.getRecentRetrievalTraces.mockReset().mockResolvedValue([]);
     mocks.service.getEndlessModeStatus.mockReset().mockResolvedValue({ mode: 'session', continuityScore: 0, workingSetSize: 0, consolidatedCount: 0 });
@@ -167,6 +173,7 @@ describe('stats API lightweight read paths', () => {
       '/api/stats/levels/L0?project=abc12345',
       '/api/stats/most-accessed?project=abc12345&limit=10',
       '/api/stats/helpfulness?project=abc12345&limit=5',
+      '/api/stats/retrieval-telemetry?project=abc12345',
       '/api/stats/timeline?project=abc12345&days=14',
       '/api/stats/kpi?project=abc12345&window=7d',
       '/api/stats/retrieval-traces?project=abc12345&limit=20',
@@ -180,6 +187,32 @@ describe('stats API lightweight read paths', () => {
     }
     expect(mocks.getServiceFromQuery).not.toHaveBeenCalled();
     expect(mocks.getLightweightServiceFromQuery).toHaveBeenCalledTimes(paths.length);
+  });
+
+  it('GET /api/stats/retrieval-telemetry preserves source-specific denominators', async () => {
+    const telemetry = {
+      deliveries: {
+        totalTraces: 4,
+        totalItems: 7,
+        byPresentation: [
+          { presentationMode: 'evidence', traceCount: 2, deliveredItemCount: 4 },
+          { presentationMode: 'reference', traceCount: 1, deliveredItemCount: 2 },
+          { presentationMode: 'core', traceCount: 1, deliveredItemCount: 1 }
+        ],
+        byTrigger: [],
+        legacyUnknownRows: 3
+      },
+      evidenceGrounding: { evaluatedDeliveries: 4, groundedDeliveries: 3, groundingRate: 0.75, averageContentOverlap: 0.42 },
+      referenceNavigation: { eligibleTraces: 1, navigatedTraces: 1, navigationRate: 1, attributedOpenCount: 2, ambiguousOpenCount: 1, unattributedOpenCount: 0 }
+    };
+    mocks.service.getRetrievalTelemetryStats.mockResolvedValue(telemetry);
+
+    const res = await createApp().request('/api/stats/retrieval-telemetry?project=abc12345');
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(telemetry);
+    expect(mocks.service.getRetrievalTelemetryStats).toHaveBeenCalledTimes(1);
+    expect(mocks.getServiceFromQuery).not.toHaveBeenCalled();
   });
 
   it('GET /api/stats/kpi window-scopes its event fetch instead of a 20k scan', async () => {

--- a/tests/core/retrieval-disclosure-service.test.ts
+++ b/tests/core/retrieval-disclosure-service.test.ts
@@ -63,6 +63,12 @@ function service(
     initialize?: () => Promise<void>;
     getEvent?: (id: string) => Promise<MemoryEvent | null>;
     getSessionEvents?: (sessionId: string) => Promise<MemoryEvent[]>;
+    recordReferenceNavigation?: (input: {
+      targetEventId: string;
+      action: 'source_ref' | 'details' | 'expand' | 'source';
+      navigationClient: string;
+      attributionSessionId?: string;
+    }) => Promise<unknown>;
     sharedStore?: { get(entryId: string): Promise<SharedTroubleshootingEntry | null> };
   } = {}
 ) {
@@ -73,7 +79,8 @@ function service(
     },
     eventStore: {
       getEvent: overrides.getEvent ?? (async (id: string) => timeline.find((item) => item.id === id) ?? null),
-      getSessionEvents: overrides.getSessionEvents ?? (async (sessionId: string) => timeline.filter((item) => item.sessionId === sessionId))
+      getSessionEvents: overrides.getSessionEvents ?? (async (sessionId: string) => timeline.filter((item) => item.sessionId === sessionId)),
+      recordReferenceNavigation: overrides.recordReferenceNavigation
     },
     sharedStore: overrides.sharedStore
   });
@@ -86,6 +93,36 @@ describe('RetrievalDisclosureService', () => {
     expect(parseDisclosureResultId('shared:shared-1')).toBe('shared:shared-1');
     expect(parseDisclosureResultRef('event:e2')).toEqual({ kind: 'event', eventId: 'e2' });
     expect(parseDisclosureResultRef('shared:shared-1')).toEqual({ kind: 'shared', entryId: 'shared-1' });
+  });
+
+  it('records successful public expand/source navigation but leaves internal expansion read-only', async () => {
+    const opens: Array<Record<string, unknown>> = [];
+    const disclosure = service(retrievalResult(), {
+      recordReferenceNavigation: async (input) => { opens.push(input); }
+    });
+
+    await disclosure.expand('event:e2');
+    expect(opens).toEqual([]);
+
+    await disclosure.expand('event:e2', {
+      recordNavigation: true,
+      navigationClient: 'dashboard',
+      attributionSessionId: 'delivery-session'
+    });
+    await disclosure.source('event:e2', {
+      recordNavigation: true,
+      navigationClient: 'cli'
+    });
+
+    expect(opens).toEqual([
+      {
+        targetEventId: 'e2',
+        action: 'expand',
+        navigationClient: 'dashboard',
+        attributionSessionId: 'delivery-session'
+      },
+      { targetEventId: 'e2', action: 'source', navigationClient: 'cli', attributionSessionId: undefined }
+    ]);
   });
 
   it('search returns spec-aligned compact envelopes with reasons and source refs', async () => {

--- a/tests/core/retrieval-telemetry.test.ts
+++ b/tests/core/retrieval-telemetry.test.ts
@@ -1,0 +1,244 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  REFERENCE_ATTRIBUTION_WINDOW_MS,
+  SQLiteEventStore
+} from '../../src/core/sqlite-event-store.js';
+import {
+  createSQLiteDatabase,
+  sqliteAll,
+  sqliteClose,
+  sqliteGet,
+  sqliteRun
+} from '../../src/core/sqlite-wrapper.js';
+
+describe('retrieval presentation and navigation telemetry', () => {
+  let tempDir: string;
+  let dbPath: string;
+  let store: SQLiteEventStore;
+
+  beforeEach(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'retrieval-telemetry-'));
+    dbPath = join(tempDir, 'events.sqlite');
+    store = new SQLiteEventStore(dbPath);
+    await store.initialize();
+  });
+
+  afterEach(() => {
+    try { store.close(); } catch {}
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  async function appendEvent(sessionId: string, content: string): Promise<string> {
+    const result = await store.append({
+      eventType: 'agent_response',
+      sessionId,
+      timestamp: new Date(),
+      content
+    });
+    if (!result.success) throw new Error('failed to append fixture event');
+    return result.eventId;
+  }
+
+  it('reports evidence, reference, and core deliveries with source-specific denominators', async () => {
+    const evidenceId = await appendEvent('delivery-session', 'Use port 37777 for the dashboard.');
+    const referenceId = await appendEvent('delivery-session', 'Reference-only deployment notes.');
+
+    await store.recordRetrievalTrace({
+      traceId: 'trace-evidence',
+      sessionId: 'delivery-session',
+      queryText: 'dashboard port',
+      candidateEventIds: [evidenceId],
+      selectedEventIds: [evidenceId],
+      presentationMode: 'evidence',
+      triggerType: 'user_prompt',
+      deliveryClient: 'claude-hook'
+    });
+    await store.recordRetrieval(evidenceId, 'delivery-session', 0.9, 'dashboard port', {
+      traceId: 'trace-evidence',
+      presentationMode: 'evidence',
+      triggerType: 'user_prompt',
+      deliveryClient: 'claude-hook'
+    });
+    await store.recordRetrievalTrace({
+      traceId: 'trace-reference',
+      sessionId: 'delivery-session',
+      queryText: '[session-start] recent project context',
+      candidateEventIds: [referenceId],
+      selectedEventIds: [referenceId],
+      presentationMode: 'reference',
+      triggerType: 'session_start',
+      deliveryClient: 'claude-hook'
+    });
+    await store.recordRetrieval(referenceId, 'delivery-session', 0.5, '[session-start]', {
+      traceId: 'trace-reference',
+      presentationMode: 'reference',
+      triggerType: 'session_start',
+      deliveryClient: 'claude-hook'
+    });
+    await store.recordRetrievalTrace({
+      traceId: 'trace-core',
+      sessionId: 'delivery-session',
+      queryText: '[session-start] core memory',
+      candidateEventIds: ['core:project'],
+      selectedEventIds: ['core:project'],
+      presentationMode: 'core',
+      triggerType: 'session_start',
+      deliveryClient: 'claude-hook'
+    });
+
+    const db = createSQLiteDatabase(dbPath);
+    sqliteRun(
+      db,
+      `UPDATE memory_helpfulness
+       SET content_overlap_score = 0.6, measured_at = datetime('now')
+       WHERE trace_id = 'trace-evidence'`
+    );
+    sqliteClose(db);
+
+    const firstOpen = await store.recordReferenceNavigation({
+      targetEventId: referenceId,
+      action: 'source_ref',
+      navigationClient: 'mcp'
+    });
+    const repeatedOpen = await store.recordReferenceNavigation({
+      targetEventId: referenceId,
+      action: 'source_ref',
+      navigationClient: 'mcp'
+    });
+
+    expect(firstOpen).toEqual({ outcome: 'attributed', traceId: 'trace-reference', repeated: false });
+    expect(repeatedOpen).toEqual({ outcome: 'attributed', traceId: 'trace-reference', repeated: true });
+
+    const stats = await store.getRetrievalTelemetryStats();
+    expect(stats.deliveries.byPresentation).toEqual([
+      { presentationMode: 'core', traceCount: 1, deliveredItemCount: 1 },
+      { presentationMode: 'evidence', traceCount: 1, deliveredItemCount: 1 },
+      { presentationMode: 'reference', traceCount: 1, deliveredItemCount: 1 }
+    ]);
+    expect(stats.deliveries.byTrigger).toEqual([
+      { triggerType: 'session_start', traceCount: 2, deliveredItemCount: 2 },
+      { triggerType: 'user_prompt', traceCount: 1, deliveredItemCount: 1 }
+    ]);
+    expect(stats.evidenceGrounding).toEqual({
+      evaluatedDeliveries: 1,
+      groundedDeliveries: 1,
+      groundingRate: 1,
+      averageContentOverlap: 0.6
+    });
+    expect(stats.referenceNavigation).toEqual({
+      eligibleTraces: 1,
+      navigatedTraces: 1,
+      navigationRate: 1,
+      attributedOpenCount: 2,
+      ambiguousOpenCount: 0,
+      unattributedOpenCount: 0
+    });
+    await expect(store.getRetrievalTraceStats()).resolves.toMatchObject({ totalQueries: 1 });
+    await expect(store.getRecentRetrievalTraces(10)).resolves.toEqual([
+      expect.objectContaining({ traceId: 'trace-evidence', triggerType: 'user_prompt' })
+    ]);
+
+    const privacyDb = createSQLiteDatabase(dbPath, { readonly: true, walMode: false });
+    const columns = sqliteAll<{ name: string }>(privacyDb, `PRAGMA table_info(retrieval_navigation_events)`)
+      .map((column) => column.name);
+    sqliteClose(privacyDb);
+    expect(columns).not.toContain('content');
+    expect(columns).not.toContain('query_text');
+    expect(columns).not.toContain('source_path');
+  });
+
+  it('fails closed for ambiguous, expired, and cross-session attribution', async () => {
+    const eventId = await appendEvent('source-session', 'A reference target');
+    for (const [traceId, sessionId] of [['trace-a', 'delivery-a'], ['trace-b', 'delivery-b']] as const) {
+      await store.recordRetrievalTrace({
+        traceId,
+        sessionId,
+        queryText: 'reference delivery',
+        candidateEventIds: [eventId],
+        selectedEventIds: [eventId],
+        presentationMode: 'reference',
+        triggerType: 'user_prompt'
+      });
+    }
+
+    await expect(store.recordReferenceNavigation({
+      targetEventId: eventId,
+      action: 'details',
+      navigationClient: 'mcp'
+    })).resolves.toMatchObject({ outcome: 'ambiguous', traceId: null });
+
+    await expect(store.recordReferenceNavigation({
+      targetEventId: eventId,
+      action: 'details',
+      navigationClient: 'mcp',
+      attributionSessionId: 'delivery-a'
+    })).resolves.toMatchObject({ outcome: 'attributed', traceId: 'trace-a' });
+
+    await expect(store.recordReferenceNavigation({
+      targetEventId: eventId,
+      action: 'expand',
+      navigationClient: 'cli',
+      attributionSessionId: 'different-session'
+    })).resolves.toMatchObject({ outcome: 'unattributed', traceId: null });
+
+    await expect(store.recordReferenceNavigation({
+      targetEventId: eventId,
+      action: 'source',
+      navigationClient: 'cli',
+      attributionSessionId: 'delivery-a',
+      openedAt: new Date(Date.now() + REFERENCE_ATTRIBUTION_WINDOW_MS + 60_000)
+    })).resolves.toMatchObject({ outcome: 'unattributed', traceId: null });
+  });
+
+  it('keeps unopened references neutral and labels omitted legacy fields unknown', async () => {
+    const eventId = await appendEvent('evaluation-session', 'Reference text that is not copied.');
+    await store.recordRetrievalTrace({
+      traceId: 'reference-evaluation',
+      sessionId: 'evaluation-session',
+      queryText: 'reference query',
+      candidateEventIds: [eventId],
+      selectedEventIds: [eventId],
+      presentationMode: 'reference',
+      triggerType: 'user_prompt'
+    });
+    await store.recordRetrieval(eventId, 'evaluation-session', 0.1, 'reference query', {
+      traceId: 'reference-evaluation',
+      injectedContent: 'reference navigation hint',
+      presentationMode: 'reference',
+      triggerType: 'user_prompt'
+    });
+    await store.recordRetrievalTrace({
+      traceId: 'legacy-trace',
+      sessionId: 'legacy-session',
+      queryText: 'legacy query',
+      candidateEventIds: [eventId],
+      selectedEventIds: [eventId]
+    });
+    await store.recordRetrieval(eventId, 'legacy-session', 0.5, 'legacy query', { traceId: 'legacy-trace' });
+
+    await store.evaluateSessionHelpfulness('evaluation-session');
+
+    const db = createSQLiteDatabase(dbPath, { readonly: true, walMode: false });
+    const row = sqliteGet<Record<string, unknown>>(
+      db,
+      `SELECT helpfulness_score, content_overlap_score, presentation_mode
+       FROM memory_helpfulness WHERE trace_id = 'reference-evaluation'`
+    );
+    sqliteClose(db);
+    expect(row).toMatchObject({ helpfulness_score: 0.5, content_overlap_score: null, presentation_mode: 'reference' });
+
+    const traces = await store.getRecentRetrievalTraces(10);
+    expect(traces.find((trace) => trace.traceId === 'legacy-trace')).toMatchObject({
+      presentationMode: 'unknown',
+      triggerType: 'unknown',
+      deliveryClient: 'unknown'
+    });
+    await expect(store.getRetrievalTelemetryStats()).resolves.toMatchObject({
+      deliveries: { legacyUnknownRows: 1 }
+    });
+  });
+});

--- a/tests/core/sqlite-event-store-retrieval-trace-legacy-schema.test.ts
+++ b/tests/core/sqlite-event-store-retrieval-trace-legacy-schema.test.ts
@@ -75,6 +75,48 @@ describe('SQLiteEventStore legacy retrieval trace schema', () => {
           avgSelectedCountForRewrittenQueries: 0,
           avgSelectedCountForRawQueries: 1,
         });
+        await expect(store.getRetrievalTelemetryStats()).resolves.toMatchObject({
+          deliveries: {
+            totalTraces: 1,
+            totalItems: 1,
+            byPresentation: [
+              { presentationMode: 'unknown', traceCount: 1, deliveredItemCount: 1 }
+            ],
+            byTrigger: [
+              { triggerType: 'unknown', traceCount: 1, deliveredItemCount: 1 }
+            ]
+          },
+          evidenceGrounding: { evaluatedDeliveries: 0 },
+          referenceNavigation: { eligibleTraces: 0, navigatedTraces: 0 }
+        });
+      } finally {
+        await store.close();
+      }
+    });
+  });
+
+  it('additively migrates presentation fields and navigation telemetry without rewriting legacy rows', async () => {
+    await withLegacyRetrievalTraceDb(async (dbPath) => {
+      const store = new SQLiteEventStore(dbPath);
+      try {
+        await store.initialize();
+        await expect(store.getRecentRetrievalTraces(5)).resolves.toEqual([
+          expect.objectContaining({
+            traceId: 'trace-old-1',
+            queryText: 'old dashboard query',
+            presentationMode: 'unknown',
+            triggerType: 'unknown',
+            deliveryClient: 'unknown'
+          })
+        ]);
+        const db = new Database(dbPath, { readonly: true });
+        try {
+          expect(db.prepare(`SELECT COUNT(*) AS count FROM retrieval_navigation_events`).get()).toEqual({ count: 0 });
+          expect(db.prepare(`SELECT query_text FROM retrieval_traces WHERE trace_id = ?`).get('trace-old-1'))
+            .toEqual({ query_text: 'old dashboard query' });
+        } finally {
+          db.close();
+        }
       } finally {
         await store.close();
       }

--- a/tests/extensions/mcp-context-tools.test.ts
+++ b/tests/extensions/mcp-context-tools.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => {
       getSessionHistory: vi.fn(),
       getStats: vi.fn(),
       recordQueryTrace: vi.fn(),
+      recordReferenceNavigation: vi.fn(),
       processPendingEmbeddings: vi.fn()
     };
   }
@@ -74,6 +75,7 @@ function resetService(service: typeof mocks.defaultService) {
   service.getSessionHistory.mockReset().mockResolvedValue([]);
   service.getStats.mockReset().mockResolvedValue({ totalEvents: 0, vectorCount: 0, levelStats: [] });
   service.recordQueryTrace.mockReset().mockResolvedValue(undefined);
+  service.recordReferenceNavigation.mockReset().mockResolvedValue({ outcome: 'attributed', traceId: 'trace-1', repeated: false });
   service.processPendingEmbeddings.mockReset().mockResolvedValue(0);
 }
 
@@ -1867,6 +1869,11 @@ describe('MCP project context tools', () => {
     expect(text).not.toContain('password=pw');
     expect(text).not.toContain('transcriptPath');
     expect(text).not.toContain('secret:');
+    expect(mocks.projectService.recordReferenceNavigation).toHaveBeenCalledWith({
+      targetEventId: sensitive.id,
+      action: 'source_ref',
+      navigationClient: 'mcp'
+    });
   });
 
   it('resolves source references by short citation id', async () => {


### PR DESCRIPTION
## Summary

- add additive presentation, trigger, and client telemetry for evidence, reference, and core deliveries
- attribute source-ref, details, expand, and source opens only to a unique reference trace within a bounded 15-minute window
- collapse repeat opens into counts and leave ambiguous, expired, or cross-session matches unattributed
- report evidence grounding and reference navigation with separate denominators in the API and dashboard

## Compatibility and safety

- preserve legacy rows as unknown without rewriting them
- store only identifiers, classifications, timestamps, and counts for navigation; no transcript or source content is duplicated
- keep existing query-trace metrics limited to user-query traces so SessionStart and core delivery telemetry do not change prior denominators
- leave SessionStart presentation defaults unchanged

## Verification

- npm run verify: 205 test files, 1301 tests passed; typecheck passed; lint completed with existing warnings only
- npm run check:architecture: passed with no new boundary violations
- npm run check:public-output-privacy: passed with zero findings
- npm run build: passed